### PR TITLE
Updated the mm_eval benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libterm"
 version = "0.1.0"
 dependencies = [
@@ -1036,6 +1041,24 @@ dependencies = [
  "tsc 0.1.0",
  "window 0.1.0",
  "window_manager 0.1.0",
+]
+
+[[package]]
+name = "libtest"
+version = "0.1.0"
+dependencies = [
+ "apic 0.1.0",
+ "atomic 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit_field 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hpet 0.1.0",
+ "libm 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory 0.1.0",
+ "pmu_x86 0.1.0",
+ "runqueue 0.1.0",
+ "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "task 0.1.0",
+ "x86_64 0.1.2",
 ]
 
 [[package]]
@@ -1098,6 +1121,21 @@ dependencies = [
 name = "managed"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mapper_spillful"
+version = "0.1.0"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "irq_safety 0.1.1 (git+https://github.com/kevinaboos/irq_safety)",
+ "kernel_config 0.1.0",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory 0.1.0",
+ "memory_structs 0.1.0",
+ "memory_x86_64 0.1.0",
+ "rbtree 0.1.5 (git+https://github.com/theseus-os/rbtree-rs.git)",
+]
 
 [[package]]
 name = "memchr"
@@ -1179,12 +1217,19 @@ dependencies = [
 name = "mm_eval"
 version = "0.1.0"
 dependencies = [
+ "apic 0.1.0",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.21 (git+https://github.com/kevinaboos/getopts)",
  "hpet 0.1.0",
  "kernel_config 0.1.0",
+ "libm 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libtest 0.1.0",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mapper_spillful 0.1.0",
  "memory 0.1.0",
+ "memory_structs 0.1.0",
+ "pmu_x86 0.1.0",
+ "runqueue 0.1.0",
  "terminal_print 0.1.0",
  "tsc 0.1.0",
 ]
@@ -1696,6 +1741,14 @@ dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rbtree"
+version = "0.1.5"
+source = "git+https://github.com/theseus-os/rbtree-rs.git#b6aa681314fb8ac8384f434bd6ef7605c5d308ee"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2514,6 +2567,7 @@ source = "git+https://github.com/kevinaboos/zero.git#9fc7ff523138a21f40359b706d2
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum libm 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 "checksum linked_list_allocator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "655d57c71827fe0891ce72231b6aa5e14033dae3f604609e6a6f807267c1678d"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -2537,6 +2591,7 @@ source = "git+https://github.com/kevinaboos/zero.git#9fc7ff523138a21f40359b706d2
 "checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
 "checksum rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3"
 "checksum raw-cpuid 7.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
+"checksum rbtree 0.1.5 (git+https://github.com/theseus-os/rbtree-rs.git)" = "<none>"
 "checksum rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"

--- a/applications/mm_eval/Cargo.toml
+++ b/applications/mm_eval/Cargo.toml
@@ -8,6 +8,7 @@ build = "../../build.rs"
 [dependencies]
 getopts = "0.2.21"
 cfg-if = "0.1.6"
+libm = "0.2.1"
 
 [dependencies.log]
 default-features = false
@@ -25,5 +26,23 @@ path = "../../kernel/kernel_config"
 [dependencies.memory]
 path = "../../kernel/memory"
 
+[dependencies.memory_structs]
+path = "../../kernel/memory_structs"
+
 [dependencies.terminal_print]
 path = "../../kernel/terminal_print"
+
+[dependencies.apic]
+path = "../../kernel/apic"
+
+[dependencies.runqueue]
+path = "../../kernel/runqueue"
+
+[dependencies.libtest]
+path = "../../kernel/libtest"
+
+[dependencies.pmu_x86]
+path = "../../kernel/pmu_x86"
+
+[dependencies.mapper_spillful]
+path = "../../kernel/mapper_spillful"

--- a/kernel/libtest/Cargo.toml
+++ b/kernel/libtest/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+authors = ["Ramla Ijaz <ijazramla.com>"]
+name = "libtest"
+description = "A set of convenience functions that can be used for benchmarking within Theseus."
+version = "0.1.0"
+build = "../../build.rs"
+
+[dependencies]
+spin = "0.4.10"
+# x86_64 = { git = "https://github.com/kevinaboos/x86_64" }
+x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+bit_field = "0.10.0"
+atomic = "0.4.5"
+libm = "0.2.1"
+
+[dependencies.apic]
+path = "../apic"
+
+[dependencies.log]
+default-features = false
+version = "0.3.7"
+
+[dependencies.memory]
+path = "../memory"
+
+[dependencies.task]
+path = "../task"
+
+[dependencies.runqueue]
+path = "../runqueue"
+
+[dependencies.hpet]
+path = "../hpet"
+
+[dependencies.pmu_x86]
+path = "../pmu_x86"
+
+
+[lib]
+crate-type = ["rlib"]

--- a/kernel/libtest/src/lib.rs
+++ b/kernel/libtest/src/lib.rs
@@ -1,0 +1,171 @@
+#![no_std]
+#![feature(asm)]
+#![feature(no_more_cas)]
+
+extern crate alloc;
+extern crate task;
+extern crate memory;
+extern crate apic;
+extern crate hpet;
+extern crate runqueue;
+extern crate pmu_x86;
+extern crate libm;
+
+use hpet::get_hpet;
+use pmu_x86::{Counter, EventType};
+use alloc::vec::Vec;
+
+const NANO_TO_FEMTO: u64 = 1_000_000;
+
+/// Helper function to convert ticks to nano seconds
+pub fn hpet_2_ns(hpet: u64) -> u64 {
+	let hpet_period = get_hpet().as_ref().unwrap().counter_period_femtoseconds();
+	hpet * hpet_period as u64 / NANO_TO_FEMTO
+}
+
+#[macro_export]
+macro_rules! CPU_ID {
+	() => (apic::get_my_apic_id().unwrap())
+}
+
+/// Helper function return the tasks in a given core's runqueue
+pub fn nr_tasks_in_rq(core: u8) -> Option<usize> {
+	match runqueue::get_runqueue(core).map(|rq| rq.read()) {
+		Some(rq) => { Some(rq.iter().count()) }
+		_ => { None }
+	}
+}
+
+/// True if only two tasks are running in the current runqueue.
+/// Used to verify if there are any other tasks than the current task and idle task in the runqueue
+pub fn check_myrq() -> bool {
+	match nr_tasks_in_rq(CPU_ID!()) {
+		Some(2) => { true }
+		_ => { false }
+	}
+}
+
+#[inline(always)]
+/// Starts the PMU counter to measure reference cycles.
+/// The PMU should be initialized before calling this function.
+/// The PMU initialization, start count and stop count should all be called on the same core.
+pub fn start_counting_reference_cycles() -> Result<Counter, &'static str> {
+	let mut counter = Counter::new(EventType::UnhaltedReferenceCycles)?;
+	counter.start()?;
+	Ok(counter)
+}
+
+#[inline(always)]
+/// Stops the PMU counter and stores the reference cycles since the start.
+/// The PMU should be initialized before calling this function.
+/// The PMU initialization, start count and stop count should all be called on the same core.
+pub fn stop_counting_reference_cycles(counter: Counter) -> Result<u64, &'static str> {
+	let count = counter.diff();
+	let _ = counter.end()?;
+	Ok(count)
+}
+
+/// Measures the overhead of using the PMU reference cycles counter.
+/// Calls `timing_overhead_inner` multiple times and averages the value. 
+/// Overhead is in reference cycles.
+pub fn cycle_count_overhead() -> Result<u64, &'static str>  {
+	const TRIES: u64 = 10;
+
+	let mut overhead_sum: u64 = 0;
+	let mut max: u64 = core::u64::MIN;
+	let mut min: u64 = core::u64::MAX;
+
+	for _ in 0..TRIES {
+		let overhead = cycle_count_overhead_inner()?;
+		overhead_sum += overhead;
+		if overhead > max {max = overhead;}
+		if overhead < min {min = overhead;}
+	}
+
+	Ok(overhead_sum/ TRIES as u64)
+}
+
+/// Internal function that actually calculates cycle count overhead. 
+/// Calls the counter read instruction multiple times and average the value. 
+/// Overhead is in reference cycles. 
+fn cycle_count_overhead_inner() -> Result<u64, &'static str> {
+	const ITERATIONS: usize = 10_000;
+	let mut _tmp: u64;
+	let delta: u64;
+
+	let counter = start_counting_reference_cycles()?;
+
+	for _ in 0..ITERATIONS {
+		_tmp = counter.diff();
+	}
+	delta = stop_counting_reference_cycles(counter)?;
+
+	Ok(delta / ITERATIONS as u64)
+}
+
+/// Helper function to calculate statistics of a provided dataset
+pub fn calculate_stats(vec: &Vec<u64>) -> Option<Stats>{
+	let mean;
+  	let median;
+  	let p_75;
+	let p_25;
+	let min;
+	let max;
+	let var;
+    let std_dev;
+
+	if vec.is_empty() {
+		return None;
+	}
+
+	let len = vec.len();
+
+  	{ // calculate average
+		let mut sum: u64 = 0;
+		for &x in vec {
+			sum = sum + x;
+		}
+
+		mean = sum as u64 / len as u64;
+  	}
+
+	{ // calculate median
+		let mut vec2 = vec.clone();
+		vec2.sort();
+		let mid = len / 2;
+		let i_75 = len * 3 / 4;
+		let i_25 = len * 1 / 4;
+
+		median = vec2[mid];
+		p_25 = vec2[i_25];
+		p_75 = vec2[i_75];
+		min = vec2[0];
+		max = vec2[len - 1];
+  	}
+
+	{ // calculate sample variance
+		let mut diff_sum: u64 = 0;
+      	for &x in vec {
+			if x > mean {
+				diff_sum = diff_sum + ((x-mean)*(x-mean));
+			}
+			else {
+				diff_sum = diff_sum + ((mean - x)*(mean - x));
+			}
+      	}
+
+    	var = (diff_sum) / (len as u64);
+        std_dev = libm::sqrt(var as f64);
+	}
+	Some(Stats{ min, p_25, median, p_75, max, mean, std_dev })
+}
+
+pub struct Stats {
+	pub min: u64,
+	pub p_25: u64,
+	pub median: u64,
+	pub p_75: u64,
+	pub max: u64, 
+	pub mean: u64,
+	pub std_dev: f64,
+}

