### PR TITLE
Replaced deprecated `hashmap_core` crate with its successor, `hashbrown`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,9 +458,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashmap_core"
-version = "0.1.9"
-source = "git+https://github.com/pepyakin/hashmap_core?branch=add-alloc-layout-extra#fbf5de0e4bb62d9b5bd30a25ac86580e85bf2b29"
+name = "hashbrown"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "heap_irq_safe"
@@ -737,7 +741,7 @@ dependencies = [
  "cow_arc 0.1.0",
  "fs_node 0.1.0",
  "goblin 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashmap_core 0.1.9 (git+https://github.com/pepyakin/hashmap_core?branch=add-alloc-layout-extra)",
+ "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "irq_safety 0.1.1 (git+https://github.com/kevinaboos/irq_safety)",
  "kernel_config 0.1.0",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1196,6 +1200,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "scroll"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,7 +1590,7 @@ source = "git+https://github.com/kevinaboos/zero.git#9fc7ff523138a21f40359b706d2
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum getopts 0.2.18 (git+https://github.com/kevinaboos/getopts)" = "<none>"
 "checksum goblin 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "c65cd533b33e3d04c6e393225fa8919ddfcf5862ca8919c7f9a167c312ef41c2"
-"checksum hashmap_core 0.1.9 (git+https://github.com/pepyakin/hashmap_core?branch=add-alloc-layout-extra)" = "<none>"
+"checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum irq_safety 0.1.1 (git+https://github.com/kevinaboos/irq_safety)" = "<none>"
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
@@ -1609,6 +1618,7 @@ source = "git+https://github.com/kevinaboos/zero.git#9fc7ff523138a21f40359b706d2
 "checksum rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,6 @@ exclude = [
 getopts = { git = "https://github.com/kevinaboos/getopts" }
 ### use our own no_std-compatible qp trie
 qp-trie = { git = "https://github.com/theseus-os/qp-trie-rs" }
-### the new nightly alloc crate needs this: <https://github.com/Amanieu/hashmap_core/pull/8>
-hashmap_core = { git = "https://github.com/pepyakin/hashmap_core", branch = "add-alloc-layout-extra" }
 
 
 ### These profiles fix the new rustc behavior of splitting one crate into many object files. 

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -11,10 +11,13 @@ spin = "0.4.10"
 multiboot2 = { path = "../../libs/multiboot2-elf64" } # currently using our local copy, forked from Phil Opp's crate
 xmas-elf = { version = "0.6.2", git = "https://github.com/kevinaboos/xmas-elf.git" }
 rustc-demangle = "0.1.9"
-hashmap_core = "0.1.9"
 qp-trie = "0.7.3"
 owning_ref = { git = "https://github.com/kevinaboos/owning-ref-rs" }
 
+
+[dependencies.hashbrown]
+version = "0.1.8"
+features = ["nightly"]
 
 [dependencies.irq_safety]
 git = "https://github.com/kevinaboos/irq_safety"

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -17,7 +17,7 @@ extern crate util;
 extern crate rustc_demangle;
 extern crate owning_ref;
 extern crate cow_arc;
-extern crate hashmap_core;
+extern crate hashbrown;
 extern crate qp_trie;
 extern crate root;
 extern crate vfs_node;
@@ -48,7 +48,7 @@ use memory::{FRAME_ALLOCATOR, MemoryManagementInfo, Frame, PageTable, VirtualAdd
 use multiboot2::BootInformation;
 use metadata::{StrongCrateRef, WeakSectionRef};
 use cow_arc::CowArc;
-use hashmap_core::HashMap;
+use hashbrown::HashMap;
 use rustc_demangle::demangle;
 use qp_trie::{Trie, wrapper::BString};
 use fs_node::{FileOrDir, File, FileRef, DirRef};


### PR DESCRIPTION
Closes #99.