### PR TITLE
Correct some book typos

### DIFF
--- a/book/src/booting.md
+++ b/book/src/booting.md
@@ -1,7 +1,7 @@
 # Booting Process and Flow of Execution
 
-The kernel takes over from the bootloader (GRUB, or another multiboot2-compatible bootloader) in `nano_core/src/boot/arch_x86_64/boot.asm:start` and is running in *32-bit protected mode*. 
-After initializing paging and other things, the assembly file `boot.asm` jumps to `long_mode_start`, which runs 64-bit code in long mode. 
-Then, it jumps to `start_high`, so now we're running in the higher half because Theseus is a [higher-half kernel](https://wiki.osdev.org/Higher_Half_Kernel). 
+The kernel takes over from the bootloader (GRUB, or another multiboot2-compatible bootloader) in `nano_core/src/boot/arch_x86_64/boot.asm:start` and is running in *32-bit protected mode*.
+After initializing paging and other things, the assembly file `boot.asm` jumps to `long_mode_start`, which runs 64-bit code in long mode.
+Then, it jumps to `start_high`, so now we're running in the higher half because Theseus is a [higher-half kernel](https://wiki.osdev.org/Higher_Half_Kernel).
 We then set up a new Global Descriptor Table (GDT), segmentation registers, and finally call the Rust code entry point [`nano_core_start()`](../nano_core/fn.nano_core_start.html) with the address of the multiboot2 boot information structure as the first argument (in register RDI).
-After calling `nano_core_start`, the assembly files are no longer used, and `nano_core_start` should never return. 
+After calling `nano_core_start`, the assembly files are no longer used, and `nano_core_start` should never return.

--- a/book/src/booting.md
+++ b/book/src/booting.md
@@ -1,9 +1,7 @@
 # Booting Process and Flow of Execution
 
-The kernel takes over from the bootloader (GRUB, or another multiboot2-compatible bootloader) in `nano_core/src//arch_x86_64/boot.asm:start` and is running in *32-bit protected mode*. 
-After initializing paging and other things, the assembly file `boot.asm` jumps to `long_mode_start`, which runs it code in long mode. 
-Then, it jumps to `start_high`, so now we're running in the higher half because Theseus is a [higher-half kernel]ps://wiki.osdev.org/Higher_Half_Kernel). 
-We then set up a new Global Descriptor Table (GDT), segmentation registers, and finally call the Rust code entry t [`nano_core_start()`](../nano_core/fn.nano_core_start.html) with the address of the multiboot2 boot rmation structure as the first argument (in register RDI).
-After calling `nano_core_start`, the assembly files are no longer used, and `nano_core_start` should never rn. 
-
-
+The kernel takes over from the bootloader (GRUB, or another multiboot2-compatible bootloader) in `nano_core/src/boot/arch_x86_64/boot.asm:start` and is running in *32-bit protected mode*. 
+After initializing paging and other things, the assembly file `boot.asm` jumps to `long_mode_start`, which runs 64-bit code in long mode. 
+Then, it jumps to `start_high`, so now we're running in the higher half because Theseus is a [higher-half kernel](https://wiki.osdev.org/Higher_Half_Kernel). 
+We then set up a new Global Descriptor Table (GDT), segmentation registers, and finally call the Rust code entry point [`nano_core_start()`](../nano_core/fn.nano_core_start.html) with the address of the multiboot2 boot information structure as the first argument (in register RDI).
+After calling `nano_core_start`, the assembly files are no longer used, and `nano_core_start` should never return. 

--- a/book/src/build_process.md
+++ b/book/src/build_process.md
@@ -10,10 +10,10 @@ The only special action it takes is to build the `nano_core` separately and full
 
 Theseus can be built in a variety of modes, but offers two presets: **debug** and **release** build modes.
 By default, Theseus is built in release mode for usable performance within an emulator like QEMU.
-To build in debug mode, set the `BUILD_MODE` environment variable when running `make`, like so:  
+To build in debug mode, set the `BUILD_MODE` environment variable when running `make`, like so:
 `make run BUILD_MODE=debug`
 
-There is a special file `cfg/Config.mk` that contains the build mode options as well as other configuration options used in the kernel Makefile. 
+There is a special file `cfg/Config.mk` that contains the build mode options as well as other configuration options used in the kernel Makefile.
 As with most languages, release mode in Rust is *way* faster, but it does take longer to compile and can be difficult to attach a debugger.
 
 ## Runtime Loading and Linking of Crates
@@ -24,6 +24,6 @@ To enable this, use the `make loadable` command to enable the `loadable` feature
 
 * Builds each crate into its own separate object file, which are not all linked together like in other OSes.
 * Enables release mode in order to make each module file smaller and faster to load, i.e., sets LD_MODE=release`.
-* Copies each crate's object file into the top-level build directory's module subdirectory (`build/grub-isofiles/modules`) such that each module is a separate object file in the final .iso image. 
+* Copies each crate's object file into the top-level build directory's module subdirectory (`build/grub-isofiles/modules`) such that each module is a separate object file in the final .iso image.
   That allows the running instance of Theseus to see all the modules currently available just by asking the loader (without needing a filesystem), and to load them individually.
 * Sets the `loadable` config option, which as seen in the `nano_core`, will enable the `#![cfg(loadable)]` code blocks that dynamically load other crates rather than include them as static dependencies.

--- a/book/src/build_process.md
+++ b/book/src/build_process.md
@@ -1,6 +1,6 @@
 # Theseus's Build Process
 
