### PR TITLE
Remove the overly-complicated notion of a "starting crate" 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,6 +2046,7 @@ name = "stack_trace"
 version = "0.1.0"
 dependencies = [
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "task 0.1.0",
  "unwind 0.1.0",
 ]

--- a/kernel/exceptions_full/src/lib.rs
+++ b/kernel/exceptions_full/src/lib.rs
@@ -103,7 +103,6 @@ fn kill_and_halt(exception_number: u8) {
         &|stack_frame, stack_frame_iter| {
             let symbol_offset = stack_frame_iter.namespace().get_section_containing_address(
                 memory::VirtualAddress::new_canonical(stack_frame.call_site_address() as usize),
-                stack_frame_iter.starting_crate(),
                 false
             ).map(|(sec_ref, offset)| (sec_ref.lock().name.clone(), offset));
             if let Some((symbol_name, offset)) = symbol_offset {

--- a/kernel/panic_wrapper/src/lib.rs
+++ b/kernel/panic_wrapper/src/lib.rs
@@ -38,7 +38,6 @@ pub fn panic_wrapper(panic_info: &PanicInfo) -> Result<(), &'static str> {
                 &|stack_frame, stack_frame_iter| {
                     let symbol_offset = stack_frame_iter.namespace().get_section_containing_address(
                         VirtualAddress::new_canonical(stack_frame.call_site_address() as usize),
-                        stack_frame_iter.starting_crate(),
                         false
                     ).map(|(sec_ref, offset)| (sec_ref.lock().name.clone(), offset));
                     if let Some((symbol_name, offset)) = symbol_offset {

--- a/kernel/stack_trace/Cargo.toml
+++ b/kernel/stack_trace/Cargo.toml
@@ -8,6 +8,10 @@ build = "../../build.rs"
 [dependencies]
 fallible-iterator = { version = "0.2.0", default-features = false }
 
+[dependencies.log]
+default-features = false
+version = "0.3.7"
+
 [dependencies.task]
 path = "../task"
 

--- a/kernel/stack_trace/src/lib.rs
+++ b/kernel/stack_trace/src/lib.rs
@@ -19,7 +19,7 @@
 #![feature(asm)]
 
 extern crate alloc;
-// #[macro_use] extern crate log;
+#[macro_use] extern crate log;
 extern crate task;
 extern crate unwind;
 extern crate fallible_iterator;
@@ -61,11 +61,8 @@ pub fn stack_trace(
     let max_recursion = max_recursion.unwrap_or(64);
 
     unwind::invoke_with_current_registers(|registers| {
-        let (namespace, app_crate) = {
-            let curr_task = task::get_my_current_task().ok_or("couldn't get current task")?;
-            (curr_task.get_namespace(), curr_task.lock().app_crate.as_ref().map(|a| a.clone_shallow()))
-        };
-        let mut stack_frame_iter = StackFrameIter::new(namespace, app_crate, registers);
+        let namespace = task::get_my_current_task().ok_or("couldn't get current task")?.get_namespace();
+        let mut stack_frame_iter = StackFrameIter::new(namespace, registers);
 
         // iterate over each frame in the call stack
         let mut i = 0;
@@ -76,7 +73,8 @@ pub fn stack_trace(
             }
             i += 1;
             if i == max_recursion {
-                return Err("reached maximum recursion depth of call stack frames");
+                trace!("stack_trace(): reached maximum recursion depth of {} stack frames", max_recursion);
+                return Err("reached recursion limit for stack frames");
             }
         }
         Ok(())


### PR DESCRIPTION
Previously used in unwinding and stack traces, primarily for looking up the crate or section that contains a virtual address.

This is no longer needed because the CrateNamespace will include app crates and app library crates too.