### PR TITLE
Redisign of TASKLIST with proper task removal (extension of #8f78505c…

### DIFF
--- a/applications/kill/src/lib.rs
+++ b/applications/kill/src/lib.rs
@@ -36,7 +36,7 @@ pub fn main(args: Vec<String>) -> isize {
                 if let Some(task_ref) = task::get_task(task_id) {
                     use core::ops::Deref;
                     if task_ref.kill(task::KillReason::Requested)
-                        .and_then(|_| RunQueue::remove_task_from_all(task_ref))
+                        .and_then(|_| RunQueue::remove_task_from_all(&task_ref))
                         .is_ok() 
                     {
                         println!("Killed task {} \n", task_ref.lock().deref());

--- a/applications/ps/src/lib.rs
+++ b/applications/ps/src/lib.rs
@@ -40,7 +40,7 @@ pub fn main(args: Vec<String>) -> isize {
     // Print all tasks
     let mut num_tasks = 0;
     let mut task_string = String::new();
-    for (id, taskref) in TASKLIST.iter() {
+    for (id, taskref) in TASKLIST.lock().iter() {
         num_tasks += 1;
         let task = taskref.lock();
         let name = &task.name;

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -214,7 +214,7 @@ pub fn init(kernel_mmi_ref: Arc<MutexIrqSafe<MemoryManagementInfo>>,
     #[cfg(simd_personality)]
     {
         warn!("SIMD_PERSONALTIY FEATURE ENABLED!");
-        KernelTaskBuilder::new(simd_personality::setup_simd_personality, None)
+        spawn::KernelTaskBuilder::new(simd_personality::setup_simd_personality, None)
             .name(String::from("setup_simd_personality"))
             .spawn()?;
     }

--- a/kernel/context_switch/src/lib.rs
+++ b/kernel/context_switch/src/lib.rs
@@ -42,6 +42,19 @@ cfg_if! {
             restore_registers_regular!();
         }
 
+        #[naked]
+        #[inline(never)]
+        pub unsafe fn context_switch_regular_to_sse_with_dead_prev<T>() {
+            // Since this is a naked function that expects its arguments in two registers,
+            // you CANNOT place any log statements or other instructions here,
+            // or at any point before, in between, or after the following macros.
+
+            switch_stacks_ignore_prev!();
+            restore_registers_sse!();
+            restore_registers_regular!();
+            drop_rdi!(T);
+        }
+
 
         /// Switches context from an SSE Task to a regular Task.
         /// 
@@ -65,6 +78,18 @@ cfg_if! {
             switch_stacks!();
             restore_registers_regular!();
         }
+
+        #[naked]
+        #[inline(never)]
+        pub unsafe fn context_switch_sse_to_regular_with_dead_prev<T>() {
+            // Since this is a naked function that expects its arguments in two registers,
+            // you CANNOT place any log statements or other instructions here,
+            // or at any point before, in between, or after the following macros.
+
+            switch_stacks_ignore_prev!();
+            restore_registers_regular!();
+            drop_rdi!(T);
+        }
     }
 
     else if #[cfg(target_feature = "sse2")] {
@@ -73,6 +98,7 @@ cfg_if! {
 
         pub use context_switch_sse::ContextSSE as Context;
         pub use context_switch_sse::context_switch_sse as context_switch;
+        pub use context_switch_sse::context_switch_sse_with_dead_prev as context_switch_with_dead_prev;
     }
     
     else {
@@ -81,6 +107,7 @@ cfg_if! {
 
         pub use context_switch_regular::ContextRegular as Context;
         pub use context_switch_regular::context_switch_regular as context_switch;
+        pub use context_switch_regular::context_switch_regular_with_dead_prev as context_switch_with_dead_prev;
     }
 }
 

--- a/kernel/context_switch_sse/src/lib.rs
+++ b/kernel/context_switch_sse/src/lib.rs
@@ -146,3 +146,16 @@ pub unsafe fn context_switch_sse() {
     restore_registers_sse!();
     restore_registers_regular!();
 }
+
+#[naked]
+#[inline(never)]
+pub unsafe fn context_switch_sse_with_dead_prev<T>() {
+    // Since this is a naked function that expects its arguments in two registers,
+    // you CANNOT place any log statements or other instructions here,
+    // or at any point before, in between, or after the following macros.
+
+    switch_stacks_ignore_prev!();
+    restore_registers_sse!();
+    restore_registers_regular!();
+    drop_rdi!(T);
+}

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -52,7 +52,7 @@ pub fn schedule() -> bool {
     // same scoping reasons as above: to release the lock around current_task
     {
         current_task = get_my_current_task().expect("schedule(): get_my_current_task() failed")
-                                            .lock_mut().deref_mut() as *mut Task; 
+                                            .lock_mut().deref_mut() as *mut Task;
     }
 
     if current_task == next_task {
@@ -65,7 +65,7 @@ pub fn schedule() -> bool {
 
     // trace!("BEFORE TASK_SWITCH CALL (AP {}), current={}, next={}, interrupts are {}", apic_id, curr, next, irq_safety::interrupts_enabled());
 
-    curr.task_switch(next, apic_id); 
+    curr.task_switch(next, apic_id);
 
     // let new_current: TaskId = CURRENT_TASK.load(Ordering::SeqCst);
     // trace!("AFTER TASK_SWITCH CALL (current={}), interrupts are {}", new_current, ::interrupts::interrupts_enabled());

--- a/kernel/task/src/fs/task_dir.rs
+++ b/kernel/task/src/fs/task_dir.rs
@@ -152,7 +152,7 @@ impl TaskDirectory {
 
     fn get_child_internal(&self, child: &str) -> Result<FileOrDir, &'static str> {
         let id = child.parse::<usize>().map_err(|_e| "could not parse usize")?;
-        let task_ref = TASKLIST.get(&id).ok_or("could not get taskref from TASKLIST")?;
+        let task_ref = super::super::get_task(id).ok_or("could not get taskref from TASKLIST")?;
         let parent_dir = match self.get_self_pointer() {
             Ok(ptr) => ptr, 
             Err(err) => {
@@ -171,7 +171,7 @@ impl TaskDirectory {
             parent: Arc::downgrade(&parent_dir),
         };
         let task_dir = Arc::new(Mutex::new(Box::new(new_dir) as Box<Directory + Send>));
-        create_mmi_dir(task_ref.clone(), &task_dir)?;
+        create_mmi_dir(task_ref, &task_dir)?;
         Ok(FileOrDir::Dir(task_dir))
     }
 }
@@ -226,7 +226,7 @@ impl Directory for TaskDirectory {
     /// Returns a string listing all the children in the directory
     fn list_children(&mut self) -> Vec<String> {
         let mut tasks_string = Vec::new();
-        for (id, _taskref) in TASKLIST.iter() {
+        for (id, _taskref) in TASKLIST.lock().iter() {
             tasks_string.push(format!("{}", id));
         }
         tasks_string


### PR DESCRIPTION
* Use BTreeMap for TASKLIST instead of AtomicMap

* get_task() returns a cloned TaskRef

* When a task exists, the task is removed.