### PR TITLE
Do not force frame pointers by default

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,8 +20,16 @@ fn main() {
         println!("{}{}", CFG_PREFIX, s);
     }
 
-    eprintln!("ran build script, configs: {}", configs);
+    // Since there is no known way to obtain cfg values for codegen options,
+    // we must manually add the ones used in Theseus.
+    // Currently, the only codegen option we need to know about is force-frame-pointers
+    if let Ok(rustflags) = std::env::var("RUSTFLAGS") {
+        if rustflags.contains("force-frame-pointers=yes") {
+            println!("{}{}", CFG_PREFIX, "frame_pointers");
+        }
+    }
 
+    eprintln!("ran build script, configs: {}", configs);
 }
 
 

--- a/cfg/Config.mk
+++ b/cfg/Config.mk
@@ -21,8 +21,8 @@ CFG_DIR := $(ROOT_DIR)/cfg
 KERNEL_PREFIX ?= k\#
 APP_PREFIX    ?= a\#
 
-### NOTE: CURRENTLY FORCING RELEASE MODE UNTIL HASH-BASED SYMBOL RESOLUTION IS WORKING
-## Build modes:  debug is default (dev mode), release is release with full optimizations.
+## Build modes: debug is development mode, release is with full optimizations.
+## We build using release mode by default, because running in debug mode is prohibitively slow.
 ## You can set these on the command line like so: "make run BUILD_MODE=release"
 # BUILD_MODE ?= debug
 BUILD_MODE ?= release
@@ -60,7 +60,9 @@ RUSTFLAGS += -Z share-generics=no
 
 ## This forces frame pointers to be generated, i.e., the stack base pointer (RBP register on x86_64)
 ## will be used to store the starting address of the current stack frame.
-## This is used for stack unwinding purposes, in order to trace back up the call stack.
-## If/when we support using DWARF .debug_* sections to obtain the size of the current stack frame,
-## we can remove/disable this, since we won't need to use RBP anymore. 
-RUSTFLAGS += -C force-frame-pointers=yes
+## This can be used for obtaining a backtrace/stack trace,
+## but isn't necessary because Theseus supports parsing DWARF .debug_* sections to handle stack unwinding.
+## Note that this reduces the number of registers available to the compiler (by reserving RBP),
+## so it often results in slightly lowered performance. 
+## By default, this is not enabled.
+# RUSTFLAGS += -C force-frame-pointers=yes

--- a/kernel/panic_wrapper/src/lib.rs
+++ b/kernel/panic_wrapper/src/lib.rs
@@ -45,6 +45,7 @@ pub fn panic_wrapper(panic_info: &PanicInfo) -> Result<(), &'static str> {
         //     }
         // }
 
+        #[cfg(frame_pointers)]
         stack_trace_using_frame_pointer(
             &mmi_ref.lock().page_table,
             &|instruction_pointer: VirtualAddress| {
@@ -104,6 +105,7 @@ pub fn panic_wrapper(panic_info: &PanicInfo) -> Result<(), &'static str> {
 /// If the compiler didn't emit frame pointers, then this function will not work.
 /// 
 /// This was adapted from Redox's stack trace implementation.
+#[cfg(frame_pointers)]
 #[inline(never)]
 pub fn stack_trace_using_frame_pointer(
     current_page_table: &PageTable,


### PR DESCRIPTION
Now that we have support for parsing DWARF debugging info (.eh_frame), we don't need frame pointers to be emitted in order to obtain a stack trace. 

Forcing frame pointers often results in a small performance degradation, since it uses a register (the RBP base pointer register on x86_64) at all times to hold the frame pointer.