-Theseus uses the [cargo virtual workspace](https://doc.rust-lang.org/cargo/reference/fest.html#the-workspace-section) feature to group all of the crates together into a single meta project, which sigificantly speeds up build times.
+Theseus uses the [cargo virtual workspace](https://doc.rust-lang.org/cargo/reference/fest.html#the-workspace-section) feature to group all of the crates together into a single meta project, which significantly speeds up build times.
 
 The top-level Makefile basically just invokes the Rust toolchain and compiler, copies the built object files into a top-level build directory, and then generates a bootable .iso image using various bootloader tools.
 We build all of the Rust code using [`xargo`](https://github.com/ric/xargo), a cross-compiler toolchain that wraps the default Rust `cargo`.
@@ -13,17 +13,17 @@ By default, Theseus is built in release mode for usable performance within an em
 To build in debug mode, set the `BUILD_MODE` environment variable when running `make`, like so:  
 `make run BUILD_MODE=debug`
 
-There is a special file `cfg/Config.mk` that contains the build mode options as well as other configuration ons used in the kernel Makefile. 
+There is a special file `cfg/Config.mk` that contains the build mode options as well as other configuration options used in the kernel Makefile. 
 As with most languages, release mode in Rust is *way* faster, but it does take longer to compile and can be difficult to attach a debugger.
 
 ## Runtime Loading and Linking of Crates
 
-By default, Theseus is built into a single kernel binary just like a regular OS, in which all crates are linked  a single static library and then zipped up into a bootable .iso file.
-However, our actual research into runtime composability dictates that all crates (except the `nano_core`) are ed at runtime, and not linked into a single static kernel binary.
+By default, Theseus is built into a single kernel binary just like a regular OS, in which all crates are linked into a single static library and then zipped up into a bootable .iso file.
+However, our actual research into runtime composability dictates that all crates (except the `nano_core`) are loaded at runtime, and not linked into a single static kernel binary.
 To enable this, use the `make loadable` command to enable the `loadable` feature, which does the following:
 
 * Builds each crate into its own separate object file, which are not all linked together like in other OSes.
 * Enables release mode in order to make each module file smaller and faster to load, i.e., sets LD_MODE=release`.
-* Copies each crate's object file into the top-level build directory's module subdirectory (`build/grub-isofiles/les`) such that each module is a separate object file in the final .iso image. 
+* Copies each crate's object file into the top-level build directory's module subdirectory (`build/grub-isofiles/modules`) such that each module is a separate object file in the final .iso image. 
   That allows the running instance of Theseus to see all the modules currently available just by asking the loader (without needing a filesystem), and to load them individually.
-* Sets the `loadable` config option, which as seen in the `nano_core`, will enable the `#![cfg(loadable)]` code ks that dynamically load other crates rather than include them as static dependencies.
+* Sets the `loadable` config option, which as seen in the `nano_core`, will enable the `#![cfg(loadable)]` code blocks that dynamically load other crates rather than include them as static dependencies.

--- a/book/src/ch00-00-introduction.md
+++ b/book/src/ch00-00-introduction.md
@@ -2,7 +2,7 @@
 
 Theseus is a new OS written from scratch in Rust, with the goals of runtime composability and state spill freedom.
 
-The Theseus kernel is composed of many small entities, each contained within a single Rust crate, and built all together as a cargo virtual workspace. 
+The Theseus kernel is composed of many small entities, each contained within a single Rust crate, and built all together as a cargo virtual workspace.
 All crates in Theseus are listed in the sidebar to the left. Click on a crate name to read more about it, and the functions and types it provides.
 Each crate is its own project with its own "Cargo.toml" manifest file that specifies that crate's dependencies and features.
 
@@ -22,7 +22,7 @@ One-line summaries of what each crate includes (may be incomplete):
 * `exceptions_full`: Exception handlers that are more fully-featured, i.e., kills tasks on an exception.
 * `fs_node`: defines the traits for File and Directory. These files and directories mimic that of a standard unix virtual filesystem
 * `gdt`: GDT (Global Descriptor Table) support (x86 only) for Theseus.
-* `interrupts`: Interrupt configuration and handlers for Theseus. 
+* `interrupts`: Interrupt configuration and handlers for Theseus.
 * `ioapic`: IOAPIC (I/O Advanced Programmable Interrupt Controller) support (x86 only) for Theseus.
 * `keyboard`: simple PS2 keyboard driver.
 * `memory`: The virtual memory subsystem.
@@ -31,7 +31,7 @@ One-line summaries of what each crate includes (may be incomplete):
 * `nano-core`: a tiny module that is responsible for bootstrapping the OS at startup.
 * `panic_entry`: Default entry point for panics and unwinding, as required by the Rust compiler.
 * `panic_wrapper`: Wrapper functions for handling and propagating panics.
-* `path`: contains functions for navigating the filesystem / getting pointers to specific directories via the Path struct 
+* `path`: contains functions for navigating the filesystem / getting pointers to specific directories via the Path struct.
 * `pci`: Basic PCI support for Theseus, x86 only.
 * `pic`: PIC (Programmable Interrupt Controller), support for a legacy interrupt controller that isn't used much.
 * `pit_clock`: PIT (Programmable Interval Timer) support for Theseus, x86 only.

--- a/book/src/ch01.md
+++ b/book/src/ch01.md
@@ -4,20 +4,20 @@ Principles and Guidelines for Theseus Development and Contribution.
 
 *Code for others how you wish they would code for you.*
 
-What does this mean? You should adhere to the following principles. 
+What does this mean? You should adhere to the following principles.
 
 * **Good abstractions.** Another developer using your code should never have to study the internals of the code itself,
   but rather be able to fully understand how to use your code simply from its struct/function names and documentation.
-  Use intuitive names and try to design an interface that makes sense, is simple, easy to use, and doesn't surprise anyone with unnecessary trickery. 
+  Use intuitive names and try to design an interface that makes sense, is simple, easy to use, and doesn't surprise anyone with unnecessary trickery.
 
 * **Be clean.** Write well-crafted, concise code with sufficient features to be useful, but without bloat.
   Adhere to code style conventions, including proper spacing, doc comments, naming conventions, etc.
 
-* **Foolproof code.** Think carefully about how others will use your code, 
+* **Foolproof code.** Think carefully about how others will use your code,
   and design it thoughtfully to prevent others from making mistakes when using your code,
-  ideally prevented at compile time instead of runtime. 
+  ideally prevented at compile time instead of runtime.
 
-* **Errors are important!**  Handle errors gracefully and thoroughly, 
+* **Errors are important!**  Handle errors gracefully and thoroughly,
   and return detailed error messages that clearly describe the issue. *Don't ever let something fail silently!*
 
 Below are some other good practices.
@@ -25,52 +25,52 @@ Below are some other good practices.
 * **Accurate metadata.**  In addition to good code and documentation, make sure to fill in additional metadata,
   such as the details present in each crate's `Cargo.toml` file: description, keywords, authors, etc.
 
-* **No "magic" numbers.** Do not use literal number values that have no documentation or explanation of why they exist. 
-  For example, instead of just writing a value like 4096 in the code, create a `const` that accurately describes the semantic meaning of that value, e.g., `const PAGE_SIZE: usize = 4096;`. 
-  Magic numbers are terrible to maintain and don't help anyone who looks at your code in the future. 
+* **No "magic" numbers.** Do not use literal number values that have no documentation or explanation of why they exist.
+  For example, instead of just writing a value like 4096 in the code, create a `const` that accurately describes the semantic meaning of that value, e.g., `const PAGE_SIZE: usize = 4096;`.
+  Magic numbers are terrible to maintain and don't help anyone who looks at your code in the future.
 
 * **Minimize global states.** Remove static (global) states as much as possible, and rethink how the same data sharing can be done without globals.
 
 # Rust-specific Guidelines
 
-* **Rust style.** Follow proper Rust coding style and naming conventions. Use correct spacing, indentation, and alignment that matches the existing style. 
+* **Rust style.** Follow proper Rust coding style and naming conventions. Use correct spacing, indentation, and alignment that matches the existing style.
   Make your code visually appealing, with spaces between operators like equal signs, addition, spaces after a comma, etc. Punctuation is important for legibility!
 
-* **Rust documentation.** Use proper rustdoc-style documentation *for all structs, functions, and types.* 
-  Make sure all of your documentation links are correct, and that you're using the correct rustdoc formatting for doc comments. 
-  Triple slashes `///` should be used above function and struct definitions, double slashes `//` for C-style inline comments (or block comments like `/* */`), and `//! ` for crate top-level documentation. 
-  Use Markdown formatting to describe function arguments, return values, and include usage examples, in a way consistent with Rust's official libraries. 
+* **Rust documentation.** Use proper rustdoc-style documentation *for all structs, functions, and types.*
+  Make sure all of your documentation links are correct, and that you're using the correct rustdoc formatting for doc comments.
+  Triple slashes `///` should be used above function and struct definitions, double slashes `//` for C-style inline comments (or block comments like `/* */`), and `//! ` for crate top-level documentation.
+  Use Markdown formatting to describe function arguments, return values, and include usage examples, in a way consistent with Rust's official libraries.
 
 * **`Option`s and `Result`s.** Use Options and Results properly. Don't use special values that have overloaded meanings, e.g., an integer in which `0` means no value, or something like that.
   [Here's a good resource](<https://blog.burntsushi.net/rust-error-handling/>) for better understanding error handling in Rust.
 
-  `Option`s should be returned when an operation might fail, but that failure condition doesn't affect the rest of the system. 
-  For example, if you're searching for an element in a list, then an `Option` is the suitable choice because the caller of your getter function would only call it in order to get and use the return value. 
-  
-  `Result`s should be returned if something can fail or succeed, and the caller needs to know whether it succeeded, but potentially need the actual return value, e.g., an init function that returns void. 
-  In this case, `Result` is the best choice because we want to force the caller to acknowledge that the init function succeeded, or handle its error if it failed. 
-  In Theseus, `Results` are mandatory when a function has some side effect, such as setting a parameter or value that might not exist or be initialized yet. 
-  In that case, a result must be used to indicate whether the function succeeded. 
+  `Option`s should be returned when an operation might fail, but that failure condition doesn't affect the rest of the system.
+  For example, if you're searching for an element in a list, then an `Option` is the suitable choice because the caller of your getter function would only call it in order to get and use the return value.
+
+  `Result`s should be returned if something can fail or succeed, and the caller needs to know whether it succeeded, but potentially need the actual return value, e.g., an init function that returns void.
+  In this case, `Result` is the best choice because we want to force the caller to acknowledge that the init function succeeded, or handle its error if it failed.
+  In Theseus, `Results` are mandatory when a function has some side effect, such as setting a parameter or value that might not exist or be initialized yet.
+  In that case, a result must be used to indicate whether the function succeeded.
 
 
 # Theseus-specific Guidelines
 
-* **Handle `Result`s properly and fully.** Don't ignore a result error, instead, log that error and then handle it if possible. 
+* **Handle `Result`s properly and fully.** Don't ignore a result error, instead, log that error and then handle it if possible.
   If you cannot handle it, return that error to the caller so they can attempt to handle it. **NEVER SILENCE OR RE ERRORS**.
-  
-  **Never use panics.**  Avoid code or functions that can panic, such as bracket indexing operations `[]`, or panicking functions like `unwrap()` or `expect()`. 
-  Instead, handle these error cases explicitly and return a `Result` to the caller, which is much cleaner than panicking. 
+
+  **Never use panics.**  Avoid code or functions that can panic, such as bracket indexing operations `[]`, or panicking functions like `unwrap()` or `expect()`.
+  Instead, handle these error cases explicitly and return a `Result` to the caller, which is much cleaner than panicking.
   Panicking is dangerous and cannot be easily recovered from. As your code most likely will run in a privileged mode, panicking will be unrecoverable.
 
-* **Never use unsafe code.** If you absolutely cannot avoid it, then you should review your case on an individual basis with the maintainer. 
-  In 99.99% of cases, unsafe code is not necessary and can be rewritten safely. 
+* **Never use unsafe code.** If you absolutely cannot avoid it, then you should review your case on an individual basis with the maintainer.
+  In 99.99% of cases, unsafe code is not necessary and can be rewritten safely.
 
 
 
 # Adding New Functionality to Theseus
 
 The easiest way to add new functionality is just to create a new crate by duplicating an existing crate and changing the details in its new `Cargo.toml` file.
-At the very least, you'll need to change the `name` entry under the `[package]` heading at the top of the `Cargo.toml` file, and you'll need to change the dependencies for your new crate.     
-If your new crate needs to be initialized, you can invoke it from the [`captain::init()`](../captain/fn.init.html) function, 
+At the very least, you'll need to change the `name` entry under the `[package]` heading at the top of the `Cargo.toml` file, and you'll need to change the dependencies for your new crate.
+If your new crate needs to be initialized, you can invoke it from the [`captain::init()`](../captain/fn.init.html) function,
 although there may be more appropriate places to do so, such as the [`device_manager::init()`](../device_manager/fn.init.html) function for drivers.
 

--- a/book/src/ch01.md
+++ b/book/src/ch01.md
@@ -6,9 +6,9 @@ Principles and Guidelines for Theseus Development and Contribution.
 
 What does this mean? You should adhere to the following principles. 
 
-* **Good abstractions.** Another developer using your code should never have to study the internals of the code lf,
-  but rather be able to fully understand how to use your code simply from its struct/function names and mentation.
-  Use intuitive names and try to design an interface that makes sense, is simple, easy to use, and doesn't rise anyone with unnecessary trickery. 
+* **Good abstractions.** Another developer using your code should never have to study the internals of the code itself,
+  but rather be able to fully understand how to use your code simply from its struct/function names and documentation.
+  Use intuitive names and try to design an interface that makes sense, is simple, easy to use, and doesn't surprise anyone with unnecessary trickery. 
 
 * **Be clean.** Write well-crafted, concise code with sufficient features to be useful, but without bloat.
   Adhere to code style conventions, including proper spacing, doc comments, naming conventions, etc.
@@ -25,52 +25,52 @@ Below are some other good practices.
 * **Accurate metadata.**  In addition to good code and documentation, make sure to fill in additional metadata,
   such as the details present in each crate's `Cargo.toml` file: description, keywords, authors, etc.
 
-* **No "magic" numbers.** Do not use literal number values that have no documentation or explanation of why they t. 
-  For example, instead of just writing a value like 4096 in the code, create a `const` that accurately describes semantic meaning of that value, e.g., `const PAGE_SIZE: usize = 4096;`. 
+* **No "magic" numbers.** Do not use literal number values that have no documentation or explanation of why they exist. 
+  For example, instead of just writing a value like 4096 in the code, create a `const` that accurately describes the semantic meaning of that value, e.g., `const PAGE_SIZE: usize = 4096;`. 
   Magic numbers are terrible to maintain and don't help anyone who looks at your code in the future. 
 
-* **Minimize global states.** Remove static (global) states as much as possible, and rethink how the same data ing can be done without globals.
+* **Minimize global states.** Remove static (global) states as much as possible, and rethink how the same data sharing can be done without globals.
 
 # Rust-specific Guidelines
 
-* **Rust style.** Follow proper Rust coding style and naming conventions. Use correct spacing, indentation, and nment that matches the existing style. 
-  Make your code visually appealing, with spaces between operators like equal signs, addition, spaces after a a, etc. Punctuation is important for legibility!
+* **Rust style.** Follow proper Rust coding style and naming conventions. Use correct spacing, indentation, and alignment that matches the existing style. 
+  Make your code visually appealing, with spaces between operators like equal signs, addition, spaces after a comma, etc. Punctuation is important for legibility!
 
 * **Rust documentation.** Use proper rustdoc-style documentation *for all structs, functions, and types.* 
-  Make sure all of your documentation links are correct, and that you're using the correct rustdoc formatting doc comments. 
-  Triple slashes `///` should be used above function and struct definitions, double slashes `//` for C-style ne comments (or block comments like `/* */`), and `//! ` for crate top-level documentation. 
-  Use Markdown formatting to describe function arguments, return values, and include usage examples, in a way istent with Rust's official libraries. 
+  Make sure all of your documentation links are correct, and that you're using the correct rustdoc formatting for doc comments. 
+  Triple slashes `///` should be used above function and struct definitions, double slashes `//` for C-style inline comments (or block comments like `/* */`), and `//! ` for crate top-level documentation. 
+  Use Markdown formatting to describe function arguments, return values, and include usage examples, in a way consistent with Rust's official libraries. 
 
-* **`Option`s and `Result`s.** Use Options and Results properly. Don't use special values that have overloaded ings, e.g., an integer in which `0` means no value, or something like that.
-  [Here's a good resource](<https://blog.burntsushi.net/rust-error-handling/>) for better understanding error ling in Rust.
+* **`Option`s and `Result`s.** Use Options and Results properly. Don't use special values that have overloaded meanings, e.g., an integer in which `0` means no value, or something like that.
+  [Here's a good resource](<https://blog.burntsushi.net/rust-error-handling/>) for better understanding error handling in Rust.
 
-  `Option`s should be returned when an operation might fail, but that failure condition doesn't affect the rest he system. 
-  For example, if you're searching for an element in a list, then an `Option` is the suitable choice because the er of your getter function would only call it in order to get and use the return value. 
+  `Option`s should be returned when an operation might fail, but that failure condition doesn't affect the rest of the system. 
+  For example, if you're searching for an element in a list, then an `Option` is the suitable choice because the caller of your getter function would only call it in order to get and use the return value. 
   
-  `Result`s should be returned if something can fail or succeed, and the caller needs to know whether it eeded, but potentially need the actual return value, e.g., an init function that returns void. 
-  In this case, `Result` is the best choice because we want to force the caller to acknowledge that the init tion succeeded, or handle its error if it failed. 
-  In Theseus, `Results` are mandatory when a function has some side effect, such as setting a parameter or value  might not exist or be initialized yet. 
+  `Result`s should be returned if something can fail or succeed, and the caller needs to know whether it succeeded, but potentially need the actual return value, e.g., an init function that returns void. 
+  In this case, `Result` is the best choice because we want to force the caller to acknowledge that the init function succeeded, or handle its error if it failed. 
+  In Theseus, `Results` are mandatory when a function has some side effect, such as setting a parameter or value that might not exist or be initialized yet. 
   In that case, a result must be used to indicate whether the function succeeded. 
 
 
 # Theseus-specific Guidelines
 
-* **Handle `Result`s properly and fully.** Don't ignore a result error, instead, log that error and then handle f possible. 
+* **Handle `Result`s properly and fully.** Don't ignore a result error, instead, log that error and then handle it if possible. 
   If you cannot handle it, return that error to the caller so they can attempt to handle it. **NEVER SILENCE OR RE ERRORS**.
   
-  **Never use panics.**  Avoid code or functions that can panic, such as bracket indexing operations `[]`, or cking functions like `unwrap()` or `expect()`. 
-  Instead, handle these error cases explicitly and return a `Result` to the caller, which is much cleaner than cking. 
-  Panicking is dangerous and cannot be easily recovered from. As your code most likely will run in a privileged , panicking will be unrecoverable.
+  **Never use panics.**  Avoid code or functions that can panic, such as bracket indexing operations `[]`, or panicking functions like `unwrap()` or `expect()`. 
+  Instead, handle these error cases explicitly and return a `Result` to the caller, which is much cleaner than panicking. 
+  Panicking is dangerous and cannot be easily recovered from. As your code most likely will run in a privileged mode, panicking will be unrecoverable.
 
-* **Never use unsafe code.** If you absolutely cannot avoid it, then you should review your case on an vidual basis with the maintainer. 
+* **Never use unsafe code.** If you absolutely cannot avoid it, then you should review your case on an individual basis with the maintainer. 
   In 99.99% of cases, unsafe code is not necessary and can be rewritten safely. 
 
 
 
 # Adding New Functionality to Theseus
 
-The easiest way to add new functionality is just to create a new crate by duplicating an existing crate and ging the details in its new `Cargo.toml` file.
-At the very least, you'll need to change the `name` entry under the `[package]` heading at the top of the go.toml` file, and you'll need to change the dependencies for your new crate.     
-If your new crate needs to be initialized, you can invoke it from the [`captain::init()`](../captain/nit.html) function, 
-although there may be more appropriate places to do so, such as the [`device_manager::init()`](../device_manager/nit.html) function for drivers.
+The easiest way to add new functionality is just to create a new crate by duplicating an existing crate and changing the details in its new `Cargo.toml` file.
+At the very least, you'll need to change the `name` entry under the `[package]` heading at the top of the `Cargo.toml` file, and you'll need to change the dependencies for your new crate.     
+If your new crate needs to be initialized, you can invoke it from the [`captain::init()`](../captain/fn.init.html) function, 
+although there may be more appropriate places to do so, such as the [`device_manager::init()`](../device_manager/fn.init.html) function for drivers.
 

--- a/book/src/chapter_2.md
+++ b/book/src/chapter_2.md
@@ -6,14 +6,14 @@
 Currently, we support building and running Theseus on the following host OSes:
  * Linux, 64-bit Debian-based distributions like Ubuntu, tested on Ubuntu 16.04 and 18.04.
  * Windows, using the Windows Subsystem for Linux (WSL), tested on the Ubuntu version.
- * MacOS, tested on version High Sierra (10.13), but likely works on others. 
+ * MacOS, tested on version High Sierra (10.13), but likely works on others.
 
 
 ### Setting up the build environment
 
 If on Linux or WSL, do the following:
-  * Update your system's package list: `sudo apt-get update`.     
-  * Install the following packages: `sudo apt-get install nasm pkg-config grub-pc-bin mtools xorriso qemu`     
+  * Update your system's package list: `sudo apt-get update`.
+  * Install the following packages: `sudo apt-get install nasm pkg-config grub-pc-bin mtools xorriso qemu`
 
 Additionally, If you're on WSL, you'll need to do the following:
   * Install an X Server for Windows; we suggest using [Xming](https://sourceforge.net/projects/xming/).
@@ -28,83 +28,83 @@ If you're on Mac OS, do the following:
 
 
 ### Installing Rust
-Install the current Rust compiler and toolchain by following the [setup instructions here](https://www.rust-lang.org/en-US/install.html), which is basically just this command:   
+Install the current Rust compiler and toolchain by following the [setup instructions here](https://www.rust-lang.org/en-US/install.html), which is basically just this command:
 `curl https://sh.rustup.rs -sSf | sh`
 
-We also need to install Xargo, a drop-in replacement wrapper for Cargo that makes cross-compiling easier:    
+We also need to install Xargo, a drop-in replacement wrapper for Cargo that makes cross-compiling easier:
 `cargo install --vers 0.3.13 xargo`
 
 
 
 ### Building and Running
-When you first check out the project, don't forget to checkout all the submodule repositories too:    
+When you first check out the project, don't forget to checkout all the submodule repositories too:
 `git submodule update --init --recursive`
 
-To build and run Theseus in QEMU, simply run:   
+To build and run Theseus in QEMU, simply run:
 `make run`
 
-Run `make help` to see other make targets. 
+Run `make help` to see other make targets.
 
 
 #### Note: Rust compiler versions
 Because we use the Rust nightly compiler (not stable), the Theseus Makefile checks to make sure that you're using the same version of Rust that we are. We were inspired to add this safety check when we failed to build other Rust projects put out there on Github because they used an earlier version of the nightly Rust compiler than what we had installed on our systems. To avoid this undiagnosable problem, we force you to use a specific version of `rustc` that is known to properly build Theseus. This version is upgraded as often as possible to align with the latest Rust nightly, but this is a best-effort policy.
 
-So, if you see a build error about the improper version of `rustc`, follow the instructions printed out at the end of the error message.     
+So, if you see a build error about the improper version of `rustc`, follow the instructions printed out at the end of the error message.
 
 
-## Using QEMU 
-QEMU allows us to run Theseus quickly and easily in its own virtual machine, completely segregated from the host machine and OS. 
-To exit Theseus in QEMU, press `Ctrl+Alt`, which releases your keyboard focus from the QEMU window. Then press `Ctrl+C` in the terminal window that you ran `make run` from originally to kill QEMU. 
+## Using QEMU
+QEMU allows us to run Theseus quickly and easily in its own virtual machine, completely segregated from the host machine and OS.
+To exit Theseus in QEMU, press `Ctrl+Alt`, which releases your keyboard focus from the QEMU window. Then press `Ctrl+C` in the terminal window that you ran `make run` from originally to kill QEMU.
 
-To investigate the state of the running QEMU entity, you can switch to the QEMU console by pressing `Ctrl+Alt+2`. Switch back to the main window with `Ctrl+Alt+1`.    
+To investigate the state of the running QEMU entity, you can switch to the QEMU console by pressing `Ctrl+Alt+2`. Switch back to the main window with `Ctrl+Alt+1`.
 
 
 ### KVM Support
 While not strictly required, KVM will speed up the execution of QEMU.
-To install KVM, run the following command:    
-`sudo apt-get install kvm`.     
+To install KVM, run the following command:
+`sudo apt-get install kvm`.
 To enable KVM support, add `kvm=yes` to your make command, e.g., `make run kvm=yes`.
 
 
 ## Loading Theseus Through PXE
 The following instructions are a combination of [this](https://www.ostechnix.com/how-to-install-pxe-server-on-ubuntu-16-04/) guide on OSTechNix to set up PXE for Ubuntu and [this](https://wellsie.net/p/286/) guide by Andrew Wells for using an arbitrary ISO with PXE.
 
-PXE can be used to load Rust onto a target computer that is connected by LAN to the host machine used for development. To set up the host machine for PXE, first make the Theseus ISO by navigating to the directory Theseus is in and running:   
+PXE can be used to load Rust onto a target computer that is connected by LAN to the host machine used for development. To set up the host machine for PXE, first make the Theseus ISO by navigating to the directory Theseus is in and running:
 `make iso`
 
 Then, you will need to set up a TFTP and DHCP server which the test machine will access.
 ### Setting up the TFTP Server
-First, install all necessary packages and dependencies for TFTP:   
-`sudo apt-get install apache2 tftpd-hpa inetutils-inetd nasm`   
-Edit the tftp-hpa configuration file:   
-`sudo nano /etc/default/tftpd-hpa`   
-Add the following lines: 
+First, install all necessary packages and dependencies for TFTP:
+`sudo apt-get install apache2 tftpd-hpa inetutils-inetd nasm`
+Edit the tftp-hpa configuration file:
+`sudo nano /etc/default/tftpd-hpa`
+Add the following lines:
 ```
 RUN_DAEMON="yes"
 OPTIONS="-l -s /var/lib/tftpboot"
 ```
-Then, edit the inetd configuration file by opening the editor:   
-`sudo nano /etc/inetd.conf`   
-And adding:   
+Then, edit the inetd configuration file by opening the editor:
+`sudo nano /etc/inetd.conf`
+And adding:
 `tftp    dgram   udp    wait    root    /usr/sbin/in.tftpd /usr/sbin/in.tftpd -s /var/lib/tftpboot`
 
-Restart the TFTP server and check to see if it's running:   
-`sudo systemctl restart tftpd-hpa`  
+Restart the TFTP server and check to see if it's running:
+`sudo systemctl restart tftpd-hpa`
 `sudo systemctl status tftpd-hpa`
 
-If the TFTP server is unable to start and mentions an in-use socket, reopen the tftp-hpa configuration file,set the line that has `TFTP_ADDRESS=":69"` to be equal to `6969` instead and restart the TFTP server. 
+If the TFTP server is unable to start and mentions an in-use socket, reopen the tftp-hpa configuration file,set the line that has `TFTP_ADDRESS=":69"` to be equal to `6969` instead and restart the TFTP server.
 
 ### Setting up the DHCP Server
-First, install package for DHCP server:   
+First, install package for DHCP server:
 `sudo apt-get install isc-dhcp-server`
 
 Then run `ifconfig` to view available networking devices and find the network device name, e.g., `eth0`.
 
 Edit the `/etc/default/isc-dhcp-server` configuration file and add the network device name from the step above to "INTERFACES". For me, this looks like `INTERFACES="eth0"`.
 
-Configure an arbitrary IP address that will be used in the next step:   
-`sudo ifconfig <network-device-name> 192.168.1.105` 
-This command might have to be done each time the computer being used as a server is restarted. 
+Configure an arbitrary IP address that will be used in the next step:
+`sudo ifconfig <network-device-name> 192.168.1.105`
+This command might have to be done each time the computer being used as a server is restarted.
 
 Edit the `/etc/dhcp/dhcpd.conf` file by uncommenting the line `authoritative;` and adding a subnet configuration such as the one below:
 ```
@@ -124,27 +124,27 @@ next-server 192.168.1.105;
 filename "pxelinux.0";
 ```
 
-Restart the DHCP server and check to see if it's running:   
-`sudo systemctl restart isc-dhcp-server`   
+Restart the DHCP server and check to see if it's running:
+`sudo systemctl restart isc-dhcp-server`
 `sudo systemctl status isc-dhcp-server`
 
 ### Loading the Theseus ISO Into the TFTP Server
-In order for the TFTP server to load Theseus, we need the Theseus ISO and a memdisk file in the boot folder. To get the memdisk file first download syslinux which contains it.   
-`wget https://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-5.10.tar.gz`   
+In order for the TFTP server to load Theseus, we need the Theseus ISO and a memdisk file in the boot folder. To get the memdisk file first download syslinux which contains it.
+`wget https://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-5.10.tar.gz`
 `tar -xzvf syslinux-*.tar.gz`
 
-Then navigate to the memdisk folder and compile.   
-`cd syslinux-*/memdisk`   
-`make memdisk`   
+Then navigate to the memdisk folder and compile.
+`cd syslinux-*/memdisk`
+`make memdisk`
 
-Next, make a TFTP boot folder for Theseus and copy the memdisk binary into it along with the Theseus ISO:   
-`sudo mkdir /var/lib/tftpboot/theseus`   
-`sudo cp /root/syslinux-*/memdisk/memdisk /var/lib/tftpboot/theseus/`   
+Next, make a TFTP boot folder for Theseus and copy the memdisk binary into it along with the Theseus ISO:
+`sudo mkdir /var/lib/tftpboot/theseus`
+`sudo cp /root/syslinux-*/memdisk/memdisk /var/lib/tftpboot/theseus/`
 `sudo cp /Theseus/build/theseus-x86_64.iso /var/lib/tftpboot/theseus/`
 
-Navigate to the PXE configuration file:   
-`sudo nano /var/lib/tftpboot/pxelinux.cfg/default`   
-And add Theseus as a menu option by adding the following:   
+Navigate to the PXE configuration file:
+`sudo nano /var/lib/tftpboot/pxelinux.cfg/default`
+And add Theseus as a menu option by adding the following:
 ```
 label theseus
     menu label Theseus
@@ -152,42 +152,42 @@ label theseus
     kernel theseus/memdisk
     append iso initrd=theseus/theseus-x86_64.iso raw
 ```
-Finally, restart the DHCP server one more time and make sure it's running:   
-`sudo systemctl restart isc-dhcp-server`   
+Finally, restart the DHCP server one more time and make sure it's running:
+`sudo systemctl restart isc-dhcp-server`
 `sudo systemctl status isc-dhcp-server`
 
-On the target computer, boot into the BIOS, turn on Legacy boot mode, and select network booting as the top boot option. Once the target computer is restarted, it should boot into a menu which displays booting into Theseus as an option. 
+On the target computer, boot into the BIOS, turn on Legacy boot mode, and select network booting as the top boot option. Once the target computer is restarted, it should boot into a menu which displays booting into Theseus as an option.
 
 ### Subsequent PXE Uses
-After setting up PXE the first time, you can run `make pxe` to make an updated ISO, remove the old one, and copy the new one over into the TFTP boot folder. At that point, you should be able to boot that new version of Theseus by restarting the target computer. If there are issues restarting the DHCP server after it worked the first time, one possible solution may be to confirm that the IP address is the one you intended it to be with the command from earlier: 
-`sudo ifconfig <network-device-name> 192.168.1.105` 
+After setting up PXE the first time, you can run `make pxe` to make an updated ISO, remove the old one, and copy the new one over into the TFTP boot folder. At that point, you should be able to boot that new version of Theseus by restarting the target computer. If there are issues restarting the DHCP server after it worked the first time, one possible solution may be to confirm that the IP address is the one you intended it to be with the command from earlier:
+`sudo ifconfig <network-device-name> 192.168.1.105`
 
-## Debugging 
-GDB has built-in support for QEMU, but it doesn't play nicely with OSes that run in long mode. In order to get it working properly with our OS in Rust, we need to patch it and build it locally. The hard part has already been done for us ([details here](http://os.phil-opp.com/set-up-gdb.html)), so we can just quickly set it up with the following commands.  
+## Debugging
+GDB has built-in support for QEMU, but it doesn't play nicely with OSes that run in long mode. In order to get it working properly with our OS in Rust, we need to patch it and build it locally. The hard part has already been done for us ([details here](http://os.phil-opp.com/set-up-gdb.html)), so we can just quickly set it up with the following commands.
 
-First, install the following packages:  
+First, install the following packages:
 `sudo apt-get install texinfo flex bison python-dev ncurses-dev`
 
-Then, from the base directory of the Theseus project, run this command to easily download and build it from an existing patched repo:  
-`curl -sf https://raw.githubusercontent.com/phil-opp/binutils-gdb/rust-os/build-rust-os-gdb.sh | sh`  
+Then, from the base directory of the Theseus project, run this command to easily download and build it from an existing patched repo:
+`curl -sf https://raw.githubusercontent.com/phil-opp/binutils-gdb/rust-os/build-rust-os-gdb.sh | sh`
 
-After that, you should have a `rust-os-gdb` directory that contains the `gdb` executables and scripts. 
+After that, you should have a `rust-os-gdb` directory that contains the `gdb` executables and scripts.
 
-Then, simply run `make debug` to build and run Theseus in QEMU, which will pause the OS's execution until we attach our patched GDB instance.   
-To attach the debugger to our paused QEMU instance, run `make gdb` in another terminal. QEMU will be paused until we move the debugger forward, with `n` to step through or `c` to continue running the debugger.  
+Then, simply run `make debug` to build and run Theseus in QEMU, which will pause the OS's execution until we attach our patched GDB instance.
+To attach the debugger to our paused QEMU instance, run `make gdb` in another terminal. QEMU will be paused until we move the debugger forward, with `n` to step through or `c` to continue running the debugger.
 Try setting a breakpoint at the kernel's entry function using `b nano_core::nano_core_start` or at a specific file/line, e.g., `b scheduler.rs:40`.
 
 
 ## Documentation
-Once your build environment is fully set up, you can generate Theseus's documentation in standard Rust docs.rs format. 
-To do so, simply run:     
+Once your build environment is fully set up, you can generate Theseus's documentation in standard Rust docs.rs format.
+To do so, simply run:
 `make doc`
 
-To view the documentation in a browser on your local machine, run:     
+To view the documentation in a browser on your local machine, run:
 `make view-doc`
 
 
-## IDE Setup  
+## IDE Setup
 Our personal preference is to use Visual Studio Code (VS Code), which has excellent, official support from the Rust language team. Other options are available [here](https://areweideyet.com/), but we don't recommend them.
 
 For VS Code, recommended plugins are:
@@ -197,4 +197,4 @@ For VS Code, recommended plugins are:
 
 
 ## License
-The source code is licensed under the MIT License. See the LICENSE-MIT file for more. 
+The source code is licensed under the MIT License. See the LICENSE-MIT file for more.

--- a/book/src/git.md
+++ b/book/src/git.md
@@ -1,30 +1,30 @@
 
 # Advice for Contributing and using git
 
-* The main Theseus repository, [`theseus-os/Theseus`](https://github.com/theseus-os/Theseus) is what we call the *upstream*. 
-  To contribute, you should create your own fork of that repository, and then check out your own fork. 
+* The main Theseus repository, [`theseus-os/Theseus`](https://github.com/theseus-os/Theseus) is what we call the *upstream*.
+  To contribute, you should create your own fork of that repository, and then check out your own fork.
   That way, your fork will be the `origin` remote by default, and then you can add the upstream as another remote by running:
-  `git remote add upstream https://github.com/theseus-os/Theseus`. 
+  `git remote add upstream https://github.com/theseus-os/Theseus`.
 
-* **Never push to the main branch.** Currently, the main branch on the upstream `theseus-os/Theseus/theseus_main` is protected from a direct push. 
+* **Never push to the main branch.** Currently, the main branch on the upstream `theseus-os/Theseus/theseus_main` is protected from a direct push.
   The only way to contribute to it is by merging a pull request into the main branch, which only authorized users can do.
-  Instead, checkout your own fork as above, create a new branch with a descriptive name, e.g., `kevin/logging_typo`, 
+  Instead, checkout your own fork as above, create a new branch with a descriptive name, e.g., `kevin/logging_typo`,
   develop your feature on that branch, and then submit a pull request.
   This is a standard Git workflow that allows people can review your code, check for pitfalls and compatibility problems,
-  and make comments and suggestions before the code makes its way into the main branch. 
+  and make comments and suggestions before the code makes its way into the main branch.
   *You must do this for all changes, even tiny ones that may seem insignificant.*
 
-* To submit a pull request (PR), the easiest way is to go to the GitHub page of your forked Theseus repo, 
-  select the branch that you created from the drop down menu, and then click "New pull request". 
+* To submit a pull request (PR), the easiest way is to go to the GitHub page of your forked Theseus repo,
+  select the branch that you created from the drop down menu, and then click "New pull request".
   By default, GitHub will create a new PR that wants to merge your branch into the upstream `theseus_main` branch,
-  which is usually what you want to do. 
+  which is usually what you want to do.
   Now, give your PR a good title and description, scroll down to review the commits and files changed,
   and if everything looks good, click "Create pull request" to notify the maintainers that you have contributions that they should review.
-   
-* **Review yourself.** Perform an initial review of your own code before submitting a pull request. 
-  Don't place the whole burden of fixing a bunch of tiny problems on others that must review your code too. 
-  This includes building the documentation and reviewing it in HTML form in a browser 
-  to make sure everything is formatted correctly and that hyperlinks work correctly. 
+
+* **Review yourself.** Perform an initial review of your own code before submitting a pull request.
+  Don't place the whole burden of fixing a bunch of tiny problems on others that must review your code too.
+  This includes building the documentation and reviewing it in HTML form in a browser
+  to make sure everything is formatted correctly and that hyperlinks work correctly.
 
 * **Commit carefully.** When making a commit, review your changes with `git status` and `git diff`
   to ensure that you're not committing accidental modifications, or editing files that you shouldn't be.

--- a/book/src/git.md
+++ b/book/src/git.md
@@ -1,25 +1,25 @@
 
 # Advice for Contributing and using git
 
-* The main Theseus repository, [`theseus-os/Theseus`](https://github.com/theseus-os/Theseus) is what we call the tream*. 
+* The main Theseus repository, [`theseus-os/Theseus`](https://github.com/theseus-os/Theseus) is what we call the *upstream*. 
   To contribute, you should create your own fork of that repository, and then check out your own fork. 
-  That way, your fork will be the `origin` remote by default, and then you can add the upstream as another te by running:
+  That way, your fork will be the `origin` remote by default, and then you can add the upstream as another remote by running:
   `git remote add upstream https://github.com/theseus-os/Theseus`. 
 
-* **Never push to the main branch.** Currently, the main branch on the upstream `theseus-os/Theseus/eus_main` is protected from a direct push. 
-  The only way to contribute to it is by merging a pull request into the main branch, which only authorized s can do.
+* **Never push to the main branch.** Currently, the main branch on the upstream `theseus-os/Theseus/theseus_main` is protected from a direct push. 
+  The only way to contribute to it is by merging a pull request into the main branch, which only authorized users can do.
   Instead, checkout your own fork as above, create a new branch with a descriptive name, e.g., `kevin/logging_typo`, 
   develop your feature on that branch, and then submit a pull request.
-  This is a standard Git workflow that allows people can review your code, check for pitfalls and compatibility lems,
+  This is a standard Git workflow that allows people can review your code, check for pitfalls and compatibility problems,
   and make comments and suggestions before the code makes its way into the main branch. 
   *You must do this for all changes, even tiny ones that may seem insignificant.*
 
 * To submit a pull request (PR), the easiest way is to go to the GitHub page of your forked Theseus repo, 
   select the branch that you created from the drop down menu, and then click "New pull request". 
-  By default, GitHub will create a new PR that wants to merge your branch into the upstream `theseus_main` ch,
+  By default, GitHub will create a new PR that wants to merge your branch into the upstream `theseus_main` branch,
   which is usually what you want to do. 
   Now, give your PR a good title and description, scroll down to review the commits and files changed,
-  and if everything looks good, click "Create pull request" to notify the maintainers that you have ributions that they should review.
+  and if everything looks good, click "Create pull request" to notify the maintainers that you have contributions that they should review.
    
 * **Review yourself.** Perform an initial review of your own code before submitting a pull request. 
   Don't place the whole burden of fixing a bunch of tiny problems on others that must review your code too. 

--- a/book/src/idea.md
+++ b/book/src/idea.md
@@ -16,7 +16,7 @@ Why? Meltdown, Spectre... need I say more?
 ## Performance
 
 * Better support for architectural extensions such as SIMD instructions. (Why Linux is not adequate)
-* Singualrity argument: no boundary crossing (single privilege level, single address space). 
+* Singularity argument: no boundary crossing (single privilege level, single address space). 
 
 // TODO mention TSA precheck analogy? 
 

--- a/book/src/idea.md
+++ b/book/src/idea.md
@@ -1,24 +1,24 @@
 ## Performance in Hardware, Isolation in Software.
 
-The PHIS principle is one of the guiding lights in the design of Theseus. 
+The PHIS principle is one of the guiding lights in the design of Theseus.
 It states that hardware should only be responsible for improving performance and efficiency,
-but should have no role (or a minimal role) in providing isolation, safety, and security. 
-Those characteristics should be the responsibility of software, not hardware. 
+but should have no role (or a minimal role) in providing isolation, safety, and security.
+Those characteristics should be the responsibility of software, not hardware.
 
 One of Theseus's goals is to transcend the reliance on hardware to provide isolation,
-mainly by completely foregoing hardware privilege levels, such as x86's Ring 0 - Ring 3 distinctions. 
+mainly by completely foregoing hardware privilege levels, such as x86's Ring 0 - Ring 3 distinctions.
 Instead, we run all code at Ring 0, including user applications that are written in purely safe Rust,
-because we can guarantee at compile time that a given application or kernel module 
-cannot violate the isolation between modules, rendering hardware privilege levels obsolete. 
+because we can guarantee at compile time that a given application or kernel module
+cannot violate the isolation between modules, rendering hardware privilege levels obsolete.
 
 Why? Meltdown, Spectre... need I say more?
 
 ## Performance
 
 * Better support for architectural extensions such as SIMD instructions. (Why Linux is not adequate)
-* Singularity argument: no boundary crossing (single privilege level, single address space). 
+* Singularity argument: no boundary crossing (single privilege level, single address space).
 
-// TODO mention TSA precheck analogy? 
+// TODO mention TSA precheck analogy?
 
 
 TODO: finish this up.

--- a/book/src/pxe.md
+++ b/book/src/pxe.md
@@ -1,42 +1,42 @@
 # Booting Theseus on Real Hardware via PXE
 The following instructions are a combination of [this](https://www.ostechnix.com/how-to-install-pxe-server-on-ubuntu-16-04/) guide on OSTechNix to set up PXE for Ubuntu and [this](https://wellsie.net/p/286/) guide by Andrew Wells for using an arbitrary ISO with PXE.
 
-PXE can be used to load Rust onto a target computer that is connected by LAN to the host machine used for development. To set up the host machine for PXE, first make the Theseus ISO by navigating to the directory Theseus is in and running:   
+PXE can be used to load Rust onto a target computer that is connected by LAN to the host machine used for development. To set up the host machine for PXE, first make the Theseus ISO by navigating to the directory Theseus is in and running:
 `make iso`
 
 Then, you will need to set up a TFTP and DHCP server which the test machine will access.
 ### Setting up the TFTP Server
-First, install all necessary packages and dependencies for TFTP:   
-`sudo apt-get install apache2 tftpd-hpa inetutils-inetd nasm`   
-Edit the tftp-hpa configuration file:   
-`sudo nano /etc/default/tftpd-hpa`   
-Add the following lines: 
+First, install all necessary packages and dependencies for TFTP:
+`sudo apt-get install apache2 tftpd-hpa inetutils-inetd nasm`
+Edit the tftp-hpa configuration file:
+`sudo nano /etc/default/tftpd-hpa`
+Add the following lines:
 ```
 RUN_DAEMON="yes"
 OPTIONS="-l -s /var/lib/tftpboot"
 ```
-Then, edit the inetd configuration file by opening the editor:   
-`sudo nano /etc/inetd.conf`   
-And adding:   
+Then, edit the inetd configuration file by opening the editor:
+`sudo nano /etc/inetd.conf`
+And adding:
 `tftp    dgram   udp    wait    root    /usr/sbin/in.tftpd /usr/sbin/in.tftpd -s /var/lib/tftpboot`
 
-Restart the TFTP server and check to see if it's running:   
-`sudo systemctl restart tftpd-hpa`  
+Restart the TFTP server and check to see if it's running:
+`sudo systemctl restart tftpd-hpa`
 `sudo systemctl status tftpd-hpa`
 
-If the TFTP server is unable to start and mentions an in-use socket, reopen the tftp-hpa configuration file,set the line that has `TFTP_ADDRESS=":69"` to be equal to `6969` instead and restart the TFTP server. 
+If the TFTP server is unable to start and mentions an in-use socket, reopen the tftp-hpa configuration file,set the line that has `TFTP_ADDRESS=":69"` to be equal to `6969` instead and restart the TFTP server.
 
 ### Setting up the DHCP Server
-First, install package for DHCP server:   
+First, install package for DHCP server:
 `sudo apt-get install isc-dhcp-server`
 
 Then run `ifconfig` to view available networking devices and find the network device name, e.g., `eth0`.
 
 Edit the `/etc/default/isc-dhcp-server` configuration file and add the network device name from the step above to "INTERFACES". For me, this looks like `INTERFACES="eth0"`.
 
-Configure an arbitrary IP address that will be used in the next step:   
-`sudo ifconfig <network-device-name> 192.168.1.105` 
-This command might have to be done each time the computer being used as a server is restarted. 
+Configure an arbitrary IP address that will be used in the next step:
+`sudo ifconfig <network-device-name> 192.168.1.105`
+This command might have to be done each time the computer being used as a server is restarted.
 
 Edit the `/etc/dhcp/dhcpd.conf` file by uncommenting the line `authoritative;` and adding a subnet configuration such as the one below:
 ```
@@ -56,27 +56,27 @@ next-server 192.168.1.105;
 filename "pxelinux.0";
 ```
 
-Restart the DHCP server and check to see if it's running:   
-`sudo systemctl restart isc-dhcp-server`   
+Restart the DHCP server and check to see if it's running:
+`sudo systemctl restart isc-dhcp-server`
 `sudo systemctl status isc-dhcp-server`
 
 ### Loading the Theseus ISO Into the TFTP Server
-In order for the TFTP server to load Theseus, we need the Theseus ISO and a memdisk file in the boot folder. To get the memdisk file first download syslinux which contains it.   
-`wget https://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-5.10.tar.gz`   
+In order for the TFTP server to load Theseus, we need the Theseus ISO and a memdisk file in the boot folder. To get the memdisk file first download syslinux which contains it.
+`wget https://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-5.10.tar.gz`
 `tar -xzvf syslinux-*.tar.gz`
 
-Then navigate to the memdisk folder and compile.   
-`cd syslinux-*/memdisk`   
-`make memdisk`   
+Then navigate to the memdisk folder and compile.
+`cd syslinux-*/memdisk`
+`make memdisk`
 
-Next, make a TFTP boot folder for Theseus and copy the memdisk binary into it along with the Theseus ISO:   
-`sudo mkdir /var/lib/tftpboot/theseus`   
-`sudo cp /root/syslinux-*/memdisk/memdisk /var/lib/tftpboot/theseus/`   
+Next, make a TFTP boot folder for Theseus and copy the memdisk binary into it along with the Theseus ISO:
+`sudo mkdir /var/lib/tftpboot/theseus`
+`sudo cp /root/syslinux-*/memdisk/memdisk /var/lib/tftpboot/theseus/`
 `sudo cp /Theseus/build/theseus-x86_64.iso /var/lib/tftpboot/theseus/`
 
-Navigate to the PXE configuration file:   
-`sudo nano /var/lib/tftpboot/pxelinux.cfg/default`   
-And add Theseus as a menu option by adding the following:   
+Navigate to the PXE configuration file:
+`sudo nano /var/lib/tftpboot/pxelinux.cfg/default`
+And add Theseus as a menu option by adding the following:
 ```
 label theseus
     menu label Theseus
@@ -84,13 +84,13 @@ label theseus
     kernel theseus/memdisk
     append iso initrd=theseus/theseus-x86_64.iso raw
 ```
-Finally, restart the DHCP server one more time and make sure it's running:   
-`sudo systemctl restart isc-dhcp-server`   
+Finally, restart the DHCP server one more time and make sure it's running:
+`sudo systemctl restart isc-dhcp-server`
 `sudo systemctl status isc-dhcp-server`
 
-On the target computer, boot into the BIOS, turn on Legacy boot mode, and select network booting as the top boot option. Once the target computer is restarted, it should boot into a menu which displays booting into Theseus as an option. 
+On the target computer, boot into the BIOS, turn on Legacy boot mode, and select network booting as the top boot option. Once the target computer is restarted, it should boot into a menu which displays booting into Theseus as an option.
 
 ### Subsequent PXE Uses
-After setting up PXE the first time, you can run `make pxe` to make an updated ISO, remove the old one, and copy the new one over into the TFTP boot folder. At that point, you should be able to boot that new version of Theseus by restarting the target computer. If there are issues restarting the DHCP server after it worked the first time, one possible solution may be to confirm that the IP address is the one you intended it to be with the command from earlier: 
-`sudo ifconfig <network-device-name> 192.168.1.105` 
+After setting up PXE the first time, you can run `make pxe` to make an updated ISO, remove the old one, and copy the new one over into the TFTP boot folder. At that point, you should be able to boot that new version of Theseus by restarting the target computer. If there are issues restarting the DHCP server after it worked the first time, one possible solution may be to confirm that the IP address is the one you intended it to be with the command from earlier:
+`sudo ifconfig <network-device-name> 192.168.1.105`
 

--- a/book/src/window_manager.md
+++ b/book/src/window_manager.md
@@ -4,13 +4,13 @@
 
 In most of the cases, both an application and the window manager want to get access to the same window. The application needs to display in the window, and the window manager requires the information and order of windows to render them to the screen. In order to share a window between an application and the window manager, we wrap a window object with `Mutex`. The application owns a strong reference to the window, while the window manager holds a weak reference since its lifetime is longer than the window.
 
-However, `Mutex` introduces a danger of deadlocks. When an application wants to get access to its window, it must lock it first, operate on it and then release it. If an application does not release the locked window, the window manager will be blocked in most of the operations such as switching or deleting since it needs to traverse all the windows including the locked one. 
+However, `Mutex` introduces a danger of deadlocks. When an application wants to get access to its window, it must lock it first, operate on it and then release it. If an application does not release the locked window, the window manager will be blocked in most of the operations such as switching or deleting since it needs to traverse all the windows including the locked one.
 
-To solve this problem, we define two objects `Window` and `WindowInner`. `WindowInner` only contains the information required by the window manager. A window manager holds a list of reference to `WindowInner`s. An application owns a `Window` object which wraps a reference to its `WindowInner` object together with other states required by the application. 
+To solve this problem, we define two objects `Window` and `WindowInner`. `WindowInner` only contains the information required by the window manager. A window manager holds a list of reference to `WindowInner`s. An application owns a `Window` object which wraps a reference to its `WindowInner` object together with other states required by the application.
 
 ## The WindowInner structure
 
-The `window_inner` crate defines a `WindowInner` structure. It has states and methods of displaying the window on the screen. 
+The `window_inner` crate defines a `WindowInner` structure. It has states and methods of displaying the window on the screen.
 
 A `WindowInner` has a framebuffer to which it can display the content of the window. The framebuffer takes a type parameter of pixels it consists of. When the window is rendered to the screen, a compositor may composite every pixel with different principles according to the type. Currently, we have implemented a normal RGB pixel and a pixel of an alpha channel.
 
@@ -33,7 +33,7 @@ An application can own multiple displayables and display any type of `Displayabl
 
 ## The WindowManager
 
-The `window_manager` crate defines a `WindowManager` structure. This structure consists of the profiles of an active window, a list of shown windows and a list of hidden windows. The hidden ones are totally overlapped by others. The structure implements basic methods to manipulate the list such as adding or deleting a window. 
+The `window_manager` crate defines a `WindowManager` structure. This structure consists of the profiles of an active window, a list of shown windows and a list of hidden windows. The hidden ones are totally overlapped by others. The structure implements basic methods to manipulate the list such as adding or deleting a window.
 
 The `WindowManager` structure contains a bottom framebuffer which represents the background image and a final framebuffer of a floating window border and a mouse arrow. In refreshing an area, it renders the framebuffers in order background -> hidden list -> shown list -> active -> top. It provides several methods to update a rectangle area or several pixels for better performance.
 

--- a/book/src/window_tutorial.md
+++ b/book/src/window_tutorial.md
@@ -6,7 +6,7 @@ An application invokes the `Window::new()` function in the `window` crate to cre
 
 ## Display in a Window
 
-An application can create a `Displayable` and invoke `Window.display()` to display it. This method is generic and works for all kinds of displayables. 
+An application can create a `Displayable` and invoke `Window.display()` to display it. This method is generic and works for all kinds of displayables.
 
 After display a displayable in its framebuffer, the window would invoke its `render()` method to render the updates to the screen. A framebuffer compositor will composite a list of framebuffers and forward the result to a final framebuffer which is mapped to the screen.
 


### PR DESCRIPTION
While reading the book I find that some words was missing or incorrect. 

After investigation I found the errors come from the e8cbd23 commit that convert the documentation embedded as crate
modules to mdbook markdown files. Four characters was removed on some wrapped lines.

Correct them and while at it remove the trailing whitespace.