### PR TITLE
Remove `rlibc` dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,6 @@ dependencies = [
  "mod_mgmt",
  "multiboot2",
  "panic_entry",
- "rlibc",
  "spin",
  "stack",
  "state_store",
@@ -2019,12 +2018,6 @@ dependencies = [
  "task",
  "wait_queue",
 ]
-
-[[package]]
-name = "rlibc"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 
 [[package]]
 name = "rm"

--- a/applications/.old_static_binary_hello/Cargo.toml
+++ b/applications/.old_static_binary_hello/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 
 [dependencies]
-rlibc = "1.0.0"
 
 
 [dependencies.log]

--- a/applications/.old_static_binary_hello/src/main.rs
+++ b/applications/.old_static_binary_hello/src/main.rs
@@ -4,7 +4,6 @@
 
 
 // extern crate alloc;
-extern crate rlibc;
 #[macro_use] extern crate log;
 extern crate print;
 

--- a/cfg/Config.mk
+++ b/cfg/Config.mk
@@ -21,6 +21,18 @@ CFG_DIR := $(ROOT_DIR)/cfg
 KERNEL_PREFIX ?= k\#
 APP_PREFIX    ?= a\#
 
+
+## Enable the following two unstable flags.
+CARGOFLAGS += -Z unstable-options
+
+## Instruct cargo that we want to build the `compiler_builtins` crate by ourselves,
+## so that we can enable the "mem" feature in our built version.
+CARGOFLAGS += -Z build-std
+
+## Enable "mem" feature so that memory utility functions (e.g. memcpy) are not
+## mangled. Rust implicitly relies on these functions.
+CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
+
 ## Build modes: debug is development mode, release is with full optimizations.
 ## We build using release mode by default, because running in debug mode is prohibitively slow.
 ## You can set these on the command line like so: "make run BUILD_MODE=release"

--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -9,7 +9,6 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.4.10"
 multiboot2 = "0.7.1"
-rlibc = "1.0.0"
 # x86_64 = { git = "https://github.com/kevinaboos/x86_64" }
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -19,7 +19,6 @@
 
 #[macro_use] extern crate log;
 extern crate alloc;
-extern crate rlibc; // basic memset/memcpy libc functions
 extern crate spin;
 extern crate multiboot2;
 extern crate x86_64;

--- a/libtheseus/Cargo.lock
+++ b/libtheseus/Cargo.lock
@@ -393,7 +393,6 @@ version = "0.1.0"
 dependencies = [
  "heap",
  "panic_entry",
- "rlibc",
  "serial_port",
 ]
 
@@ -709,12 +708,6 @@ dependencies = [
  "cc",
  "rustc_version",
 ]
-
-[[package]]
-name = "rlibc"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 
 [[package]]
 name = "root"

--- a/libtheseus/Cargo.toml
+++ b/libtheseus/Cargo.toml
@@ -7,7 +7,6 @@ build = "../build.rs"
 # links = "serial_port"
 
 [dependencies]
-rlibc = "1.0.0"
 # getopts = "0.2.21"
 
 [dependencies.serial_port]

--- a/libtheseus/src/lib.rs
+++ b/libtheseus/src/lib.rs
@@ -9,7 +9,6 @@
 extern crate panic_entry;
 extern crate heap;
 
-extern crate rlibc;
 #[macro_use] extern crate alloc;
 // #[macro_use] extern crate terminal_print;
 extern crate serial_port;


### PR DESCRIPTION
- Remove `rlibc` dependency from `nano_core` and `libtheseus`.
- Instruct `cargo` to build our own `compiler_builtin` crate with the `mem` feature turned on.