### PR TITLE
Split `terminal` into `libterm` and `shell`.

### DIFF
--- a/applications/shell/Cargo.toml
+++ b/applications/shell/Cargo.toml
@@ -1,0 +1,75 @@
+[package]
+name = "shell"
+version = "0.1.0"
+description = "Shell that can run commands in application directory"
+authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
+build = "../../build.rs"
+
+
+[dependencies]
+spin = "0.4.10"
+x86_64 = { path = "../../libs/x86_64" }
+
+[dependencies.log]
+default-features = false
+version = "0.3.7"
+
+[dependencies.keycodes_ascii]
+path = "../../libs/keycodes_ascii"
+
+[dependencies.dfqueue]
+path = "../../libs/dfqueue"
+version = "0.1.0"
+
+[dependencies.event_types]
+path = "../../kernel/event_types"
+
+[dependencies.spawn]
+path = "../../kernel/spawn"
+
+[dependencies.task]
+path = "../../kernel/task"
+
+[dependencies.runqueue]
+path = "../../kernel/runqueue"
+
+[dependencies.memory]
+path  = "../../kernel/memory"
+
+[dependencies.mod_mgmt]
+path = "../../kernel/mod_mgmt"
+
+[dependencies.frame_buffer]
+path = "../../kernel/frame_buffer"
+
+[dependencies.window_manager]
+path = "../../kernel/window_manager"
+
+[dependencies.text_display]
+path = "../../kernel/text_display"
+[dependencies.terminal_print]
+path = "../terminal_print"
+
+[dependencies.print]
+path = "../../kernel/print"
+
+[dependencies.fs_node]
+path = "../../kernel/fs_node"
+
+[dependencies.environment]
+path = "../../kernel/environment"
+
+[dependencies.root]
+path = "../../kernel/root"
+
+[dependencies.path]
+path = "../../kernel/path"
+
+[dependencies.libterm]
+path = "../../kernel/libterm"
+
+[lib]
+crate-type = ["rlib"]
+
+
+

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -1,0 +1,480 @@
+//! Shell with event-driven architecture
+//! Commands that can be run are the names of the crates in the applications directory
+//! 
+//! The shell has the following responsibilities: handles key events delivered from terminal, manages terminal display,
+//! spawns and manages tasks, and records previously executed user commands.
+//! 
+//! Problem: Currently there's no upper bound to the user command line history.
+//!
+//! Acknowledgement: Most of the functions are adopted from the `Terminal` implemented by Andrew Pham <apham727@gmail.com>.
+
+#![no_std]
+extern crate frame_buffer;
+extern crate keycodes_ascii;
+extern crate spin;
+extern crate dfqueue;
+extern crate mod_mgmt;
+extern crate spawn;
+extern crate task;
+extern crate runqueue;
+extern crate memory;
+extern crate event_types; 
+extern crate window_manager;
+extern crate text_display;
+extern crate fs_node;
+extern crate path;
+extern crate root;
+
+extern crate terminal_print;
+extern crate print;
+extern crate environment;
+extern crate libterm;
+
+#[macro_use] extern crate alloc;
+#[macro_use] extern crate log;
+
+use event_types::{Event};
+use keycodes_ascii::{Keycode, KeyAction, KeyEvent};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use spawn::{ApplicationTaskBuilder, KernelTaskBuilder};
+use path::Path;
+use task::{TaskRef, ExitValue, KillReason};
+use fs_node::FileOrDir;
+use libterm::Terminal;
+
+pub const APPLICATIONS_NAMESPACE_PATH: &'static str = "/namespaces/default/applications";
+
+/// A main function that spawns a new shell and waits for the shell loop to exit before returning an exit value
+#[no_mangle]
+pub fn main(_args: Vec<String>) -> isize {
+
+    let terminal =  match Terminal::new() {
+        Ok(_terminal) => { _terminal }
+        Err(err) => {
+            error!("{}", err);
+            error!("could not create terminal instance");
+            return -1;
+        }
+    };
+
+    let _task_ref = match KernelTaskBuilder::new(shell_loop, terminal)
+        .name("shell_loop".to_string())
+        .spawn() {
+        Ok(task_ref) => { task_ref }
+        Err(err) => {
+            error!("{}", err);
+            error!("failed to spawn shell");
+            return -1; 
+        }
+    };
+
+    loop {
+        // block this task, because it never needs to actually run again
+        if let Some(my_task) = task::get_my_current_task() {
+            my_task.block();
+        }
+    }
+    // TODO FIXME: once join() doesn't cause interrupts to be disabled, we can use join again instead of the above loop
+    // waits for the terminal loop to exit before exiting the main function
+    // match term_task_ref.join() {
+    //     Ok(_) => { }
+    //     Err(err) => {error!("{}", err)}
+    // }
+}
+
+/// Errors when attempting to invoke an application from the terminal. 
+enum AppErr {
+    /// The command does not match the name of any existing application in the 
+    /// application namespace directory. 
+    NotFound(String),
+    /// The terminal could not find the application namespace due to a filesystem error. 
+    NamespaceErr,
+    /// The terminal could not spawn a new task to run the new application.
+    /// Includes the String error returned from the task spawn function.
+    SpawnErr(String)
+}
+
+struct Shell {
+    /// Variable that stores the task id of any application manually spawned from the terminal
+    current_task_ref: Option<TaskRef>,
+    /// Vector that stores the history of commands that the user has entered
+    command_history: Vec<String>,
+    /// Variable used to track the net number of times the user has pressed up/down to cycle through the commands
+    /// ex. if the user has pressed up twice and down once, then command shift = # ups - # downs = 1 (cannot be negative)
+    history_index: usize,
+    /// When someone enters some commands, but before pressing `enter` it presses `up` to see previous commands,
+    /// we must push it to command_history. We don't want to push it twice.
+    buffered_cmd_recorded: bool,
+    /// the terminal that is bind with the shell instance
+    terminal: Terminal
+}
+
+impl Shell {
+    /// Create a new shell. Must provide a terminal to bind with the new shell in the argument.
+    fn new(terminal: Terminal) -> Shell {
+        Shell {
+            current_task_ref: None,
+            command_history: Vec::new(),
+            history_index: 0,
+            buffered_cmd_recorded: false,
+            terminal
+        }
+    }
+
+
+    fn goto_previous_command(&mut self) {
+        if self.history_index == self.command_history.len() {
+            return;
+        }
+        self.terminal.refresh_prompt_if_needed();
+        if self.history_index == 0 {
+            let previous_input = self.terminal.get_cmdline();
+            if !previous_input.is_empty() {
+                self.command_history.push(previous_input);
+                self.history_index += 1;
+                self.buffered_cmd_recorded = true;
+            }
+        }
+        self.history_index += 1;
+        let selected_command = self.command_history[self.command_history.len() - self.history_index].clone();
+        self.terminal.set_cmdline(selected_command);
+    }
+
+    fn goto_next_command(&mut self) {
+        if self.history_index == 0 {
+            return;
+        }
+        if self.history_index == 1 {
+            if self.buffered_cmd_recorded {
+                // command_histroy has at least one element. safe to unwrap here.
+                let selected_command = self.command_history.pop().unwrap();
+                self.terminal.set_cmdline(selected_command);
+                self.history_index -= 1;
+                self.buffered_cmd_recorded = false;
+                return;
+            }
+        }
+        self.history_index -=1;
+        if self.history_index == 0 {
+            self.terminal.clear_cmdline();
+            return;
+        }
+        let selected_command = self.command_history[self.command_history.len() - self.history_index].clone();
+        self.terminal.set_cmdline(selected_command);
+    }
+
+    fn handle_key_event(&mut self, keyevent: KeyEvent) -> Result<(), &'static str> {       
+        // EVERYTHING BELOW HERE WILL ONLY OCCUR ON A KEY PRESS (not key release)
+        if keyevent.action != KeyAction::Pressed {
+            return Ok(()); 
+        }
+
+        // Ctrl+C signals the main loop to exit the task
+        if keyevent.modifiers.control && keyevent.keycode == Keycode::C {
+            let task_ref_copy = match self.current_task_ref {
+                Some(ref task_ref) => task_ref.clone(), 
+                None => {
+                    self.terminal.clear_cmdline();
+                    self.terminal.clear_buffer_string();
+                    self.terminal.print_to_terminal("^C\n".to_string());
+                    self.terminal.redisplay_prompt();
+                    return Ok(());
+                }
+            };
+            match task_ref_copy.kill(KillReason::Requested) {
+                Ok(_) => {
+                    if let Err(e) = runqueue::remove_task_from_all(&task_ref_copy) {
+                        error!("Killed task but could not remove it from runqueue: {}", e);
+                    }
+                }
+                Err(e) => error!("Could not kill task, error: {}", e),
+            }
+            return Ok(());
+        }
+
+        // Tracks what the user does whenever she presses the backspace button
+        if keyevent.keycode == Keycode::Backspace  {
+            self.terminal.erase_left_cmdline();
+            return Ok(());
+        }
+
+        if keyevent.keycode == Keycode::Delete {
+            self.terminal.erase_right_cmdline();
+            return Ok(());
+        }
+
+        // Attempts to run the command whenever the user presses enter and updates the cursor tracking variables 
+        if keyevent.keycode == Keycode::Enter && keyevent.keycode.to_ascii(keyevent.modifiers).is_some() {
+            let cmdline = self.terminal.get_cmdline();
+            if cmdline.len() == 0 {
+                // reprints the prompt on the next line if the user presses enter and hasn't typed anything into the prompt
+                self.terminal.print_to_terminal("\n".to_string());
+                self.terminal.redisplay_prompt();
+                return Ok(());
+            } else if self.current_task_ref.is_some() { // prevents the user from trying to execute a new command while one is currently running
+                self.terminal.print_to_terminal("Wait until the current command is finished executing\n".to_string());
+            } else {
+                self.terminal.print_to_terminal("\n".to_string());
+                self.command_history.push(cmdline.clone());
+                self.command_history.dedup(); // Removes any duplicates
+                self.history_index = 0;
+                match self.eval_cmdline() {
+                    Ok(new_task_ref) => { 
+                        let task_id = {new_task_ref.lock().id};
+                        self.current_task_ref = Some(new_task_ref);
+                        terminal_print::add_child(task_id, self.terminal.get_producer_to_screen())?; // adds the terminal's print producer to the terminal print crate
+                    }
+                    Err(err) => {
+                        let err_msg = match err {
+                            AppErr::NotFound(command) => format!("{:?} command not found.\n", command),
+                            AppErr::NamespaceErr      => format!("Failed to find directory of application executables.\n"),
+                            AppErr::SpawnErr(e)       => format!("Failed to spawn new task to run command. Error: {}.\n", e),
+                        };
+                        self.terminal.print_to_terminal(err_msg);
+                        self.terminal.redisplay_prompt();
+                        self.terminal.clear_cmdline_without_erase();
+                        return Ok(());
+                    }
+                }
+            }
+            // Clears the buffer for next command once current command starts executing
+            self.terminal.clear_cmdline_without_erase();
+            return Ok(());
+        }
+
+        // home, end, page up, page down, up arrow, down arrow for the input_event_manager
+        if keyevent.keycode == Keycode::Home && keyevent.modifiers.control {
+            self.terminal.move_screen_to_begin();
+            return Ok(());
+        }
+        if keyevent.keycode == Keycode::End && keyevent.modifiers.control{
+            self.terminal.move_screen_to_end();
+            return Ok(());
+        }
+        if keyevent.modifiers.control && keyevent.modifiers.shift && keyevent.keycode == Keycode::Up  {
+            self.terminal.move_screen_line_up();
+            return Ok(());
+        }
+        if keyevent.modifiers.control && keyevent.modifiers.shift && keyevent.keycode == Keycode::Down  {
+            self.terminal.move_screen_line_down();
+            return Ok(());
+        }
+
+        if keyevent.keycode == Keycode::PageUp && keyevent.modifiers.shift {
+            self.terminal.move_screen_page_up();
+            return Ok(());
+        }
+
+        if keyevent.keycode == Keycode::PageDown && keyevent.modifiers.shift {
+            self.terminal.move_screen_page_down();
+            return Ok(());
+        }
+
+        // Cycles to the next previous command
+        if  keyevent.keycode == Keycode::Up {
+            self.goto_previous_command();
+            return Ok(());
+        }
+        // Cycles to the next most recent command
+        if keyevent.keycode == Keycode::Down {
+            self.goto_next_command();
+            return Ok(());
+        }
+
+        // Jumps to the beginning of the input string
+        if keyevent.keycode == Keycode::Home {
+            self.terminal.move_cursor_leftmost();
+            return Ok(());
+        }
+
+        // Jumps to the end of the input string
+        if keyevent.keycode == Keycode::End {
+            self.terminal.move_cursor_rightmost();
+            return Ok(());
+        }
+
+        // Adjusts the cursor tracking variables when the user presses the left and right arrow keys
+        if keyevent.keycode == Keycode::Left {
+            self.terminal.move_cursor_left();
+            return Ok(());
+        }
+
+        if keyevent.keycode == Keycode::Right {
+            self.terminal.move_cursor_right();
+            return Ok(());
+        }
+
+        // Tracks what the user has typed so far, excluding any keypresses by the backspace and Enter key, which are special and are handled directly below
+        if keyevent.keycode != Keycode::Enter && keyevent.keycode.to_ascii(keyevent.modifiers).is_some() {
+            match keyevent.keycode.to_ascii(keyevent.modifiers) {
+                Some(c) => {
+                    // If currently we have a task running, insert it to the terminal buffer, otherwise
+                    // to the cmdline.
+                    if self.current_task_ref.is_some() {
+                        self.terminal.insert_character_to_buffer(c);
+                        return Ok(());
+                    }
+                    else {
+                        self.terminal.insert_character_to_cmdline(c)?;
+                    }
+                },
+                None => {
+                    return Err("Couldn't get key event");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn eval_cmdline(&mut self) -> Result<TaskRef, AppErr> {
+        // Parse the cmdline
+        let cmdline = self.terminal.get_cmdline();
+        let mut args: Vec<String> = cmdline.split_whitespace().map(|s| s.to_string()).collect();
+        let command = args.remove(0);
+
+        // Check that the application actually exists
+        let app_path = Path::new(APPLICATIONS_NAMESPACE_PATH.to_string());
+        let app_list = match app_path.get(root::get_root()) {
+            Some(FileOrDir::Dir(app_dir)) => {app_dir.lock().list()},
+            _ => return Err(AppErr::NamespaceErr)
+        };
+        let mut executable = command.clone();
+        executable.push_str(".o");
+        if !app_list.contains(&executable) {
+            return Err(AppErr::NotFound(command));
+        }
+
+        let taskref = match ApplicationTaskBuilder::new(Path::new(command))
+            .argument(args)
+            .spawn() {
+                Ok(taskref) => taskref, 
+                Err(e) => return Err(AppErr::SpawnErr(e.to_string()))
+            };
+        
+        taskref.set_env(self.terminal.get_environment()); // Set environment variable of application to the same as terminal task
+
+        // Gets the task id so we can reference this task if we need to kill it with Ctrl+C
+        return Ok(taskref);
+    }
+
+    fn task_handler(&mut self) -> Result<(), &'static str> {
+        let task_ref_copy = match self.current_task_ref.clone() {
+            Some(task_ref) => task_ref,
+            None => { return Ok(());}
+        };
+        let exit_result = task_ref_copy.take_exit_value();
+        // match statement will see if the task has finished with an exit value yet
+        match exit_result {
+            Some(exit_val) => {
+                match exit_val {
+                    ExitValue::Completed(exit_status) => {
+                        // here: the task ran to completion successfully, so it has an exit value.
+                        // we know the return type of this task is `isize`,
+                        // so we need to downcast it from Any to isize.
+                        let val: Option<&isize> = exit_status.downcast_ref::<isize>();
+                        info!("terminal: task returned exit value: {:?}", val);
+                        if let Some(val) = val {
+                            if *val < 0 {
+                                self.terminal.print_to_terminal(format!("task returned error value {:?}\n", val));
+                            }
+                        }
+                    },
+
+                    ExitValue::Killed(KillReason::Requested) => {
+                        self.terminal.print_to_terminal("^C\n".to_string());
+                    },
+                    // If the user manually aborts the task
+                    ExitValue::Killed(kill_reason) => {
+                        warn!("task was killed because {:?}", kill_reason);
+                        self.terminal.print_to_terminal(format!("task was killed because {:?}\n", kill_reason));
+                    }
+                }
+                
+                terminal_print::remove_child(task_ref_copy.lock().id)?;
+                // Resets the current task id to be ready for the next command
+                self.current_task_ref = None;
+                self.terminal.redisplay_prompt();
+                // Pushes the keypresses onto the input_event_manager that were tracked whenever another command was running
+                if !self.terminal.is_buffer_string_empty() {
+                    self.terminal.consume_buffer_string()?;
+                }
+                // Resets the bool to true once the print prompt has been redisplayed
+                self.terminal.refresh_display();
+            },
+        // None value indicates task has not yet finished so does nothing
+        None => { /* WARNING: really should do nothing? */ },
+        }
+        return Ok(());
+    }
+
+    /// This main loop is the core component of the shell's event-driven architecture. The shell receives events
+    /// from two queues
+    /// 
+    /// 1) The print queue handles print events from applications. The producer to this queue
+    ///    is any EXTERNAL application that prints to the terminal.
+    /// 
+    /// 2) The input queue (provided by the window manager when the temrinal request a window) gives key events
+    ///    and resize event to the application.
+    /// 
+    /// The print queue is handled first inside the loop iteration, which means that all print events in the print
+    /// queue will always be printed to the text display before input events or any other managerial functions are handled. 
+    /// This allows for clean appending to the scrollback buffer and prevents interleaving of text.
+    fn start(mut self) -> Result<(), &'static str> {
+        loop {
+            self.terminal.blink_cursor();
+
+            // If there is anything from running applications to be printed, it printed on the screen and then
+            // return true, so that the loop continues, otherwise nothing happens and we keep on going with the
+            // loop body. We do so to ensure that printing is handled before keypresses.
+            if self.terminal.check_and_print_app_output() { continue; }
+
+
+            // Handles the cleanup of any application task that has finished running, including refreshing the display
+            self.task_handler()?;
+            self.terminal.refresh_prompt_if_needed();
+
+            // Looks at the input queue from the window manager
+            // If it has unhandled items, it handles them with the match
+            // If it is empty, it proceeds directly to the next loop iteration
+            let event = match self.terminal.get_key_event() {
+                Some(ev) => {
+                    ev
+                },
+                _ => { continue; }
+            };
+
+            match event {
+                // Returns from the main loop so that the terminal object is dropped
+                Event::ExitEvent => {
+                    trace!("exited terminal");
+                    self.terminal.close_window()?;
+                    return Ok(());
+                }
+
+                Event::ResizeEvent(ref _rev) => {
+                    self.terminal.refresh_display(); // application refreshes display after resize event is received
+                }
+
+                // Handles ordinary keypresses
+                Event::InputEvent(ref input_event) => {
+                    self.handle_key_event(input_event.key_event)?;
+                    if input_event.key_event.action == KeyAction::Pressed {
+                        // only refreshes the display on keypresses to improve display performance 
+                        self.terminal.refresh_display();
+                    }
+                }
+                _ => { }
+            }
+        }
+    }
+}
+
+
+/// Start a new shell. Shell::start() is an infinite loop, so normally we do not return from this function.
+fn shell_loop(mut terminal: Terminal) -> Result<(), &'static str> {
+
+    terminal.initialize_screen()?;
+    Shell::new(terminal).start()?;
+    Ok(())
+}

