### PR TITLE
Improvements to heap benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,6 +1390,7 @@ dependencies = [
  "slabmalloc 0.7.0",
  "slabmalloc_safe 0.7.0",
  "slabmalloc_unsafe 0.7.0",
+ "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/applications/heap_eval/src/shbench.rs
+++ b/applications/heap_eval/src/shbench.rs
@@ -2,9 +2,6 @@
 //! 
 //! The original version can be found on MicroQuill's website
 //! http://www.microquill.com/smartheap/shbench/bench.zip
-//! 
-//! Since shbench stresses the system and continuously grows the heap,
-//! we run each trial after restarting Theseus so that the initial size of the heap is the same for each trial.
 
 use alloc::{
     vec::Vec,

--- a/kernel/multiple_heaps/Cargo.toml
+++ b/kernel/multiple_heaps/Cargo.toml
@@ -9,6 +9,8 @@ build = "../../build.rs"
 intrusive-collections = "0.9.0"
 static_assertions = "1.1.0"
 cfg-if = "0.1.6"
+spin = "0.4.10"
+
 
 [dependencies.irq_safety]
 git = "https://github.com/kevinaboos/irq_safety"


### PR DESCRIPTION
- updated shbench to run for multiple iterations, and deallocate all allocations. 
- Changed the unsafe heap to store its Mapped Pages within the heap structure rather than the kernel mmi