### PR TITLE
Fix task_fs offset calculation

### DIFF
--- a/kernel/task_fs/src/lib.rs
+++ b/kernel/task_fs/src/lib.rs
@@ -296,7 +296,7 @@ impl File for TaskFile {
             return Err("read offset exceeds file size");
         }
         let count = core::cmp::min(buf.len(), output.len() - offset);
-        buf[..count].copy_from_slice(&output.as_bytes()[offset..count]);
+        buf[..count].copy_from_slice(&output.as_bytes()[offset..(offset + count)]);
         Ok(count)
     }
 
@@ -444,7 +444,7 @@ impl File for MmiFile {
             return Err("read offset exceeds file size");
         }
         let count = core::cmp::min(buf.len(), output.len() - offset);
-        buf[..count].copy_from_slice(&output.as_bytes()[offset..count]);
+        buf[..count].copy_from_slice(&output.as_bytes()[offset..(offset + count)]);
         Ok(count)
     }
 


### PR DESCRIPTION
The correct slice range is now calculated, previously the end of the slice range did not account for the offset.