--- a/kernel/input_event_manager/src/lib.rs
+++ b/kernel/input_event_manager/src/lib.rs
@@ -46,7 +46,7 @@ pub fn init() -> Result<DFQueueProducer<Event>, &'static str> {
         .spawn()?;
 
     // Spawn the default terminal (will also start the windowing manager)
-    ApplicationTaskBuilder::new(Path::new(String::from("terminal")))
+    ApplicationTaskBuilder::new(Path::new(String::from("shell")))
         .name("default_terminal".to_string())
         .spawn()?;
     // start the input event loop thread
@@ -82,7 +82,7 @@ fn input_event_loop(consumer:DFQueueConsumer<Event>) -> Result<(), &'static str>
                 if key_input.modifiers.control && key_input.keycode == Keycode::T && key_input.action == KeyAction::Pressed {
                     let task_name: String = format!("terminal {}", terminal_id_counter);
                     let args: Vec<String> = vec![]; // terminal::main() does not accept any arguments
-                    ApplicationTaskBuilder::new(Path::new(String::from("terminal")))
+                    ApplicationTaskBuilder::new(Path::new(String::from("shell")))
                         .argument(args)
                         .name(task_name)
                         .spawn()?;

--- a/kernel/libterm/Cargo.toml
+++ b/kernel/libterm/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "libterm"
+version = "0.1.0"
+authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
+
+[dependencies]
+spin = "0.4.10"
+
+[dependencies.log]
+default-features = false
+version = "0.3.7"
+
+
+[dependencies.dfqueue]
+path = "../../libs/dfqueue"
+version = "0.1.0"
+
+[dependencies.window_manager]
+path = "../window_manager"
+
+[dependencies.environment]
+path = "../environment"
+
+[dependencies.root]
+path = "../root"
+
+[dependencies.print]
+path = "../print"
+
+[dependencies.event_types]
+path = "../event_types"
+
+[lib]
+crate-type = ["rlib"]

--- a/kernel/libterm/src/lib.rs
+++ b/kernel/libterm/src/lib.rs
@@ -1,0 +1,822 @@
+//! Terminal emulator library
+//!
+//! The terminal roughly does the following things: manages all characters in a String that should be printed to the screen;
+//! cuts a slice from this String and send it to window manager to get things actually printed; manages user input command line
+//! as well as the cursor position, and delivers keyboard events.
+//! 
+//! Problem: Currently there's no upper bound to the scrollback buffer, as well as other user input buffer.
+//! 
+//! Acknowledgement: Most of the functions are adopted from the `Terminal` implemented by Andrew Pham <apham727@gmail.com>.
+
+#![no_std]
+
+#[macro_use] extern crate alloc;
+#[macro_use] extern crate log;
+extern crate dfqueue;
+extern crate window_manager;
+extern crate root;
+extern crate environment;
+extern crate print;
+extern crate event_types;
+extern crate spin;
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use alloc::sync::Arc;
+use dfqueue::{DFQueue, DFQueueConsumer, DFQueueProducer};
+use environment::Environment;
+use event_types::Event;
+use spin::Mutex;
+use window_manager::displayable::text_display::TextDisplay;
+
+pub const FONT_COLOR: u32 = 0x93ee90;
+pub const BACKGROUND_COLOR: u32 = 0x000000;
+
+/// Error type for tracking different scroll errors that a terminal
+/// application could encounter.
+pub enum ScrollError {
+    /// Occurs when a index-calculation returns an index that is outside of the 
+    /// bounds of the scroll buffer
+    OffEndBound
+}
+
+/// Terminal Structure that allows multiple terminals to be individually run.
+/// There are now two queues that constitute the event-driven terminal architecture
+/// 1) The terminal print queue that handles printing from external applications
+///     - Consumer is the main terminal loop
+///     - Producers are any external application trying to print to the terminal's stdout
+/// 
+/// 2) The input queue (in the window manager) that handles keypresses and resize events
+///     - Consumer is the main terminal loop
+///     - Producer is the window manager. Window manager is responsible for enqueuing keyevents into the active application
+pub struct Terminal {
+    /// The terminal's own window
+    window: window_manager::WindowObj,
+    /// The string that stores the users keypresses after the prompt
+    cmdline: String,
+    /// Indicates whether the prompt string + any additional keypresses are the last thing that is printed on the prompt
+    /// If this is false, the terminal will reprint out the prompt + the additional keypresses 
+    correct_prompt_position: bool,
+    // Name of the displayable object of the terminal
+    display_name: String,
+    /// The secondary buffer that stores the user's keypresses if a command is currently running
+    buffer_string: String,
+    /// The string that is prompted to the user (ex. kernel_term~$)
+    prompt_string: String,
+    /// The terminal's scrollback buffer which stores a string to be displayed by the text display
+    scrollback_buffer: String,
+    /// Indicates whether the text display is displaying the last part of the scrollback buffer slice
+    is_scroll_end: bool,
+    /// The starting index of the scrollback buffer string slice that is currently being displayed on the text display
+    scroll_start_idx: usize,
+    /// Indicates the rightmost position of the cursor ON THE text display, NOT IN THE SCROLLBACK BUFFER (i.e. one more than the position of the last non_whitespace character
+    /// being displayed on the text display)
+    absolute_cursor_pos: usize,
+    /// Variable that tracks how far left the cursor is from the maximum rightmost position (above)
+    /// absolute_cursor_pos - left shift will be the position on the text display where the cursor will be displayed
+    left_shift: usize,
+    /// The consumer to the terminal's print dfqueue
+    print_consumer: DFQueueConsumer<Event>,
+    /// The producer to the terminal's print dfqueue
+    print_producer: DFQueueProducer<Event>,
+    /// The terminal's current environment
+    env: Arc<Mutex<Environment>>
+}
+
+/// Privite methods of `Terminal`.
+impl Terminal {
+    /// Erase a character from buffered command line string. It removes a character right at the cursor (i.e. del)
+    /// or on the left of the cursor (i.e. backspace). This behavior is controlled by `erase_left` parameter.
+    fn erase_from_cmdline(&mut self, erase_left: bool) {
+        let mut dir = 0;
+        if erase_left {
+            dir = 1;
+        }
+        let buffer_len = self.scrollback_buffer.len();
+        self.scrollback_buffer.remove(buffer_len - self.left_shift - dir);
+    }
+
+    /// Get the width and height of the text display.
+    fn get_displayable_dimensions(&self, name:&str) -> (usize, usize){
+        if let Some(text_display) = self.window.get_displayable(name){
+            text_display.get_dimensions()
+        } else {
+            (0, 0)
+        }
+    }
+
+    /// This function takes in the end index of some index in the scrollback buffer and calculates the starting index of the
+    /// scrollback buffer so that a slice containing the starting and ending index would perfectly fit inside the dimensions of 
+    /// text display. 
+    /// If the text display's first line will display a continuation of a syntactical line in the scrollback buffer, this function 
+    /// calculates the starting index so that when displayed on the text display, it preserves that line so that it looks the same
+    /// as if the whole physical line is displayed on the buffer
+    /// 
+    /// Return: starting index of the string and the cursor position(with respect to position on the screen, not in the scrollback buffer) in that order
+    fn calc_start_idx(&self, end_idx: usize, display_name:&str) -> (usize, usize) {
+        let (buffer_width, buffer_height) = self.get_displayable_dimensions(display_name);
+        let mut start_idx = end_idx;
+        let result;
+        // Grabs a max-size slice of the scrollback buffer (usually does not totally fit because of newlines)
+        if end_idx > buffer_width * buffer_height {
+            result = self.scrollback_buffer.get(end_idx - buffer_width*buffer_height..end_idx);
+        } else {
+            result = self.scrollback_buffer.get(0..end_idx);
+        }
+
+        if let Some(slice) = result {
+            let mut total_lines = 0;
+            // Obtains a vector of indices of newlines in the slice in the REVERSE order that they occur
+            let new_line_indices: Vec<(usize, &str)> = slice.rmatch_indices('\n').collect();
+            // if there are no new lines in the slice
+            if new_line_indices.is_empty() {
+                if buffer_height * buffer_width > end_idx {
+                    return (0,buffer_height * buffer_width -1);
+                } else {
+                    start_idx -= buffer_height * buffer_width; // text with no newlines will fill the entire buffer
+                    return (start_idx, buffer_height * buffer_width -1);
+                }
+            }
+
+            let mut last_line_chars = 1;
+            // Case where the last newline does not occur at the end of the slice
+            if new_line_indices[0].0 != slice.len() - 1 {
+                start_idx -= slice.len() -1 - new_line_indices[0].0;
+                total_lines += (slice.len()-1 - new_line_indices[0].0)/buffer_width + 1;
+                last_line_chars = (slice.len() -1 - new_line_indices[0].0) % buffer_width; // fix: account for more than one line
+            }
+
+            // covers everything *up to* the characters between the beginning of the slice and the first new line character
+            for i in 0..new_line_indices.len()-1 {
+                if total_lines >= buffer_height {
+                    break;
+                }
+                let num_chars = new_line_indices[i].0 - new_line_indices[i+1].0;
+                let num_lines = if (num_chars-1)%buffer_width != 0 || (num_chars -1) == 0 {
+                                    (num_chars-1) / buffer_width + 1 
+                                } else {
+                                    (num_chars-1)/buffer_width}; // using (num_chars -1) because that's the number of characters that actually show up on the screen
+                if num_chars > start_idx { // prevents subtraction overflow
+                    return (0, total_lines * buffer_width + last_line_chars);
+                }  
+                start_idx -= num_chars;
+                total_lines += num_lines;
+            }
+
+            // tracks the characters between the beginning of the slice and the first new line character
+            let first_chars = new_line_indices[new_line_indices.len() -1].0;
+            let first_chars_lines = first_chars/buffer_width + 1;
+
+            // covers the case where the text inside the new_lines_indices array overflow the text buffer 
+            if total_lines > buffer_height {
+                start_idx += (total_lines - buffer_height) * buffer_width; // adds back the overcounted lines to the starting index
+                total_lines = buffer_height;
+            // covers the case where the text between the last newline and the end of the slice overflow the text buffer
+            } else if first_chars_lines + total_lines > buffer_height {
+                let diff = buffer_height - total_lines;
+                total_lines += diff;
+                start_idx -= diff * buffer_width;
+            // covers the case where the text between the last newline and the end of the slice exactly fits the text buffer
+            } else if first_chars_lines + total_lines == buffer_height {
+                total_lines += first_chars_lines;
+                start_idx -= first_chars;
+            // covers the case where the slice fits within the text buffer (i.e. there is not enough output to fill the screen)
+            } else {
+                return (0, total_lines * buffer_width + last_line_chars); // In  the case that an end index argument corresponded to a string slice that underfits the text display
+            }
+
+            // If the previous loop overcounted, this cuts off the excess string from string. Happens when there are many charcters between newlines at the beginning of the slice
+            return (start_idx, (total_lines - 1) * buffer_width + last_line_chars);
+
+        } else {
+            return (0,0); /* WARNING: should change to Option<> rather than returning (0, 0) */
+        }   
+    }
+
+    /// This function takes in the start index of some index in the scrollback buffer and calculates the end index of the
+    /// scrollback buffer so that a slice containing the starting and ending index would perfectly fit inside the dimensions of 
+    /// text display. 
+    fn calc_end_idx(&self, start_idx: usize, display_name:&str) -> Result<usize, ScrollError> {
+        let (buffer_width,buffer_height) = self.get_displayable_dimensions(display_name);
+        let scrollback_buffer_len = self.scrollback_buffer.len();
+        let mut end_idx = start_idx;
+        let result;
+        // Grabs a max-size slice of the scrollback buffer (usually does not totally fit because of newlines)
+        if start_idx + buffer_width * buffer_height > scrollback_buffer_len {
+            result = self.scrollback_buffer.get(start_idx..scrollback_buffer_len-1);
+        } else {
+            result = self.scrollback_buffer.get(start_idx..start_idx + buffer_width * buffer_height);
+        }
+
+        // calculate the starting index for the slice
+        if let Some(slice) = result {
+            let mut total_lines = 0;
+            // Obtains a vector of the indices of the slice where newlines occur in ascending order
+            let new_line_indices: Vec<(usize, &str)> = slice.match_indices('\n').collect();
+            // if there are no new lines in the slice
+            if new_line_indices.len() == 0 {
+                // indicates that the text is just one continuous string with no newlines and will therefore fill the buffer completely
+                end_idx += buffer_height * buffer_width;
+                if end_idx <= self.scrollback_buffer.len() -1 {
+                    return Ok(end_idx); 
+                } else {
+                    return Err(ScrollError::OffEndBound);
+                }
+            }
+
+            let mut counter = 0;
+            // Covers the case where the start idx argument corresponds to a string that does not start on a newline 
+            if new_line_indices[0].0 != 0 {
+                end_idx += new_line_indices[0].0;
+                total_lines += new_line_indices[0].0/buffer_width + 1;
+            }
+            // the characters between the last newline and the end of the slice
+            let last_line_chars = slice.len() -1 - new_line_indices[new_line_indices.len() -1].0;  
+            let num_last_lines = last_line_chars%buffer_width + 1; // +1 to account for the physical line that the last characters will take up
+
+            for i in 0..new_line_indices.len()-1 {
+                if total_lines >= buffer_height {
+                    break;
+                }
+                let num_chars = new_line_indices[i+1].0 - new_line_indices[i].0;
+                let num_lines = num_chars/buffer_width + 1;
+                end_idx += num_chars;
+                total_lines += num_lines;
+                counter += 1;
+            }
+            // covers the case where the text inside the new_line_indices array overflows the text buffer capacity            
+            if total_lines > buffer_height {
+                let num_chars = new_line_indices[counter].0 - new_line_indices[counter -1].0;
+                end_idx -= num_chars;
+                end_idx += buffer_width;
+            // covers the case where the characters between the last newline and the end of the slice overflow the text buffer capacity
+            } else if total_lines + num_last_lines >= total_lines {
+                let diff = buffer_height - total_lines;
+                end_idx += diff * buffer_width;
+            // covers the case where the entire slice exactly fits or is smaller than the text buffer capacity
+            } else {
+                end_idx += last_line_chars;
+            }
+
+            if end_idx <= self.scrollback_buffer.len() -1 {
+                return Ok(end_idx); 
+            } else {
+                return Err(ScrollError::OffEndBound);
+            }
+        } else {
+            return Ok(self.scrollback_buffer.len() - 1) /* WARNING: maybe should return Error? */
+        }
+    }
+
+    /// Scrolls the text display up one line
+    fn scroll_up_one_line(&mut self) {
+        let buffer_width = self.get_displayable_dimensions(&self.display_name).0;
+        let mut start_idx = self.scroll_start_idx;
+        //indicates that the user has scrolled to the top of the page
+        if start_idx < 1 {
+            return; 
+        } else {
+            start_idx -= 1;
+        }
+        let new_start_idx;
+        let result;
+        let slice_len;
+        if buffer_width < start_idx {
+            result = self.scrollback_buffer.as_str().get(start_idx - buffer_width .. start_idx);
+            slice_len = buffer_width;
+        } else {
+            result = self.scrollback_buffer.as_str().get(0 .. start_idx);
+            slice_len = start_idx;
+        }
+        // Searches this slice for a newline
+
+        if let Some(slice) = result {
+            let index = slice.rfind('\n');   
+            new_start_idx = match index {
+                Some(index) => { start_idx - slice_len + index }, // Moves the starting index back to the position of the nearest newline back
+                None => { start_idx - slice_len}, // If no newline is found, moves the start index back by the buffer width value
+            }; // we're moving the cursor one position to the right relative to the end of the input string
+        } else {
+            return;
+        }
+        self.scroll_start_idx = new_start_idx;
+        // Recalculates the end index after the new starting index is found
+        self.is_scroll_end = false;
+    }
+
+    /// Scrolls the text display down one line
+    fn scroll_down_one_line(&mut self) {
+        let buffer_width = self.get_displayable_dimensions(&self.display_name).0;
+        let prev_start_idx;
+        // Prevents the user from scrolling down if already at the bottom of the page
+        if self.is_scroll_end == true {
+            return;} 
+        prev_start_idx = self.scroll_start_idx;
+        let result = self.calc_end_idx(prev_start_idx, &self.display_name);
+        let mut end_idx = match result {
+            Ok(end_idx) => end_idx,
+            Err(ScrollError::OffEndBound) => self.scrollback_buffer.len() -1,
+        };
+
+        // If the newly calculated end index is the bottom of the scrollback buffer, recalculates the start index and returns
+        if end_idx == self.scrollback_buffer.len() -1 {
+            self.is_scroll_end = true;
+            let new_start = self.calc_start_idx(end_idx, &self.display_name).0;
+            self.scroll_start_idx = new_start;
+            return;
+        }
+        end_idx += 1; // Advances to the next character for the calculation
+        let new_end_idx;
+        {
+            let result;
+            let slice_len; // specifies the length of the grabbed slice
+            // Grabs a slice (the size of the buffer width at most) of the scrollback buffer that is directly below the current slice being displayed on the text display
+            if self.scrollback_buffer.len() > end_idx + buffer_width {
+                slice_len = buffer_width;
+                result = self.scrollback_buffer.as_str().get(end_idx .. end_idx + buffer_width);
+            } else {
+                slice_len = self.scrollback_buffer.len() - end_idx -1; 
+                result = self.scrollback_buffer.as_str().get(end_idx .. self.scrollback_buffer.len());
+            }
+            // Searches the grabbed slice for a newline
+            if let Some(slice) = result {
+                let index = slice.find('\n');   
+                new_end_idx = match index {
+                    Some(index) => { end_idx + index + 1}, // Moves end index forward to the next newline
+                    None => { end_idx + slice_len}, // If no newline is found, moves the end index forward by the buffer width value
+                }; 
+            } else {
+                return;
+            }
+        }
+        // Recalculates new starting index
+        let start_idx = self.calc_start_idx(new_end_idx, &self.display_name).0;
+        self.scroll_start_idx = start_idx;
+    }
+
+    /// Shifts the text display up by making the previous first line the last line displayed on the text display
+    fn page_up(&mut self) {
+        let new_end_idx = self.scroll_start_idx;
+        let new_start_idx = self.calc_start_idx(new_end_idx, &self.display_name);
+        self.scroll_start_idx = new_start_idx.0;
+    }
+
+    /// Shifts the text display down by making the previous last line the first line displayed on the text display
+    fn page_down(&mut self) {
+        let start_idx = self.scroll_start_idx;
+        let result = self.calc_end_idx(start_idx, &self.display_name);
+        let new_start_idx = match result {
+            Ok(idx) => idx+ 1, 
+            Err(ScrollError::OffEndBound) => {
+                let scrollback_buffer_len = self.scrollback_buffer.len();
+                let new_start_idx = self.calc_start_idx(scrollback_buffer_len, &self.display_name).0;
+                self.scroll_start_idx = new_start_idx;
+                self.is_scroll_end = true;
+                return;
+            },
+        };
+        let result = self.calc_end_idx(new_start_idx, &self.display_name);
+        let new_end_idx = match result {
+            Ok(end_idx) => end_idx,
+            Err(ScrollError::OffEndBound) => {
+                let scrollback_buffer_len = self.scrollback_buffer.len();
+                let new_start_idx = self.calc_start_idx(scrollback_buffer_len, &self.display_name).0;
+                self.scroll_start_idx = new_start_idx;
+                self.is_scroll_end = true;
+                return;
+            },
+        };
+        if new_end_idx == self.scrollback_buffer.len() -1 {
+            // if the user page downs near the bottom of the page so only gets a partial shift
+            self.is_scroll_end = true;
+            return;
+        }
+        self.scroll_start_idx = new_start_idx;
+    }
+
+    /// Updates the text display by taking a string index and displaying as much as it starting from the passed string index (i.e. starts from the top of the display and goes down)
+    fn update_display_forwards(&mut self, start_idx: usize) -> Result<(), &'static str> {
+        self.scroll_start_idx = start_idx;
+        let result= self.calc_end_idx(start_idx, &self.display_name); 
+        let end_idx = match result {
+            Ok(end_idx) => end_idx,
+            Err(ScrollError::OffEndBound) => {
+                let new_end_idx = self.scrollback_buffer.len() -1;
+                let new_start_idx = self.calc_start_idx(new_end_idx, &self.display_name).0;
+                self.scroll_start_idx = new_start_idx;
+                new_end_idx
+            },
+        };
+        let result  = self.scrollback_buffer.get(start_idx..=end_idx); // =end_idx includes the end index in the slice
+        if let Some(slice) = result {
+            if let Some(text_display) = self.window.get_displayable(&self.display_name){
+                text_display.display_string(&(self.window), slice, FONT_COLOR, BACKGROUND_COLOR)?;
+            } else {
+                return Err("faild to get the text displayable component")
+            }
+        } else {
+            return Err("could not get slice of scrollback buffer string");
+        }
+        Ok(())
+    }
+
+    /// Updates the text display by taking a string index and displaying as much as it can going backwards from the passed string index (i.e. starts from the bottom of the display and goes up)
+    fn update_display_backwards(&mut self, end_idx: usize) -> Result<(), &'static str> {
+        let (start_idx, cursor_pos) = self.calc_start_idx(end_idx, &self.display_name);
+        self.scroll_start_idx = start_idx;
+
+        let result = self.scrollback_buffer.get(start_idx..end_idx);
+
+        if let Some(slice) = result {
+            if let Some(text_display) = self.window.get_displayable(&self.display_name){
+                text_display.display_string(&(self.window), slice, FONT_COLOR, BACKGROUND_COLOR)?;
+                self.absolute_cursor_pos = cursor_pos;          
+            } else {
+                return Err("faild to get the text displayable component")
+            }
+        } else {
+            return Err("could not get slice of scrollback buffer string");
+        }
+        Ok(())
+    }
+
+    /// Updates the cursor to a new position and refreshes display
+    fn cursor_handler(&mut self) -> Result<(), &'static str> { 
+        let buffer_width = self.get_displayable_dimensions(&self.display_name).0;
+        let mut new_x = self.absolute_cursor_pos %buffer_width;
+        let mut new_y = self.absolute_cursor_pos /buffer_width;
+        // adjusts to the correct position relative to the max rightmost absolute cursor position
+        if new_x >= self.left_shift  {
+            new_x -= self.left_shift;
+        } else {
+            new_x = buffer_width  + new_x - self.left_shift;
+            new_y -=1;
+        }
+
+        if let Some(text_display) = self.window.get_displayable(&self.display_name){
+            text_display.set_cursor(&(self.window), new_y as u16, new_x as u16, FONT_COLOR, true);
+        } else {
+            return Err("faild to get the text displayable component")
+        }
+        return Ok(());
+    }
+}
+
+/// Public methods of `Terminal`.
+impl Terminal {
+    pub fn new() -> Result<Terminal, &'static str> {
+        // initialize another dfqueue for the terminal object to handle printing from applications
+        let terminal_print_dfq: DFQueue<Event>  = DFQueue::new();
+        let terminal_print_consumer = terminal_print_dfq.into_consumer();
+        let terminal_print_producer = terminal_print_consumer.obtain_producer();
+
+        // Sets up the kernel to print to this terminal instance
+        print::set_default_print_output(terminal_print_producer.obtain_producer());
+
+        // Requests a new window object from the window manager
+        let window_object = match window_manager::new_default_window() {
+            Ok(window_object) => window_object,
+            Err(err) => {debug!("new window returned err"); return Err(err)}
+        };
+
+        let root = root::get_root();
+
+        let env = Environment {
+            working_dir: Arc::clone(root::get_root()), 
+        };
+
+        let mut prompt_string = root.lock().get_absolute_path(); // ref numbers are 0-indexed
+        prompt_string = format!("{}: ",prompt_string);
+        let mut terminal = Terminal {
+            window: window_object,
+            cmdline: String::new(),
+            display_name: String::from("content"),
+            correct_prompt_position: true,
+            buffer_string: String::new(),          
+            prompt_string: prompt_string,
+            scrollback_buffer: String::new(),
+            scroll_start_idx: 0,
+            is_scroll_end: true,
+            absolute_cursor_pos: 0, 
+            left_shift: 0,
+            print_consumer: terminal_print_consumer,
+            print_producer: terminal_print_producer,
+            env: Arc::new(Mutex::new(env))
+        };
+
+        // Inserts a producer for the print queue into global list of terminal print producers
+        let prompt_string = terminal.prompt_string.clone();
+        terminal.print_to_terminal(format!("Theseus Terminal Emulator\nPress Ctrl+C to quit a task\n{}", prompt_string));
+        terminal.absolute_cursor_pos = terminal.scrollback_buffer.len();
+        Ok(terminal)
+    }
+
+    /// Redisplays the terminal prompt (does not insert a newline before it)
+    pub fn redisplay_prompt(&mut self) {
+        let curr_env = self.env.lock();
+        let mut prompt = curr_env.working_dir.lock().get_absolute_path();
+        prompt = format!("{}: ",prompt);
+        self.scrollback_buffer.push_str(&prompt);
+        self.correct_prompt_position = true;
+    }
+
+    /// Adds a string to be printed to the terminal to the terminal scrollback buffer.
+    /// Note that one needs to call `refresh_display` to get things actually printed. 
+    pub fn print_to_terminal(&mut self, s: String) {
+        self.scrollback_buffer.push_str(&s);
+    }
+
+    /// Actually refresh the screen. Currently it's expensive.
+    pub fn refresh_display(&mut self) {
+        let start_idx = self.scroll_start_idx;
+        // handling display refreshing errors here so that we don't clog the main loop of the terminal
+        if self.is_scroll_end {
+            let buffer_len = self.scrollback_buffer.len();
+            match self.update_display_backwards(buffer_len) {
+                Ok(_) => { }
+                Err(err) => {error!("could not update display backwards: {}", err); return}
+            }
+            match self.cursor_handler() {
+                Ok(_) => { }
+                Err(err) => {error!("could not update cursor: {}", err); return}
+            }
+        } else {
+            match self.update_display_forwards(start_idx) {
+                Ok(_) => { }
+                Err(err) => {error!("could not update display forwards: {}", err); return}
+            }
+        }
+    }
+
+    /// Get the buffered user input command line.
+    pub fn get_cmdline(&mut self) -> String {
+        self.cmdline.clone()
+    }
+
+    /// Clear the user buffered command line. The scrollback buffer is synchronically updated,
+    /// but one needs to call `refresh_display` to actually remove the line from screen.
+    pub fn clear_cmdline(&mut self) {
+        self.left_shift = 0;
+        for _i in 0..self.cmdline.len() {
+            self.erase_from_cmdline(true);
+        }
+        self.cmdline.clear();
+    }
+
+    /// Set a new buffered command line to terminal. The scrollback buffer is synchronically updated,
+    /// but one needs to call `refresh_display` to actually show the new line onto the screen.
+    pub fn set_cmdline(&mut self, s: String) {
+        if !self.cmdline.is_empty() {
+            self.clear_cmdline();
+        }
+        let buffer_len = self.scrollback_buffer.len();
+        self.scrollback_buffer.insert_str(buffer_len - self.left_shift , &s);
+        self.cmdline = s;
+        self.left_shift = 0;
+        self.correct_prompt_position = true;
+    }
+
+    /// Just clear the buffered cmdline string in terminal. The existing characters on the screen are
+    /// left untouched.
+    pub fn clear_cmdline_without_erase(&mut self) {
+        self.cmdline.clear();
+        self.left_shift = 0;
+    }
+
+    /// Erase a character on the left of the cursor. If there's nothing on the left, it simply returns.
+    pub fn erase_left_cmdline(&mut self) {
+        // Prevents user from moving cursor to the left of the typing bounds
+        if self.cmdline.len() == 0 || self.cmdline.len() - self.left_shift == 0 { 
+            return;
+        } else {
+            // Subtraction by accounts for 0-indexing
+            if let Some(text_display) = self.window.get_displayable(&self.display_name){
+                text_display.disable_cursor();
+            }
+            let remove_idx: usize =  self.cmdline.len() - self.left_shift -1;
+            self.cmdline.remove(remove_idx);
+            self.erase_from_cmdline(true);
+            return;
+        }
+    }
+
+    /// Erase a character at the cursor. If there's nothing at the cursor as well as on its right, it
+    /// simply returns.
+    pub fn erase_right_cmdline(&mut self) {
+        // if there's no characters to the right of the cursor, does nothing
+        if self.cmdline.len() == 0 || self.left_shift == 0 { 
+            return;
+        } else {
+            // Subtraction by accounts for 0-indexing
+            if let Some(text_display) = self.window.get_displayable(&self.display_name){
+                text_display.disable_cursor();
+            }
+            let remove_idx: usize =  self.cmdline.len() - self.left_shift;
+            // we're moving the cursor one position to the right relative to the end of the input string
+            self.cmdline.remove(remove_idx);
+            self.erase_from_cmdline(false);
+            self.left_shift -= 1; 
+            return;
+        }
+    }
+
+    /// Move the cursor to the very beginning of the input command line.
+    pub fn move_cursor_leftmost(&mut self) {
+        self.left_shift = self.cmdline.len();
+    }
+
+    /// Move the cursor to the very end of the input command line.
+    pub fn move_cursor_rightmost(&mut self) {
+        self.left_shift = 0;
+    }
+
+    /// Move the cursor a character left. If the cursor is already at the beginning of the command line,
+    /// it simply returns.
+    pub fn move_cursor_left(&mut self) {
+        if self.left_shift < self.cmdline.len() {
+            self.left_shift += 1;
+        }
+    }
+
+    /// Move the cursor a character right. If the cursor is already at the end of the command line,
+    /// it simply returns.
+    pub fn move_cursor_right(&mut self) {
+        if self.left_shift > 0 {
+            self.left_shift -= 1;
+        }
+    }
+
+    /// Insert a character at the cursor.
+    pub fn insert_character_to_cmdline(&mut self, c: char) -> Result<(), &'static str> {
+        let insert_idx = self.cmdline.len() - self.left_shift;
+        self.cmdline.insert(insert_idx, c);
+        let buffer_len = self.scrollback_buffer.len();
+        self.scrollback_buffer.insert_str(buffer_len - self.left_shift , &c.to_string());
+
+        // If the prompt and any keypresses aren't already the last things being displayed on the buffer, it reprints
+        if !self.correct_prompt_position {
+            let mut cmdline = self.cmdline.clone();
+            match cmdline.pop() {
+                Some(_) => { }
+                None => {return Err("couldn't pop newline from input event string")}
+            }
+            self.redisplay_prompt();
+            self.print_to_terminal(cmdline);
+            // out dated: redisplay_prompt have set it // terminal.correct_prompt_position = true;
+        }
+        Ok(())
+    }
+
+    /// Insert a character to the secondary buffer. It is used when currently a command is running.
+    /// Should be removed later when we have abstraction of `stdio`.
+    pub fn insert_character_to_buffer(&mut self, c: char) {
+        self.buffer_string.push(c);
+    }
+
+    /// Move contents from the secondary buffer to the command line buffer.
+    pub fn consume_buffer_string(&mut self) -> Result<(), &'static str> {
+        let temp = self.buffer_string.clone();
+        self.print_to_terminal(temp.clone());
+        self.cmdline = temp;
+        self.buffer_string.clear();
+        Ok(())
+    }
+
+    /// Clear the secondary buffer.
+    pub fn clear_buffer_string(&mut self) {
+        self.buffer_string.clear();
+    }
+
+    pub fn is_buffer_string_empty(&self) -> bool {
+        self.buffer_string.is_empty()
+    }
+
+    /// Scroll the screen to the very beginning.
+    pub fn move_screen_to_begin(&mut self) {
+        // Home command only registers if the text display has the ability to scroll
+        if self.scroll_start_idx != 0 {
+            self.is_scroll_end = false;
+            self.scroll_start_idx = 0; // takes us up to the start of the page
+            if let Some(text_display) = self.window.get_displayable(&self.display_name){
+                text_display.disable_cursor();
+            }
+        }
+    }
+
+    /// Scroll the screen to the very end.
+    pub fn move_screen_to_end(&mut self) {
+        if !self.is_scroll_end {
+            self.is_scroll_end = true;
+            let buffer_len = self.scrollback_buffer.len();
+            self.scroll_start_idx = self.calc_start_idx(buffer_len, &self.display_name).0;
+        }
+    }
+
+    /// Scroll the screen a line up.
+    pub fn move_screen_line_up(&mut self) {
+        if self.scroll_start_idx != 0 {
+            self.scroll_up_one_line();
+            if let Some(text_display) = self.window.get_displayable(&self.display_name){
+                text_display.disable_cursor();
+            }
+        }
+    }
+
+    /// Scroll the screen a line down.
+    pub fn move_screen_line_down(&mut self) {
+        if !self.is_scroll_end {
+            self.scroll_down_one_line();
+        }
+    }
+
+    /// Scroll the screen a page up.
+    pub fn move_screen_page_up(&mut self) {
+        if self.scroll_start_idx <= 1 {
+            return;
+        }
+        self.page_up();
+        self.is_scroll_end = false;
+        if let Some(text_display) = self.window.get_displayable(&self.display_name){
+            text_display.disable_cursor();
+        }
+    }
+
+    /// Scroll the screen a page down.
+    pub fn move_screen_page_down(&mut self) {
+        if self.is_scroll_end {
+            return;
+        }
+        self.page_down();
+    }
+
+    pub fn initialize_screen(&mut self) -> Result<(), &'static str> {
+        let display_name = self.display_name.clone();
+        { 
+            let (width, height) = self.window.dimensions();
+            let width  = width  - 2*window_manager::WINDOW_MARGIN;
+            let height = height - 2*window_manager::WINDOW_MARGIN;
+            match self.window.add_displayable(&display_name, 0, 0,
+                TextDisplay::new(&display_name, width, height)) {
+                    Ok(_) => { }
+                    Err(err) => {return Err(err);}
+            };
+        }
+        self.refresh_display();
+        Ok(())
+    }
+
+    pub fn blink_cursor(&mut self) {
+        if let Some(text_display) = self.window.get_displayable(&self.display_name){
+            text_display.cursor_blink(&self.window, FONT_COLOR, BACKGROUND_COLOR);
+        }
+    }
+
+    /// Get a key event from the underlying window.
+    pub fn get_key_event(&self) -> Option<Event> {
+        self.window.get_key_event()
+    }
+
+    pub fn close_window(self) -> Result<(), &'static str> {
+        window_manager::delete(self.window)?;
+        Ok(())
+    }
+
+    /// If there is any output event from running application, print it to the screen, otherwise it does nothing.
+    pub fn check_and_print_app_output(&mut self) -> bool {
+        use core::ops::Deref;
+        if let Some(print_event) = self.print_consumer.peek() {
+            match print_event.deref() {
+                &Event::OutputEvent(ref s) => {
+                    self.print_to_terminal(s.text.clone());
+
+                    // Sets this bool to true so that on the next iteration the TextDisplay will refresh AFTER the 
+                    // task_handler() function has cleaned up, which does its own printing to the console
+                    self.refresh_display();
+                    self.correct_prompt_position = false;
+                },
+                _ => { },
+            }
+            print_event.mark_completed();
+            // Goes to the next iteration of the loop after processing print event to ensure that printing is handled before keypresses
+            return true;
+        }
+        false
+    }
+
+    /// Print a new prompt if we need, otherwise do nothing.
+    pub fn refresh_prompt_if_needed(&mut self) {
+        if !self.correct_prompt_position {
+            self.redisplay_prompt();
+        }
+    }
+
+    /// Get a producer to the print event queue.
+    pub fn get_producer_to_screen(&mut self) -> DFQueueProducer<Event> {
+        self.print_producer.obtain_producer()
+    }
+
+    /// Get current environment.
+    pub fn get_environment(&self) -> Arc<Mutex<Environment>> {
+        Arc::clone(&self.env)
+    }
+}


### PR DESCRIPTION
`terminal` is now split into `libterm` and `shell`.

`libterm` manages the layout on the text display, and directs events to `shell`. `libterm` is now merely a `struct` and does not contain any active thread.

`shell` depends on `libterm`, and is responsible for event handling, task spawning and managing, as well as command line history  managing.

Several minor bugs are fixed with some minor enhancement.
- Add `return OK(())` at several places in events handling functions
- Eliminate some redundant code
- Fix the logic in handling history command line navigating

Previous `stdin_buffer`, `stdout_buffer` are removed, since they are not currently used by applications and are not working like the conventional term.

Now on Theseus initialization, `shell` will be spawned instead of `terminal`.