### PR TITLE
Use the current task's namespace for dynamic symbol resolution in loadable mode

### DIFF
--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -54,9 +54,6 @@ path = "../panic_entry"
 path = "../vga_buffer"
 
 
-[features]
-loadable = []
-
 
 [lib]
 # staticlib is required to build a self-contained, fully-linked .a file 


### PR DESCRIPTION
Closes #198.