--- a/kernel/mapper_spillful/Cargo.toml
+++ b/kernel/mapper_spillful/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "mapper_spillful"
+description = "A spillful version of the mapper for the virtual memory subsystem."
+version = "0.1.0"
+build = "../../build.rs"
+
+[dependencies]
+cfg-if = "0.1.6"
+
+[dependencies.log]
+default-features = false
+version = "0.3.7"
+
+[dependencies.lazy_static]
+features = ["spin_no_std", "nightly"]
+version = "1.2.0"
+
+[dependencies.irq_safety]
+git = "https://github.com/kevinaboos/irq_safety"
+
+[dependencies.kernel_config]
+path = "../kernel_config"
+
+[dependencies.memory_x86_64]
+path = "../memory_x86_64"
+
+[dependencies.memory_structs]
+path = "../memory_structs"
+
+[dependencies.rbtree]
+git = "https://github.com/theseus-os/rbtree-rs.git"
+
+[dependencies.memory]
+path = "../memory"
+
+[lib]
+crate-type = ["rlib"]

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -43,8 +43,12 @@ macro_rules! try_forget {
 
 
 mod area_frame_allocator;
-mod paging;
 mod stack_allocator;
+#[cfg(not(mapper_spillful))]
+mod paging;
+
+#[cfg(mapper_spillful)]
+pub mod paging;
 
 
 pub use self::area_frame_allocator::AreaFrameAllocator;
@@ -166,7 +170,7 @@ pub fn create_contiguous_mapping(size_in_bytes: usize, flags: EntryFlags) -> Res
 
 
 
-static BROADCAST_TLB_SHOOTDOWN_FUNC: Once<fn(Vec<VirtualAddress>)> = Once::new();
+pub static BROADCAST_TLB_SHOOTDOWN_FUNC: Once<fn(Vec<VirtualAddress>)> = Once::new();
 
 /// Set the function callback that will be invoked every time a TLB shootdown is necessary,
 /// i.e., during page table remapping and unmapping operations.

--- a/kernel/memory/src/paging/mod.rs
+++ b/kernel/memory/src/paging/mod.rs
@@ -9,12 +9,12 @@
 
 mod virtual_address_allocator;
 mod entry;
-mod table;
 mod temporary_page;
 mod mapper;
-
+#[cfg(not(mapper_spillful))]
+mod table;
 #[cfg(mapper_spillful)]
-pub mod mapper_spillful;
+pub mod table;
 
 
 pub use self::entry::*;

--- a/kernel/memory_structs/src/lib.rs
+++ b/kernel/memory_structs/src/lib.rs
@@ -286,6 +286,10 @@ impl VirtualMemoryArea {
         let end_page = Page::containing_address(self.start + self.size - 1);
         PageRange::new(start_page, end_page)
     }
+
+    pub fn set_flags(&mut self, flags: EntryFlags) {
+        self.flags = flags;
+    }
 }
 
 


### PR DESCRIPTION
* used an rb tree for the VMA list
* used a PMU counter to measure cycles rather than timers
* moved mapper_spillful to a separate crate

Also added a libtest crate which contains commonly used functions for benchmarking.