### PR TITLE
Upgrade Rust edition to 2018

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "pit_clock",
  "rsdp",
  "rsdt",
- "spin",
+ "spin 0.4.10",
  "volatile",
 ]
 
@@ -62,7 +62,7 @@ dependencies = [
  "memory",
  "scheduler",
  "spawn",
- "spin",
+ "spin 0.4.10",
  "stack",
  "tlb_shootdown",
 ]
@@ -82,7 +82,7 @@ dependencies = [
  "owning_ref",
  "pit_clock",
  "raw-cpuid",
- "spin",
+ "spin 0.4.10",
  "static_assertions",
  "volatile",
  "x86_64",
@@ -101,7 +101,7 @@ dependencies = [
  "log",
  "print",
  "serial_port",
- "spin",
+ "spin 0.4.10",
  "stdio",
  "task",
  "window_manager",
@@ -126,7 +126,7 @@ dependencies = [
  "hpet",
  "log",
  "mpmc",
- "spin",
+ "spin 0.4.10",
  "task",
  "wait_queue",
 ]
@@ -139,7 +139,7 @@ dependencies = [
  "log",
  "pci",
  "port_io",
- "spin",
+ "spin 0.4.10",
  "storage_device",
 ]
 
@@ -411,7 +411,7 @@ name = "cow_arc"
 version = "0.1.0"
 dependencies = [
  "owning_ref",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -435,7 +435,7 @@ dependencies = [
  "hashbrown",
  "log",
  "memory",
- "spin",
+ "spin 0.4.10",
  "xmas-elf",
 ]
 
@@ -462,7 +462,7 @@ dependencies = [
  "mod_mgmt",
  "path",
  "qp-trie",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -522,7 +522,7 @@ dependencies = [
  "log",
  "memory",
  "mod_mgmt",
- "spin",
+ "spin 0.4.10",
  "task",
  "terminal_print",
 ]
@@ -563,7 +563,7 @@ dependencies = [
 name = "dfqueue"
 version = "0.1.0"
 dependencies = [
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -582,7 +582,7 @@ dependencies = [
  "color",
  "framebuffer",
  "shapes",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ dependencies = [
  "owning_ref",
  "pci",
  "pic",
- "spin",
+ "spin 0.4.10",
  "static_assertions",
  "volatile",
  "x86_64",
@@ -761,7 +761,7 @@ dependencies = [
 name = "font"
 version = "0.1.0"
 dependencies = [
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -785,7 +785,7 @@ dependencies = [
  "hashbrown",
  "lazy_static",
  "shapes",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -812,7 +812,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memory",
- "spin",
+ "spin 0.4.10",
  "x86_64",
 ]
 
@@ -826,7 +826,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memory",
- "spin",
+ "spin 0.4.10",
  "tss",
  "x86_64",
 ]
@@ -889,7 +889,7 @@ dependencies = [
  "kernel_config",
  "log",
  "memory",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -900,7 +900,7 @@ dependencies = [
  "irq_safety",
  "log",
  "memory",
- "spin",
+ "spin 0.4.10",
  "x86_64",
 ]
 
@@ -922,7 +922,7 @@ dependencies = [
  "memory",
  "owning_ref",
  "sdt",
- "spin",
+ "spin 0.4.10",
  "volatile",
  "zerocopy",
 ]
@@ -995,7 +995,7 @@ dependencies = [
  "port_io",
  "ps2",
  "scheduler",
- "spin",
+ "spin 0.4.10",
  "task",
  "tlb_shootdown",
  "tss",
@@ -1021,7 +1021,7 @@ dependencies = [
  "log",
  "memory",
  "owning_ref",
- "spin",
+ "spin 0.4.10",
  "volatile",
  "zerocopy",
 ]
@@ -1032,7 +1032,7 @@ version = "0.1.1"
 source = "git+https://github.com/kevinaboos/irq_safety#b80ccd4f0c8428c968e9be2e39901c22f13f10ed"
 dependencies = [
  "owning_ref",
- "spin",
+ "spin 0.4.10",
  "stable_deref_trait 1.1.1 (git+https://github.com/kevinaboos/stable_deref_trait.git?branch=spin)",
 ]
 
@@ -1073,7 +1073,7 @@ dependencies = [
  "pit_clock",
  "rand",
  "runqueue",
- "spin",
+ "spin 0.4.10",
  "static_assertions",
  "virtual_nic",
  "volatile",
@@ -1100,7 +1100,7 @@ dependencies = [
  "log",
  "mpmc",
  "ps2",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -1138,7 +1138,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 dependencies = [
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -1153,7 +1153,7 @@ dependencies = [
  "libterm",
  "log",
  "path",
- "spin",
+ "spin 0.4.10",
  "stdio",
  "task",
 ]
@@ -1207,7 +1207,7 @@ dependencies = [
  "memory",
  "pmu_x86",
  "runqueue",
- "spin",
+ "spin 0.4.10",
  "task",
  "x86_64",
 ]
@@ -1233,7 +1233,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "serial_port",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -1301,7 +1301,7 @@ dependencies = [
  "irq_safety",
  "log",
  "memory",
- "spin",
+ "spin 0.4.10",
  "x86_64",
 ]
 
@@ -1329,7 +1329,7 @@ dependencies = [
  "memory_x86_64",
  "multiboot2",
  "page_allocator",
- "spin",
+ "spin 0.4.10",
  "x86_64",
  "xmas-elf",
  "zerocopy",
@@ -1423,7 +1423,7 @@ dependencies = [
  "qp-trie",
  "root",
  "rustc-demangle",
- "spin",
+ "spin 0.4.10",
  "util",
  "vfs_node",
  "xmas-elf",
@@ -1438,7 +1438,7 @@ dependencies = [
  "mouse_data",
  "mpmc",
  "ps2",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -1473,7 +1473,7 @@ dependencies = [
  "mod_mgmt",
  "pause",
  "pit_clock",
- "spin",
+ "spin 0.4.10",
  "stack",
  "volatile",
  "zerocopy",
@@ -1496,7 +1496,7 @@ dependencies = [
  "slabmalloc",
  "slabmalloc_safe",
  "slabmalloc_unsafe",
- "spin",
+ "spin 0.4.10",
  "static_assertions",
 ]
 
@@ -1506,7 +1506,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "owning_ref",
- "spin",
+ "spin 0.4.10",
  "stable_deref_trait 1.1.1 (git+https://github.com/kevinaboos/stable_deref_trait.git?branch=spin)",
  "task",
  "wait_queue",
@@ -1527,7 +1527,7 @@ dependencies = [
  "mod_mgmt",
  "multiboot2",
  "panic_entry",
- "spin",
+ "spin 0.4.10",
  "stack",
  "state_store",
  "vga_buffer",
@@ -1550,7 +1550,7 @@ dependencies = [
  "log",
  "owning_ref",
  "smoltcp",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -1650,7 +1650,7 @@ name = "owning_ref"
 version = "0.4.0"
 source = "git+https://github.com/kevinaboos/owning-ref-rs#03db99a3707a5d7c9e376800498c94c88a877d15"
 dependencies = [
- "spin",
+ "spin 0.4.10",
  "stable_deref_trait 1.1.1 (git+https://github.com/kevinaboos/stable_deref_trait.git?branch=spin)",
 ]
 
@@ -1672,7 +1672,7 @@ dependencies = [
  "kernel_config",
  "log",
  "memory_structs",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -1710,7 +1710,7 @@ dependencies = [
  "lazy_static",
  "log",
  "root",
- "spin",
+ "spin 0.4.10",
  "vfs_node",
  "x86_64",
 ]
@@ -1727,7 +1727,7 @@ dependencies = [
  "log",
  "memory",
  "port_io",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -1776,7 +1776,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "port_io",
- "spin",
+ "spin 0.4.10",
  "x86_64",
 ]
 
@@ -1820,7 +1820,7 @@ dependencies = [
  "pit_clock",
  "port_io",
  "raw-cpuid",
- "spin",
+ "spin 0.4.10",
  "task",
  "x86_64",
 ]
@@ -1836,7 +1836,7 @@ dependencies = [
  "dfqueue",
  "event_types",
  "log",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -1880,7 +1880,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "port_io",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -2015,7 +2015,7 @@ dependencies = [
  "irq_safety",
  "log",
  "scheduler",
- "spin",
+ "spin 0.4.10",
  "task",
  "wait_queue",
 ]
@@ -2040,7 +2040,7 @@ dependencies = [
  "fs_node",
  "lazy_static",
  "log",
- "spin",
+ "spin 0.4.10",
  "x86_64",
 ]
 
@@ -2086,7 +2086,7 @@ dependencies = [
  "lazy_static",
  "log",
  "port_io",
- "spin",
+ "spin 0.4.10",
  "state_store",
  "x86_64",
 ]
@@ -2154,7 +2154,7 @@ dependencies = [
  "runqueue",
  "scheduler_priority",
  "scheduler_round_robin",
- "spin",
+ "spin 0.4.10",
  "task",
 ]
 
@@ -2176,7 +2176,7 @@ dependencies = [
  "log",
  "runqueue",
  "runqueue_priority",
- "spin",
+ "spin 0.4.10",
  "task",
 ]
 
@@ -2187,7 +2187,7 @@ dependencies = [
  "log",
  "runqueue",
  "runqueue_round_robin",
- "spin",
+ "spin 0.4.10",
  "task",
 ]
 
@@ -2273,7 +2273,7 @@ dependencies = [
  "runqueue",
  "scheduler",
  "spawn",
- "spin",
+ "spin 0.4.10",
  "stdio",
  "task",
  "terminal_print",
@@ -2364,7 +2364,7 @@ dependencies = [
  "log",
  "network_manager",
  "smoltcp",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -2398,6 +2398,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
 
 [[package]]
+name = "spin"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13287b4da9d1207a4f4929ac390916d64eacfe236a487e9a9f5b3be392be5162"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,7 +2414,7 @@ name = "stable_deref_trait"
 version = "1.1.1"
 source = "git+https://github.com/kevinaboos/stable_deref_trait.git?branch=spin#82478940fa89747f48523bfbcb0ab700fd1cbe7b"
 dependencies = [
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -2420,7 +2426,7 @@ dependencies = [
  "memory",
  "memory_structs",
  "page_allocator",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -2448,7 +2454,7 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "lazy_static",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -2464,7 +2470,7 @@ dependencies = [
  "mod_mgmt",
  "runqueue_priority",
  "runqueue_round_robin",
- "spin",
+ "spin 0.4.10",
  "task",
 ]
 
@@ -2480,7 +2486,7 @@ version = "0.1.0"
 dependencies = [
  "bare-io",
  "keycodes_ascii",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -2492,7 +2498,7 @@ dependencies = [
  "log",
  "owning_ref",
  "pci",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -2504,7 +2510,7 @@ dependencies = [
  "log",
  "owning_ref",
  "pci",
- "spin",
+ "spin 0.4.10",
  "storage_device",
 ]
 
@@ -2571,7 +2577,7 @@ dependencies = [
  "memory",
  "mod_mgmt",
  "root",
- "spin",
+ "spin 0.4.10",
  "stack",
  "tss",
  "x86_64",
@@ -2586,7 +2592,7 @@ dependencies = [
  "memory",
  "path",
  "root",
- "spin",
+ "spin 0.4.10",
  "task",
  "x86_64",
 ]
@@ -2599,7 +2605,7 @@ dependencies = [
  "event_types",
  "lazy_static",
  "serial_port",
- "spin",
+ "spin 0.4.10",
  "task",
  "x86_64",
 ]
@@ -2615,7 +2621,7 @@ dependencies = [
  "rendezvous",
  "scheduler",
  "spawn",
- "spin",
+ "spin 0.4.10",
  "task",
  "terminal_print",
 ]
@@ -2638,7 +2644,7 @@ dependencies = [
  "scheduler",
  "shapes",
  "spawn",
- "spin",
+ "spin 0.4.10",
  "task",
  "terminal_print",
  "unified_channel",
@@ -2662,7 +2668,7 @@ dependencies = [
  "lazy_static",
  "log",
  "spawn",
- "spin",
+ "spin 0.4.10",
  "terminal_print",
 ]
 
@@ -2676,7 +2682,7 @@ dependencies = [
  "framebuffer",
  "framebuffer_printer",
  "shapes",
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -2709,7 +2715,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memory",
- "spin",
+ "spin 0.4.10",
  "x86_64",
 ]
 
@@ -2795,7 +2801,7 @@ dependencies = [
  "ota_update_client",
  "path",
  "smoltcp",
- "spin",
+ "spin 0.4.10",
  "task",
  "terminal_print",
  "vfs_node",
@@ -2812,7 +2818,7 @@ dependencies = [
  "fs_node",
  "log",
  "memory",
- "spin",
+ "spin 0.4.10",
  "x86_64",
 ]
 
@@ -2822,7 +2828,7 @@ version = "0.1.0"
 dependencies = [
  "kernel_config",
  "serial_port",
- "spin",
+ "spin 0.4.10",
  "volatile",
 ]
 
@@ -2885,7 +2891,7 @@ dependencies = [
  "path",
  "shapes",
  "spawn",
- "spin",
+ "spin 0.4.10",
  "window_inner",
  "window_manager",
 ]
@@ -2921,7 +2927,7 @@ dependencies = [
  "scheduler",
  "shapes",
  "spawn",
- "spin",
+ "spin 0.4.10",
  "window_inner",
 ]
 

--- a/applications/.old_static_binary_hello/Cargo.toml
+++ b/applications/.old_static_binary_hello/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hello"
 version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 

--- a/applications/app_io/Cargo.toml
+++ b/applications/app_io/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 description = "Offers applications the ability to read from or print to the terminal."
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/applications/app_io/src/lib.rs
+++ b/applications/app_io/src/lib.rs
@@ -17,14 +17,14 @@
 
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
-extern crate stdio;
-extern crate spin;
+
+
 #[macro_use] extern crate alloc;
-extern crate keycodes_ascii;
-extern crate libterm;
-extern crate serial_port;
-extern crate bare_io;
-extern crate window_manager;
+
+
+use serial_port;
+
+
 
 use stdio::{StdioReader, StdioWriter, KeyEventReadGuard,
             KeyEventQueueReader};
@@ -321,7 +321,7 @@ use core::fmt;
 use bare_io::Write;
 /// Converts the given `core::fmt::Arguments` to a `String` and enqueues the string into the correct
 /// terminal print-producer
-pub fn print_to_stdout_args(fmt_args: fmt::Arguments) {
+pub fn print_to_stdout_args(fmt_args: fmt::Arguments<'_>) {
     let task_id = match task::get_my_current_task_id() {
         Some(task_id) => task_id,
         None => {

--- a/applications/app_io/src/lib.rs
+++ b/applications/app_io/src/lib.rs
@@ -88,8 +88,8 @@ impl IoStreams {
 mod shared_maps {
     use spin::{Mutex, MutexGuard};
     use alloc::collections::BTreeMap;
-    use IoControlFlags;
-    use IoStreams;
+    use crate::IoControlFlags;
+    use crate::IoStreams;
 
     lazy_static! {
         /// Map a task to its IoControlFlags structure.

--- a/applications/bm/Cargo.toml
+++ b/applications/bm/Cargo.toml
@@ -3,6 +3,7 @@ name = "bm"
 version = "0.1.0"
 authors = ["Minhong Yun <mhyun@rice.edu>"]
 build = "../../build.rs"
+edition = "2018"
 
 [features]
 bm_in_us = []

--- a/applications/bm/src/lib.rs
+++ b/applications/bm/src/lib.rs
@@ -9,25 +9,25 @@
 #![no_std]
 
 #[macro_use] extern crate alloc;
-extern crate task;
-extern crate hpet;
+use task;
+
 #[macro_use] extern crate terminal_print;
 // #[macro_use] extern crate log;
-extern crate fs_node;
-extern crate apic;
-extern crate spawn;
-extern crate path;
-extern crate runqueue;
-extern crate heapfile;
-extern crate scheduler;
-extern crate libtest;
-extern crate memory;
-extern crate rendezvous;
-extern crate async_channel;
-extern crate simple_ipc;
-extern crate getopts;
-extern crate pmu_x86;
-extern crate mod_mgmt;
+
+use apic;
+use spawn;
+
+
+
+use scheduler;
+
+
+use rendezvous;
+use async_channel;
+use simple_ipc;
+
+use pmu_x86;
+
 
 use core::str;
 use alloc::vec::Vec;

--- a/applications/cat/Cargo.toml
+++ b/applications/cat/Cargo.toml
@@ -3,6 +3,7 @@ name = "cat"
 version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/cat/src/lib.rs
+++ b/applications/cat/src/lib.rs
@@ -3,11 +3,11 @@
 // #[macro_use] extern crate log;
 
 #[macro_use] extern crate alloc;
-extern crate task;
-extern crate getopts;
-extern crate path;
-extern crate fs_node;
-extern crate bare_io;
+use task;
+
+
+
+
 
 use core::str;
 use alloc::{

--- a/applications/cd/Cargo.toml
+++ b/applications/cd/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cd"
 version = "0.1.0"
 authors = ["Christine Wang <chrissywang54@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -3,11 +3,11 @@
 // #[macro_use] extern crate log;
 
 extern crate alloc;
-extern crate task;
-extern crate getopts;
-extern crate path;
-extern crate fs_node;
-extern crate root;
+use task;
+
+
+
+use root;
 
 use alloc::vec::Vec;
 use alloc::string::String;

--- a/applications/channel_app/Cargo.toml
+++ b/applications/channel_app/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Used for evaluating live evolution between sync/async channels in Theseus"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/channel_app/src/lib.rs
+++ b/applications/channel_app/src/lib.rs
@@ -6,11 +6,11 @@
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate log;
 #[macro_use] extern crate terminal_print;
-extern crate getopts;
-extern crate unified_channel;
-extern crate task;
-extern crate spawn;
-extern crate apic;
+
+use unified_channel;
+
+use spawn;
+use apic;
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 use alloc::vec::Vec;

--- a/applications/cpu/Cargo.toml
+++ b/applications/cpu/Cargo.toml
@@ -3,6 +3,7 @@ name = "cpu"
 version = "0.1.0"
 authors = ["Christine Wang <chrissywang54@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/cpu/src/lib.rs
+++ b/applications/cpu/src/lib.rs
@@ -2,10 +2,10 @@
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate terminal_print;
 
-extern crate apic;
-extern crate getopts;
-extern crate task;
-extern crate runqueue;
+
+
+
+use runqueue;
 
 use getopts::Options;
 use alloc::vec::Vec;

--- a/applications/date/Cargo.toml
+++ b/applications/date/Cargo.toml
@@ -3,6 +3,7 @@ name = "date"
 version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/applications/date/src/lib.rs
+++ b/applications/date/src/lib.rs
@@ -5,7 +5,7 @@
 
 extern crate alloc;
 #[macro_use] extern crate terminal_print;
-extern crate rtc;
+use rtc;
 
 use alloc::vec::Vec;
 use alloc::string::String;

--- a/applications/deps/Cargo.toml
+++ b/applications/deps/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "Allows a developer to explore dependencies in Theseus's crate management"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/deps/src/lib.rs
+++ b/applications/deps/src/lib.rs
@@ -49,7 +49,7 @@ macro_rules! println_log {
 
 static VERBOSE: Once<bool> = Once::new();
 macro_rules! verbose {
-    () => (VERBOSE.try() == Some(&true));
+    () => (VERBOSE.r#try() == Some(&true));
 }
 
 

--- a/applications/deps/src/lib.rs
+++ b/applications/deps/src/lib.rs
@@ -8,14 +8,14 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate terminal_print;
-extern crate itertools;
 
-extern crate getopts;
-extern crate task;
-extern crate memory;
-extern crate mod_mgmt;
-extern crate crate_name_utils;
-extern crate spin;
+
+
+use task;
+
+use mod_mgmt;
+
+
 
 
 use alloc::{

--- a/applications/example/Cargo.toml
+++ b/applications/example/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "An example application that shows how to write a basic application for Theseus."
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/example/src/lib.rs
+++ b/applications/example/src/lib.rs
@@ -4,7 +4,7 @@
 
 extern crate alloc;
 #[macro_use] extern crate terminal_print;
-extern crate getopts;
+
 
 use alloc::vec::Vec;
 use alloc::string::String;

--- a/applications/heap_eval/Cargo.toml
+++ b/applications/heap_eval/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Benchmarks to evaluate Theseus's heap design"
 authors = ["Ramla Ijaz <ijazramla@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 qp-trie = "0.7.3"

--- a/applications/hello/Cargo.toml
+++ b/applications/hello/Cargo.toml
@@ -3,6 +3,7 @@ name = "hello"
 version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/applications/immediate_input_echo/Cargo.toml
+++ b/applications/immediate_input_echo/Cargo.toml
@@ -3,6 +3,7 @@ name = "immediate_input_echo"
 version = "0.1.0"
 authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 bare-io = { version = "0.2.1", features = [ "alloc" ] }

--- a/applications/immediate_input_echo/src/lib.rs
+++ b/applications/immediate_input_echo/src/lib.rs
@@ -2,9 +2,9 @@
 #![no_std]
 
 #[macro_use] extern crate alloc;
-extern crate bare_io;
-extern crate stdio;
-extern crate app_io;
+
+
+use app_io;
 #[macro_use] extern crate log;
 
 use alloc::vec::Vec;

--- a/applications/input_echo/Cargo.toml
+++ b/applications/input_echo/Cargo.toml
@@ -3,6 +3,7 @@ name = "input_echo"
 version = "0.1.0"
 authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 bare-io = { version = "0.2.1", features = [ "alloc" ] }

--- a/applications/input_echo/src/lib.rs
+++ b/applications/input_echo/src/lib.rs
@@ -2,8 +2,8 @@
 #![no_std]
 
 #[macro_use] extern crate alloc;
-extern crate bare_io;
-extern crate app_io;
+
+use app_io;
 #[macro_use] extern crate log;
 
 use alloc::vec::Vec;

--- a/applications/keyboard_echo/Cargo.toml
+++ b/applications/keyboard_echo/Cargo.toml
@@ -3,6 +3,7 @@ name = "keyboard_echo"
 version = "0.1.0"
 authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 bare-io = { version = "0.2.1", features = [ "alloc" ] }

--- a/applications/keyboard_echo/src/lib.rs
+++ b/applications/keyboard_echo/src/lib.rs
@@ -3,10 +3,10 @@
 #![no_std]
 
 #[macro_use] extern crate alloc;
-extern crate bare_io;
-extern crate scheduler;
-extern crate app_io;
-extern crate keycodes_ascii;
+
+use scheduler;
+use app_io;
+
 #[macro_use] extern crate log;
 
 use bare_io::Write;

--- a/applications/kill/Cargo.toml
+++ b/applications/kill/Cargo.toml
@@ -3,6 +3,7 @@ name = "kill"
 version = "0.1.0"
 authors = ["Christine Wang <chrissywang54@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/kill/src/lib.rs
+++ b/applications/kill/src/lib.rs
@@ -3,9 +3,9 @@
 #[macro_use] extern crate terminal_print;
 #[macro_use] extern crate debugit;
 
-extern crate task;
-extern crate runqueue;
-extern crate getopts;
+use task;
+use runqueue;
+
 
 use getopts::Options;
 use alloc::vec::Vec;

--- a/applications/less/Cargo.toml
+++ b/applications/less/Cargo.toml
@@ -3,6 +3,7 @@ name = "less"
 version = "0.1.0"
 authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/less/src/lib.rs
+++ b/applications/less/src/lib.rs
@@ -3,16 +3,16 @@
 #![no_std]
 
 #[macro_use] extern crate alloc;
-extern crate task;
-extern crate getopts;
-extern crate path;
-extern crate fs_node;
-extern crate keycodes_ascii;
-extern crate libterm;
-extern crate spin;
-extern crate app_io;
-extern crate stdio;
-extern crate bare_io;
+use task;
+
+
+
+
+
+
+use app_io;
+
+
 #[macro_use] extern crate log;
 
 use keycodes_ascii::{Keycode, KeyAction};

--- a/applications/ls/Cargo.toml
+++ b/applications/ls/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ls"
 version = "0.1.0"
 authors = ["Christine Wang <chrissywang54@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/ls/src/lib.rs
+++ b/applications/ls/src/lib.rs
@@ -1,12 +1,12 @@
 #![no_std]
 
-extern crate task;
+use task;
 #[macro_use] extern crate terminal_print;
 #[macro_use] extern crate alloc;
 // #[macro_use] extern crate log;
-extern crate fs_node;
-extern crate getopts;
-extern crate path;
+
+
+
 
 use alloc::vec::Vec;
 use alloc::string::String;

--- a/applications/mkdir/Cargo.toml
+++ b/applications/mkdir/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mkdir"
 version = "0.1.0"
 authors = ["Christine Wang <chrissywang54@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/mkdir/src/lib.rs
+++ b/applications/mkdir/src/lib.rs
@@ -2,10 +2,10 @@
 #[macro_use] extern crate terminal_print;
 
 extern crate alloc;
-extern crate task;
-extern crate getopts;
-extern crate fs_node;
-extern crate vfs_node;
+use task;
+
+
+
 
 use alloc::vec::Vec;
 use alloc::string::String;

--- a/applications/mm_eval/Cargo.toml
+++ b/applications/mm_eval/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "A application that microbenchmarks various memory mapping implementations"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/mm_eval/src/lib.rs
+++ b/applications/mm_eval/src/lib.rs
@@ -7,15 +7,15 @@
 extern crate alloc;
 #[macro_use] extern crate cfg_if;
 #[macro_use] extern crate terminal_print;
-extern crate log;
-extern crate memory;
-extern crate getopts;
-extern crate hpet;
-extern crate kernel_config;
-extern crate tsc;
-extern crate memory_structs;
-extern crate apic;
-extern crate runqueue;
+
+
+
+
+
+
+
+
+
 
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/applications/ns/Cargo.toml
+++ b/applications/ns/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "An app for interacting with crate namespaces"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/ns/src/lib.rs
+++ b/applications/ns/src/lib.rs
@@ -5,12 +5,12 @@
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate terminal_print;
 
-extern crate getopts;
-extern crate memory;
-extern crate task;
-extern crate mod_mgmt;
-extern crate fs_node;
-extern crate path;
+
+use memory;
+use task;
+
+
+
 
 use core::{
     ops::Deref,

--- a/applications/ping/Cargo.toml
+++ b/applications/ping/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "pings an IPv4 address and returns ping statistics"
 authors = ["Barry Shiberu <berketshiberu@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 byteorder = { version = "1.0", default-features = false }

--- a/applications/ping/src/lib.rs
+++ b/applications/ping/src/lib.rs
@@ -9,14 +9,14 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate terminal_print;
-extern crate smoltcp;
-extern crate network_manager;
-extern crate byteorder;
-extern crate hpet;
-extern crate smoltcp_helper;
-extern crate hashbrown;
-extern crate ota_update_client;
-extern crate getopts;
+
+
+
+
+
+
+
+
 
 
 use getopts::{Matches, Options};
@@ -151,7 +151,7 @@ fn get_default_iface() -> Result<NetworkInterfaceRef, String> {
 
 // Retrieves the echo reply contained in the receive buffer and prints data pertaining to the packet
 fn get_icmp_pong (waiting_queue: &mut HashMap<u16, u64>, times: &mut Vec<u64>, total_time: &mut u64, 
-    repr: Icmpv4Repr, received: &mut u16, remote_addr: IpAddress, timestamp: u64)  {
+    repr: Icmpv4Repr<'_>, received: &mut u16, remote_addr: IpAddress, timestamp: u64)  {
     
     if let Icmpv4Repr::EchoReply { seq_no, data, ..} = repr {
         if let Some(_) = waiting_queue.get(&seq_no) {
@@ -231,7 +231,7 @@ fn ping(address: IpAddress, count: usize, interval: u64, timeout: u64, verbose: 
                 Ok(time) => time,
                 Err(err) => return println!("couldn't get timestamp:{}", err),
             };
-            let mut socket = sockets.get::<IcmpSocket>(icmp_handle); 
+            let mut socket = sockets.get::<IcmpSocket<'_, '_>>(icmp_handle); 
             
             // Checks if the icmp socket is open, and only bind the identifier icmp to it if 
             // it is closed

--- a/applications/pmu_sample_start/Cargo.toml
+++ b/applications/pmu_sample_start/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "A basic application that retrieves samples."
 authors = ["Aryan Sefidi <aryansefidi@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/pmu_sample_start/src/lib.rs
+++ b/applications/pmu_sample_start/src/lib.rs
@@ -4,9 +4,9 @@
 
 extern crate alloc;
 #[macro_use] extern crate print;
-extern crate getopts;
-extern crate pmu_x86;
-extern crate spawn;
+
+use pmu_x86;
+
 
 use alloc::vec::Vec;
 use alloc::string::String;

--- a/applications/pmu_sample_stop/Cargo.toml
+++ b/applications/pmu_sample_stop/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "A basic application that starts sampling and retrieves samples."
 authors = ["Aryan Sefidi <aryansefidi@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/pmu_sample_stop/src/lib.rs
+++ b/applications/pmu_sample_stop/src/lib.rs
@@ -5,8 +5,8 @@
 
 extern crate alloc;
 #[macro_use] extern crate print;
-extern crate getopts;
-extern crate pmu_x86;
+
+use pmu_x86;
 
 use alloc::vec::Vec;
 use alloc::string::String;

--- a/applications/print_fault_log/Cargo.toml
+++ b/applications/print_fault_log/Cargo.toml
@@ -2,6 +2,7 @@
 name = "print_fault_log"
 version = "0.1.0"
 authors = ["Namitha Liyanage <namithaliyanage@gmail.com>"]
+edition = "2018"
 
 [dependencies.fault_log]
 path = "../../kernel/fault_log"

--- a/applications/print_fault_log/src/lib.rs
+++ b/applications/print_fault_log/src/lib.rs
@@ -3,7 +3,7 @@
 #![no_std]
 
 extern crate alloc;
-extern crate fault_log;
+
 
 use alloc::vec::Vec;
 use alloc::string::String;

--- a/applications/ps/Cargo.toml
+++ b/applications/ps/Cargo.toml
@@ -3,6 +3,7 @@ name = "ps"
 version = "0.1.0"
 authors = ["Christine Wang <chrissywang54@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/ps/src/lib.rs
+++ b/applications/ps/src/lib.rs
@@ -2,9 +2,9 @@
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate terminal_print;
 
-extern crate task;
-extern crate getopts;
-extern crate scheduler;
+
+
+
 
 use getopts::Options;
 use alloc::vec::Vec;

--- a/applications/pwd/Cargo.toml
+++ b/applications/pwd/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pwd"
 version = "0.1.0"
 authors = ["Christine Wang <chrissywang54@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/pwd/src/lib.rs
+++ b/applications/pwd/src/lib.rs
@@ -2,8 +2,8 @@
 #[macro_use] extern crate terminal_print;
 
 extern crate alloc;
-extern crate task;
-extern crate getopts;
+use task;
+
 
 use alloc::vec::Vec;
 use alloc::string::String;

--- a/applications/rm/Cargo.toml
+++ b/applications/rm/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Andrew Pham <apham@rice.edu"]
 build = "../../build.rs"
 description = "removes the directory from the virtual filesystem"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/rm/src/lib.rs
+++ b/applications/rm/src/lib.rs
@@ -3,11 +3,11 @@
 // #[macro_use] extern crate log;
 
 #[macro_use] extern crate alloc;
-extern crate task;
-extern crate getopts;
-extern crate path;
-extern crate fs_node;
-extern crate root;
+use task;
+
+
+
+
 
 use alloc::vec::Vec;
 use alloc::string::String;

--- a/applications/rq_eval/Cargo.toml
+++ b/applications/rq_eval/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "A application that microbenchmarks runqueue performance"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/rq_eval/src/lib.rs
+++ b/applications/rq_eval/src/lib.rs
@@ -168,7 +168,7 @@ fn run_single(iterations: usize) -> Result<(), &'static str> {
         #[cfg(runqueue_spillful)] 
         {   
             let task_on_rq = { taskref.lock().on_runqueue.clone() };
-            if let Some(remove_from_runqueue) = task::RUNQUEUE_REMOVAL_FUNCTION.try() {
+            if let Some(remove_from_runqueue) = task::RUNQUEUE_REMOVAL_FUNCTION.r#try() {
                 if let Some(rq) = task_on_rq {
                     remove_from_runqueue(&taskref, rq)?;
                 }

--- a/applications/rq_eval/src/lib.rs
+++ b/applications/rq_eval/src/lib.rs
@@ -21,13 +21,13 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate terminal_print;
-extern crate task;
-extern crate apic;
-extern crate spawn;
-extern crate runqueue;
-extern crate getopts;
-extern crate hpet;
-extern crate libtest;
+
+use apic;
+use spawn;
+use runqueue;
+
+
+
 
 use alloc::{
     boxed::Box,

--- a/applications/scheduler_eval/Cargo.toml
+++ b/applications/scheduler_eval/Cargo.toml
@@ -3,6 +3,7 @@ name = "scheduler_eval"
 version = "0.1.0"
 authors = ["Namitha Liyanage <namithaliyanage@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/applications/scheduler_eval/src/lib.rs
+++ b/applications/scheduler_eval/src/lib.rs
@@ -2,9 +2,9 @@
 
 #[macro_use] extern crate log;
 extern crate alloc;
-extern crate spawn;
-extern crate scheduler;
-extern crate task;
+use spawn;
+use scheduler;
+use task;
 
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/applications/shell/Cargo.toml
+++ b/applications/shell/Cargo.toml
@@ -5,6 +5,7 @@ description = "Shell that can run commands in application directory"
 authors = ["Andrew Pham <apham727@gmail.com>", "Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -5,25 +5,25 @@
 //! spawns and manages tasks, and records the history of executed user commands.
 
 #![no_std]
-extern crate keycodes_ascii;
-extern crate spin;
-extern crate dfqueue;
-extern crate spawn;
-extern crate task;
-extern crate runqueue;
-extern crate event_types; 
-extern crate window_manager;
-extern crate path;
-extern crate root;
-extern crate scheduler;
-extern crate stdio;
-extern crate bare_io;
-extern crate app_io;
-extern crate fs_node;
-extern crate terminal_print;
-extern crate print;
-extern crate environment;
-extern crate libterm;
+
+
+
+use spawn;
+use task;
+use runqueue;
+ 
+
+
+use root;
+use scheduler;
+
+
+use app_io;
+
+use terminal_print;
+use print;
+
+
 
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate log;
@@ -411,8 +411,8 @@ impl Shell {
                 };
 
                 // Lock the shared structure in `app_io` and then kill the running application
-                app_io::lock_and_execute(&move |_flags_guard: MutexGuard<BTreeMap<usize, IoControlFlags>>,
-                                                _streamss_guard: MutexGuard<BTreeMap<usize, IoStreams>>| {
+                app_io::lock_and_execute(&move |_flags_guard: MutexGuard<'_, BTreeMap<usize, IoControlFlags>>,
+                                                _streamss_guard: MutexGuard<'_, BTreeMap<usize, IoStreams>>| {
 
                     // Kill all tasks in the job.
                     for task_ref in &task_refs {
@@ -463,8 +463,8 @@ impl Shell {
                 };
 
                 // Lock the shared structure in `app_io` and then stop the running application
-                app_io::lock_and_execute(&move |_flags_guard: MutexGuard<BTreeMap<usize, IoControlFlags>>,
-                                                _streams_guard: MutexGuard<BTreeMap<usize, IoStreams>>| {
+                app_io::lock_and_execute(&move |_flags_guard: MutexGuard<'_, BTreeMap<usize, IoControlFlags>>,
+                                                _streams_guard: MutexGuard<'_, BTreeMap<usize, IoStreams>>| {
                     
                     // Stop all tasks in the job.
                     for task_ref in &task_refs {

--- a/applications/swap/Cargo.toml
+++ b/applications/swap/Cargo.toml
@@ -3,6 +3,7 @@ name = "swap"
 version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/swap/src/lib.rs
+++ b/applications/swap/src/lib.rs
@@ -7,16 +7,16 @@
 
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate terminal_print;
-extern crate itertools;
 
-extern crate getopts;
-extern crate memory;
-extern crate mod_mgmt;
-extern crate crate_swap;
-extern crate hpet;
-extern crate task;
-extern crate path;
-extern crate fs_node;
+
+
+use memory;
+
+use crate_swap;
+
+use task;
+
+
 
 use alloc::{
     string::{String, ToString},

--- a/applications/test_channel/Cargo.toml
+++ b/applications/test_channel/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Tests Theseus's channel implementations with multiple tasks"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/test_channel/src/lib.rs
+++ b/applications/test_channel/src/lib.rs
@@ -25,13 +25,13 @@ use spin::Once;
 static VERBOSE: Once<bool> = Once::new();
 #[allow(unused)]
 macro_rules! verbose {
-    () => (VERBOSE.try() == Some(&true));
+    () => (VERBOSE.r#try() == Some(&true));
 }
 
 static PINNED: Once<bool> = Once::new();
 macro_rules! pin_task {
     ($tb:ident, $cpu:expr) => (
-        if PINNED.try() == Some(&true) {
+        if PINNED.r#try() == Some(&true) {
             $tb.pin_on_core($cpu)
         } else {
             $tb

--- a/applications/test_channel/src/lib.rs
+++ b/applications/test_channel/src/lib.rs
@@ -3,14 +3,14 @@
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate log;
 #[macro_use] extern crate terminal_print;
-extern crate getopts;
-extern crate spin;
-extern crate task;
-extern crate spawn;
-extern crate scheduler;
-extern crate rendezvous;
-extern crate async_channel;
-extern crate apic;
+
+
+
+use spawn;
+
+use rendezvous;
+use async_channel;
+use apic;
 
 
 use alloc::{

--- a/applications/test_downtime/Cargo.toml
+++ b/applications/test_downtime/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Measure the downtime when various subsystems crash"
 authors = ["Namitha Liyanage <namithaliyanage@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/test_downtime/src/lib.rs
+++ b/applications/test_downtime/src/lib.rs
@@ -4,22 +4,22 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate terminal_print;
-extern crate getopts;
-extern crate spin;
-extern crate task;
-extern crate spawn;
-extern crate scheduler;
-extern crate rendezvous;
-extern crate async_channel;
-extern crate apic;
-extern crate runqueue;
-extern crate window;
-extern crate framebuffer;
-extern crate framebuffer_drawer;
-extern crate color;
-extern crate shapes;
-extern crate hpet;
-extern crate unified_channel;
+
+
+
+
+
+
+
+use apic;
+use runqueue;
+
+use framebuffer;
+use framebuffer_drawer;
+use color;
+use shapes;
+
+use unified_channel;
 
 
 use alloc::{

--- a/applications/test_exception/Cargo.toml
+++ b/applications/test_exception/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "a simple app for testing recovery from a machine exception"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/applications/test_exception2/Cargo.toml
+++ b/applications/test_exception2/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "a simple app for testing recovery from a machine exception"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/applications/test_filerw/Cargo.toml
+++ b/applications/test_filerw/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_filerw"
 version = "0.1.0"
 authors = ["Andrew Pham <apham727@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/applications/test_ixgbe/Cargo.toml
+++ b/applications/test_ixgbe/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_ixgbe"
 version = "0.1.0"
 authors = ["Ramla Ijaz <ijazramla@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/applications/test_mutex_sleep/Cargo.toml
+++ b/applications/test_mutex_sleep/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Tests the blocking sleeping mutex with multiple tasks"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies.log]
 version = "0.4.8"

--- a/applications/test_panic/Cargo.toml
+++ b/applications/test_panic/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_panic"
 version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/applications/test_panic/src/lib.rs
+++ b/applications/test_panic/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 #[macro_use] extern crate log;
 #[macro_use] extern crate terminal_print;
-extern crate task;
+use task;
 
 
 use alloc::vec::Vec;

--- a/applications/test_restartable/Cargo.toml
+++ b/applications/test_restartable/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_restartable"
 version = "0.1.0"
 authors = ["Namitha Liyanage <namithaliyanage@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/test_restartable/src/lib.rs
+++ b/applications/test_restartable/src/lib.rs
@@ -6,10 +6,10 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate terminal_print;
 #[macro_use] extern crate lazy_static;
-extern crate getopts;
+
 extern crate alloc;
-extern crate spawn;
-extern crate spin;
+
+
 
 
 use spin::Mutex;

--- a/applications/test_wait_queue/Cargo.toml
+++ b/applications/test_wait_queue/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Tests the wait queue functionality of Theseus with multiple tasks"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/applications/unwind_test/Cargo.toml
+++ b/applications/unwind_test/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "a simple app for testing whether unwinding works"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/applications/unwind_test/src/lib.rs
+++ b/applications/unwind_test/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 #[macro_use] extern crate log;
 // #[macro_use] extern crate terminal_print;
-extern crate task;
+use task;
 
 
 use alloc::vec::Vec;

--- a/applications/upd/Cargo.toml
+++ b/applications/upd/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "Front-end application to communicate with Theseus update server"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 getopts = "0.2.21"

--- a/applications/upd/src/lib.rs
+++ b/applications/upd/src/lib.rs
@@ -8,21 +8,21 @@
 
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate terminal_print;
-extern crate itertools;
 
-extern crate getopts;
-extern crate task;
-extern crate ota_update_client;
-extern crate network_manager;
-extern crate memory;
-extern crate mod_mgmt;
-extern crate crate_swap;
-extern crate smoltcp;
-extern crate path;
-extern crate memfs;
-extern crate fs_node;
-extern crate vfs_node;
-extern crate spin;
+
+
+use task;
+use ota_update_client;
+
+use memory;
+use mod_mgmt;
+use crate_swap;
+
+
+
+
+
+
 
 
 use core::str::FromStr;

--- a/applications/upd/src/lib.rs
+++ b/applications/upd/src/lib.rs
@@ -55,7 +55,7 @@ use ota_update_client::DIFF_FILE_NAME;
 
 static VERBOSE: Once<bool> = Once::new();
 macro_rules! verbose {
-    () => (VERBOSE.try() == Some(&true));
+    () => (VERBOSE.r#try() == Some(&true));
 }
 
 

--- a/kernel/acpi/Cargo.toml
+++ b/kernel/acpi/Cargo.toml
@@ -4,6 +4,7 @@ name = "acpi"
 description = "ACPI (Advanced Configuration and Power Interface) support for Theseus"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/acpi_table/Cargo.toml
+++ b/kernel/acpi_table/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "Definitions for ACPI tables bookkeeping"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 zerocopy = "0.3.0"

--- a/kernel/acpi_table_handler/Cargo.toml
+++ b/kernel/acpi_table_handler/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "Functions for handling specific types of ACPI tables"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/ap_start/Cargo.toml
+++ b/kernel/ap_start/Cargo.toml
@@ -4,6 +4,7 @@ name = "ap_start"
 description = "High-level initialization code that runs on each AP (core) after it has booted up"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/apic/Cargo.toml
+++ b/kernel/apic/Cargo.toml
@@ -4,6 +4,7 @@ name = "apic"
 description = "APIC (Advanced Programmable Interrupt Controller) support for Theseus (x86 only), including apic/xapic and x2apic"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -61,7 +61,7 @@ static APIC_REGS: Once<BoxRef<MappedPages, ApicRegisters>> = Once::new();
 static BSP_PROCESSOR_ID: Once<u8> = Once::new(); 
 
 pub fn get_bsp_id() -> Option<u8> {
-    BSP_PROCESSOR_ID.try().cloned()
+    BSP_PROCESSOR_ID.r#try().cloned()
 }
 
 /// Returns true if the currently executing processor core is the bootstrap processor, 

--- a/kernel/async_channel/Cargo.toml
+++ b/kernel/async_channel/Cargo.toml
@@ -4,6 +4,7 @@ name = "async_channel"
 description = "Channel for asynchronous Inter-Task Communication via a bounded buffer"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/ata/Cargo.toml
+++ b/kernel/ata/Cargo.toml
@@ -4,6 +4,7 @@ name = "ata"
 description = "Support for accessing ATA (IDE) disks"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 bitflags = "1.1.0"

--- a/kernel/block_allocator/Cargo.toml
+++ b/kernel/block_allocator/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Philipp Oppermann <dev@phil-opp.com>", "Ramla Ijaz <ijazramla@gmail.com"]
 name = "block_allocator"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies.linked_list_allocator]
 version = "0.8.6"

--- a/kernel/block_io/Cargo.toml
+++ b/kernel/block_io/Cargo.toml
@@ -4,6 +4,7 @@ name = "block_io"
 description = "A generic layer for converting between IO streams of different block sizes, with caching"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -4,6 +4,7 @@ name = "captain"
 description = "The main driver of Theseus. Controls the loading and initialization of all subsystems and other crates."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/catch_unwind/Cargo.toml
+++ b/kernel/catch_unwind/Cargo.toml
@@ -4,6 +4,7 @@ name = "catch_unwind"
 description = "Support for catching unwinding after a panic, like `std::panic::catch_unwind`"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/color/Cargo.toml
+++ b/kernel/color/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Wenqiu Yu <yuwenqiuj@gmail.com>", "Kevin Boos <kevinaboos@gmail.com>"]
 description = "A simple representation of the standard RGB color model"
 build = "../../build.rs"
+edition = "2018"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/compositor/Cargo.toml
+++ b/kernel/compositor/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "a compositor trait which composites a list of buffers to a single buffer"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies.framebuffer]
 path = "../framebuffer"

--- a/kernel/context_switch/Cargo.toml
+++ b/kernel/context_switch/Cargo.toml
@@ -4,6 +4,7 @@ name = "context_switch"
 description = "Top-level wrapper crate for managing all possible configurations for context switching routines and structs"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 cfg-if = "0.1.6"

--- a/kernel/context_switch_avx/Cargo.toml
+++ b/kernel/context_switch_avx/Cargo.toml
@@ -4,6 +4,7 @@ name = "context_switch_avx"
 description = "Context switching routines and structs for AVX-enabled register sets"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 zerocopy = "0.3.0"

--- a/kernel/context_switch_regular/Cargo.toml
+++ b/kernel/context_switch_regular/Cargo.toml
@@ -4,6 +4,7 @@ name = "context_switch_regular"
 description = "Context switching routines and structs for regular (non-SSE) register sets"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 zerocopy = "0.3.0"

--- a/kernel/context_switch_sse/Cargo.toml
+++ b/kernel/context_switch_sse/Cargo.toml
@@ -4,6 +4,7 @@ name = "context_switch_sse"
 description = "Context switching routines and structs for SSE-enabled register sets"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 zerocopy = "0.3.0"

--- a/kernel/crate_metadata/Cargo.toml
+++ b/kernel/crate_metadata/Cargo.toml
@@ -5,6 +5,7 @@ description = "Types for tracking loaded crates and their dependency metadata wi
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/crate_name_utils/Cargo.toml
+++ b/kernel/crate_name_utils/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "crate_name_utils"
 description = "Utility functions for processing, parsing, and working with crate names/symbol strings"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies.itertools]
 version = "0.7.9"

--- a/kernel/crate_swap/Cargo.toml
+++ b/kernel/crate_swap/Cargo.toml
@@ -5,6 +5,7 @@ description = "Handles crate swapping for live evolution and fault recovery purp
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/debug_info/Cargo.toml
+++ b/kernel/debug_info/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Support for processing and using DWARF debug information from ELF files"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 xmas-elf = { version = "0.6.2", git = "https://github.com/kevinaboos/xmas-elf.git" }

--- a/kernel/device_manager/Cargo.toml
+++ b/kernel/device_manager/Cargo.toml
@@ -4,6 +4,7 @@ name = "device_manager"
 description = "Code for handling the sequence required to manage and initialize each driver"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/displayable/Cargo.toml
+++ b/kernel/displayable/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "provides a Displayable trait, which abstracts objects that can display themselves onto a framebuffer"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/displayable/text_display/Cargo.toml
+++ b/kernel/displayable/text_display/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "a text display is a block of text which can display onto a framebuffer"
 build = "../../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/e1000/Cargo.toml
+++ b/kernel/e1000/Cargo.toml
@@ -4,6 +4,7 @@ name = "e1000"
 description = "Support for the e1000 NIC and driver"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/e1000/src/lib.rs
+++ b/kernel/e1000/src/lib.rs
@@ -30,7 +30,7 @@ extern crate nic_initialization;
 
 pub mod test_e1000_driver;
 mod regs;
-use regs::*;
+use crate::regs::*;
 
 use spin::Once; 
 use alloc::vec::Vec;
@@ -72,7 +72,7 @@ static E1000_NIC: Once<MutexIrqSafe<E1000Nic>> = Once::new();
 /// Returns a reference to the E1000Nic wrapped in a MutexIrqSafe,
 /// if it exists and has been initialized.
 pub fn get_e1000_nic() -> Option<&'static MutexIrqSafe<E1000Nic>> {
-    E1000_NIC.try()
+    E1000_NIC.r#try()
 }
 
 /// How many ReceiveBuffers are preallocated for this driver to use. 
@@ -422,7 +422,7 @@ impl E1000Nic {
 }
 
 extern "x86-interrupt" fn e1000_handler(_stack_frame: &mut ExceptionStackFrame) {
-    if let Some(ref e1000_nic_ref) = E1000_NIC.try() {
+    if let Some(ref e1000_nic_ref) = E1000_NIC.r#try() {
         let mut e1000_nic = e1000_nic_ref.lock();
         if let Err(e) = e1000_nic.handle_interrupt() {
             error!("e1000_handler(): error handling interrupt: {:?}", e);

--- a/kernel/e1000/src/test_e1000_driver.rs
+++ b/kernel/e1000/src/test_e1000_driver.rs
@@ -74,6 +74,6 @@ pub fn dhcp_request_packet() -> Result<(), &'static str> {
         let buffer: &mut [u8] = transmit_buffer.as_slice_mut(0, 314)?;
         buffer.copy_from_slice(&packet);
     }
-    let mut e1000_nc = E1000_NIC.try().ok_or("e1000 NIC hasn't been initialized yet")?.lock();
+    let mut e1000_nc = E1000_NIC.r#try().ok_or("e1000 NIC hasn't been initialized yet")?.lock();
     e1000_nc.send_packet(transmit_buffer)
 }

--- a/kernel/entryflags_x86_64/Cargo.toml
+++ b/kernel/entryflags_x86_64/Cargo.toml
@@ -4,6 +4,7 @@ name = "entryflags_x86_64"
 description = "Defines the structure of page table entry flags on x86_64"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 bitflags = "1.0.4"

--- a/kernel/environment/Cargo.toml
+++ b/kernel/environment/Cargo.toml
@@ -2,6 +2,7 @@
 name = "environment"
 version = "0.1.0"
 authors = ["christinewang5 <chrissywang54@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/ethernet_smoltcp_device/Cargo.toml
+++ b/kernel/ethernet_smoltcp_device/Cargo.toml
@@ -4,6 +4,7 @@ name = "ethernet_smoltcp_device"
 description = "An interface glue layer that allows smoltcp to use ethernet crates"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 owning_ref = { git = "https://github.com/kevinaboos/owning-ref-rs" }

--- a/kernel/event_types/Cargo.toml
+++ b/kernel/event_types/Cargo.toml
@@ -4,6 +4,7 @@ name = "event_types"
 description = "Types of input and output events that flow throughout the system"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies.keycodes_ascii]
 path = "../../libs/keycodes_ascii"

--- a/kernel/exceptions_early/Cargo.toml
+++ b/kernel/exceptions_early/Cargo.toml
@@ -4,6 +4,7 @@ name = "exceptions_early"
 description = "Early exception handlers that do nothing but print an error and hang."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 # x86_64 = { git = "https://github.com/kevinaboos/x86_64" }

--- a/kernel/exceptions_full/Cargo.toml
+++ b/kernel/exceptions_full/Cargo.toml
@@ -4,6 +4,7 @@ name = "exceptions_full"
 description = "Exception handlers that are fully-featured, i.e., aware of the apic/task subsystems, and kill tasks on an exception"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 # x86_64 = { git = "https://github.com/kevinaboos/x86_64" }

--- a/kernel/fadt/Cargo.toml
+++ b/kernel/fadt/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "Support for ACPI FADT"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 zerocopy = "0.3.0"

--- a/kernel/fault_crate_swap/Cargo.toml
+++ b/kernel/fault_crate_swap/Cargo.toml
@@ -5,6 +5,7 @@ description = "Handles crate swapping of fault crates for fault tolerance purpos
 authors = ["Namitha Liyanage <namithaliyanage@gmail.com>"]
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies.log]
 default-features = false

--- a/kernel/fault_log/Cargo.toml
+++ b/kernel/fault_log/Cargo.toml
@@ -5,6 +5,7 @@ description = "Logs all exceptions occuring in Theseus"
 authors = ["Namitha Liyanage <namithaliyanage@gmail.com>"]
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies.lazy_static]
 features = ["spin_no_std", "nightly"]

--- a/kernel/first_application/Cargo.toml
+++ b/kernel/first_application/Cargo.toml
@@ -4,6 +4,7 @@ name = "first_application"
 description = "Starts the first application in Theseus after kernel initialization is complete"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/font/Cargo.toml
+++ b/kernel/font/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "define and initialize the bitmaps of ASCII characters"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/framebuffer/Cargo.toml
+++ b/kernel/framebuffer/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "a framebuffer is a buffer of pixels which can be composited to another framebuffer or be mapped to some physical memory"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 owning_ref = { git = "https://github.com/kevinaboos/owning-ref-rs" }

--- a/kernel/framebuffer/src/lib.rs
+++ b/kernel/framebuffer/src/lib.rs
@@ -18,7 +18,7 @@ use core::ops::DerefMut;
 use memory::{EntryFlags, FrameRange, MappedPages, PhysicalAddress, get_frame_allocator_ref};
 use owning_ref::BoxRefMut;
 use shapes::Coord;
-pub use pixel::*;
+pub use crate::pixel::*;
 
 /// Initializes the final framebuffer based on VESA graphics mode information obtained during boot.
 /// 

--- a/kernel/framebuffer_compositor/Cargo.toml
+++ b/kernel/framebuffer_compositor/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "the framebuffer compositor composites multiple source framebuffers into one destination framebuffer"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/framebuffer_drawer/Cargo.toml
+++ b/kernel/framebuffer_drawer/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "basic draw interfaces"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies.framebuffer]
 path = "../framebuffer"

--- a/kernel/framebuffer_printer/Cargo.toml
+++ b/kernel/framebuffer_printer/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "print a string in a framebuffer"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies.framebuffer]
 path = "../framebuffer"

--- a/kernel/fs_node/Cargo.toml
+++ b/kernel/fs_node/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Andrew Pham <apham727@gmail.com>, Christine Wang <chrissywang54@gmail.com"]
 description = "defines the traits for File and Directory. These files and directories mimic that of a standard unix virtual filesystem"
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.5"

--- a/kernel/gdt/Cargo.toml
+++ b/kernel/gdt/Cargo.toml
@@ -4,6 +4,7 @@ name = "gdt"
 description = "GDT (Global Descriptor Table) support (x86 only) for Theseus"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/gdt/src/lib.rs
+++ b/kernel/gdt/src/lib.rs
@@ -54,25 +54,25 @@ pub enum AvailableSegmentSelector {
 pub fn get_segment_selector(selector: AvailableSegmentSelector) -> SegmentSelector {
     let seg: &SegmentSelector = match selector {
         AvailableSegmentSelector::KernelCode => {
-            KERNEL_CODE_SELECTOR.try().expect("KERNEL_CODE_SELECTOR wasn't yet inited!")
+            KERNEL_CODE_SELECTOR.r#try().expect("KERNEL_CODE_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::KernelData => {
-            KERNEL_DATA_SELECTOR.try().expect("KERNEL_DATA_SELECTOR wasn't yet inited!")
+            KERNEL_DATA_SELECTOR.r#try().expect("KERNEL_DATA_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::UserCode32 => {
-            USER_CODE_32_SELECTOR.try().expect("USER_CODE_32_SELECTOR wasn't yet inited!")
+            USER_CODE_32_SELECTOR.r#try().expect("USER_CODE_32_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::UserData32 => {
-            USER_DATA_32_SELECTOR.try().expect("USER_DATA_32_SELECTOR wasn't yet inited!")
+            USER_DATA_32_SELECTOR.r#try().expect("USER_DATA_32_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::UserCode64 => {
-            USER_CODE_64_SELECTOR.try().expect("USER_CODE_64_SELECTOR wasn't yet inited!")
+            USER_CODE_64_SELECTOR.r#try().expect("USER_CODE_64_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::UserData64 => {
-            USER_DATA_64_SELECTOR.try().expect("USER_DATA_64_SELECTOR wasn't yet inited!")
+            USER_DATA_64_SELECTOR.r#try().expect("USER_DATA_64_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::Tss => {
-            TSS_SELECTOR.try().expect("TSS_SELECTOR wasn't yet inited!")
+            TSS_SELECTOR.r#try().expect("TSS_SELECTOR wasn't yet inited!")
         }
     };
 

--- a/kernel/heap/Cargo.toml
+++ b/kernel/heap/Cargo.toml
@@ -4,6 +4,7 @@ name = "heap"
 description = "global allocator for the system"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/heap/src/lib.rs
+++ b/kernel/heap/src/lib.rs
@@ -75,7 +75,7 @@ impl Heap {
 unsafe impl GlobalAlloc for Heap {
 
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        match DEFAULT_ALLOCATOR.try() {
+        match DEFAULT_ALLOCATOR.r#try() {
             Some(allocator) => {
                 allocator.alloc(layout)
             }
@@ -90,7 +90,7 @@ unsafe impl GlobalAlloc for Heap {
             self.initial_allocator.lock().deallocate(ptr, layout);
         }
         else {
-            DEFAULT_ALLOCATOR.try()
+            DEFAULT_ALLOCATOR.r#try()
                 .expect("Ptr passed to dealloc is not within the initial allocator's range, and another allocator has not been set up")
                 .dealloc(ptr, layout);
         }

--- a/kernel/heapfile/Cargo.toml
+++ b/kernel/heapfile/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "An implementation of in-memory files, backed by heap memory"
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.5"

--- a/kernel/hpet/Cargo.toml
+++ b/kernel/hpet/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "Support for the x86 HPET: High Precision Event Timer"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/hpet/src/lib.rs
+++ b/kernel/hpet/src/lib.rs
@@ -34,7 +34,7 @@ static HPET: Once<RwLock<BoxRefMut<MappedPages, Hpet>>> = Once::new();
 /// let counter_val = get_hpet().as_ref().unwrap().get_counter();
 /// ```
 pub fn get_hpet() -> Option<RwLockReadGuard<'static, BoxRefMut<MappedPages, Hpet>>> {
-    HPET.try().map(|h| h.read())
+    HPET.r#try().map(|h| h.read())
 }
 
 /// Returns a mutable reference to the HPET timer structure, wrapped in an Option,
@@ -44,7 +44,7 @@ pub fn get_hpet() -> Option<RwLockReadGuard<'static, BoxRefMut<MappedPages, Hpet
 /// get_hpet_mut().as_mut().unwrap().enable_counter(true);
 /// ```
 pub fn get_hpet_mut() -> Option<RwLockWriteGuard<'static, BoxRefMut<MappedPages, Hpet>>> {
-    HPET.try().map(|h| h.write())
+    HPET.r#try().map(|h| h.write())
 }
 
 

--- a/kernel/http_client/Cargo.toml
+++ b/kernel/http_client/Cargo.toml
@@ -4,6 +4,7 @@ name = "http_client"
 description = "Functions for creating and sending HTTP requests and receiving responses"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 httparse = { version = "1.3.3", default-features = false }

--- a/kernel/intel_ethernet/Cargo.toml
+++ b/kernel/intel_ethernet/Cargo.toml
@@ -4,6 +4,7 @@ description = "defines structs and traits for DMA descriptors unique to Intel NI
 version = "0.1.0"
 authors = ["Ramla-I <ijazramla@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 volatile = "0.2.7"

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -4,6 +4,7 @@ name = "interrupts"
 description = "Interrupt configuration and handlers for Theseus"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/interrupts/src/lib.rs
+++ b/kernel/interrupts/src/lib.rs
@@ -242,7 +242,7 @@ pub fn eoi(irq: Option<u8>) {
             apic::get_my_apic().expect("eoi(): couldn't get my apic to send EOI!").write().eoi();
         }
         InterruptChip::PIC => {
-            PIC.try().expect("eoi(): PIC not initialized").notify_end_of_interrupt(irq.expect("PIC eoi, but no arg provided"));
+            PIC.r#try().expect("eoi(): PIC not initialized").notify_end_of_interrupt(irq.expect("PIC eoi, but no arg provided"));
         }
     }
 }
@@ -359,7 +359,7 @@ extern "x86-interrupt" fn unimplemented_interrupt_handler(_stack_frame: &mut Exc
     println_raw!("\nUnimplemented interrupt handler: {:#?}", _stack_frame);
 	match apic::INTERRUPT_CHIP.load(Ordering::Acquire) {
         apic::InterruptChip::PIC => {
-            let irq_regs = PIC.try().map(|pic| pic.read_isr_irr());  
+            let irq_regs = PIC.r#try().map(|pic| pic.read_isr_irr());  
             println_raw!("PIC IRQ Registers: {:?}", irq_regs);
         }
         apic::InterruptChip::APIC | apic::InterruptChip::X2APIC => {
@@ -390,7 +390,7 @@ extern "x86-interrupt" fn unimplemented_interrupt_handler(_stack_frame: &mut Exc
 /// See here for more: https://mailman.linuxchix.org/pipermail/techtalk/2002-August/012697.html.
 /// We handle it according to this advice: https://wiki.osdev.org/8259_PIC#Spurious_IRQs
 extern "x86-interrupt" fn pic_spurious_interrupt_handler(_stack_frame: &mut ExceptionStackFrame ) {
-    if let Some(pic) = PIC.try() {
+    if let Some(pic) = PIC.r#try() {
         let irq_regs = pic.read_isr_irr();
         // check if this was a real IRQ7 (parallel port) (bit 7 will be set)
         // (pretty sure this will never happen)

--- a/kernel/ioapic/Cargo.toml
+++ b/kernel/ioapic/Cargo.toml
@@ -4,6 +4,7 @@ name = "ioapic"
 description = "IOAPIC (I/O Advanced Programmable Interrupt Controller) support (x86 only) for Theseus"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/ixgbe/Cargo.toml
+++ b/kernel/ixgbe/Cargo.toml
@@ -3,6 +3,7 @@ name = "ixgbe"
 version = "0.1.0"
 description = "Driver for the 10 GbE Intel 82599 NIC"
 authors = ["Ramla <ijazramla@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 spin = "0.4.5"

--- a/kernel/ixgbe/src/lib.rs
+++ b/kernel/ixgbe/src/lib.rs
@@ -47,8 +47,8 @@ mod regs;
 mod queue_registers;
 pub mod virtual_function;
 pub mod test_packets;
-use regs::*;
-use queue_registers::*;
+use crate::regs::*;
+use crate::queue_registers::*;
 
 use spin::Once;
 use alloc::{
@@ -122,7 +122,7 @@ pub static IXGBE_NICS: Once<Vec<MutexIrqSafe<IxgbeNic>>> = Once::new();
 /// Returns a reference to the IxgbeNic wrapped in a MutexIrqSafe, if it exists and has been initialized.
 /// Currently we use the pci location of the device as identification since it should not change after initialization.
 pub fn get_ixgbe_nic(id: PciLocation) -> Result<&'static MutexIrqSafe<IxgbeNic>, &'static str> {
-    let nics = IXGBE_NICS.try().ok_or("Ixgbe NICs weren't initialized")?;
+    let nics = IXGBE_NICS.r#try().ok_or("Ixgbe NICs weren't initialized")?;
     nics.iter()
         .find( |nic| { nic.lock().dev_id == id } )
         .ok_or("Ixgbe NIC with this ID does not exist")
@@ -130,7 +130,7 @@ pub fn get_ixgbe_nic(id: PciLocation) -> Result<&'static MutexIrqSafe<IxgbeNic>,
 
 /// Returns a reference to the list of all initialized ixgbe NICs
 pub fn get_ixgbe_nics_list() -> Option<&'static Vec<MutexIrqSafe<IxgbeNic>>> {
-    IXGBE_NICS.try()
+    IXGBE_NICS.r#try()
 }
 
 /// How many ReceiveBuffers are preallocated for this driver to use. 

--- a/kernel/kernel_config/Cargo.toml
+++ b/kernel/kernel_config/Cargo.toml
@@ -4,6 +4,7 @@ name = "kernel_config"
 description = "configuration values and settings used in the Theseus kernel, e.g., timeslices, memory layouts, etc"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/keyboard/Cargo.toml
+++ b/kernel/keyboard/Cargo.toml
@@ -4,6 +4,7 @@ name = "keyboard"
 description = "The keyboard driver"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -115,7 +115,7 @@ pub fn handle_keyboard_input(scan_code: u8, extended: bool) -> Result<(), &'stat
             match keycode {
                 Some(keycode) => {
                     let event = Event::new_keyboard_event(KeyEvent::new(keycode, action, modifiers.clone()));
-                    if let Some(producer) = KEYBOARD_PRODUCER.try() {
+                    if let Some(producer) = KEYBOARD_PRODUCER.r#try() {
                         producer.push(event).map_err(|_e| "keyboard input queue is full")
                     }
                     else {

--- a/kernel/libterm/Cargo.toml
+++ b/kernel/libterm/Cargo.toml
@@ -3,6 +3,7 @@ name = "libterm"
 version = "0.1.0"
 authors = ["Andrew Pham <apham727@gmail.com>", "Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/libterm/src/lib.rs
+++ b/kernel/libterm/src/lib.rs
@@ -30,7 +30,7 @@ extern crate color;
 use core::ops::DerefMut;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use cursor::*;
+use crate::cursor::*;
 use text_display::TextDisplay;
 use displayable::Displayable;
 use event_types::Event;
@@ -422,7 +422,7 @@ impl Terminal {
 impl Terminal {
     /// Creates a new terminal and adds it to the window manager `wm_mutex`
     pub fn new() -> Result<Terminal, &'static str> {
-        let wm_ref = window_manager::WINDOW_MANAGER.try().ok_or("The window manager is not initialized")?;
+        let wm_ref = window_manager::WINDOW_MANAGER.r#try().ok_or("The window manager is not initialized")?;
         let (window_width, window_height) = {
             let wm = wm_ref.lock();
             wm.get_screen_size()

--- a/kernel/libtest/Cargo.toml
+++ b/kernel/libtest/Cargo.toml
@@ -4,6 +4,7 @@ name = "libtest"
 description = "A set of convenience functions that can be used for benchmarking within Theseus."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/logger/Cargo.toml
+++ b/kernel/logger/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "logger"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/logger/src/lib.rs
+++ b/kernel/logger/src/lib.rs
@@ -88,7 +88,7 @@ impl Log for Logger {
         // If there was an error above, there's literally nothing we can do but ignore it,
         // because there is no other lower-level way to log errors than the serial port.
         
-        if let Some(func) = MIRROR_VGA_FUNC.try() {
+        if let Some(func) = MIRROR_VGA_FUNC.r#try() {
             // Currently printing to the VGA terminal doesn't support ANSI color escape sequences,
             // so we exclude the first and the last elements that set those colors.
             func(format_args!("{}{}:{}: {}",

--- a/kernel/madt/Cargo.toml
+++ b/kernel/madt/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "Support for ACPI MADT"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 zerocopy = "0.3.0"

--- a/kernel/mapper_spillful/Cargo.toml
+++ b/kernel/mapper_spillful/Cargo.toml
@@ -4,6 +4,7 @@ name = "mapper_spillful"
 description = "A spillful version of the mapper for the virtual memory subsystem."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 cfg-if = "0.1.6"

--- a/kernel/mapper_spillful/src/lib.rs
+++ b/kernel/mapper_spillful/src/lib.rs
@@ -159,7 +159,7 @@ impl MapperSpillful {
             tlb_flush_virt_addr(page.start_address());
         }
         
-        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.try() {
+        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.r#try() {
             func(pages);
         }
 
@@ -194,7 +194,7 @@ impl MapperSpillful {
             tlb_flush_virt_addr(page.start_address());
         }
         
-        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.try() {
+        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.r#try() {
             func(pages);
         }
 

--- a/kernel/memfs/Cargo.toml
+++ b/kernel/memfs/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Andrew Pham <apham727@gmail.com>, Christine Wang <chrissywang54@gmail.com"]
 description = "contains the MappedPages-backed implementation of the fs_node traits"
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.5"

--- a/kernel/memory/Cargo.toml
+++ b/kernel/memory/Cargo.toml
@@ -4,6 +4,7 @@ name = "memory"
 description = "The virtual memory subsystem."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -61,7 +61,7 @@ pub type MmiRef = Arc<MutexIrqSafe<MemoryManagementInfo>>;
 /// Returns a cloned reference to the kernel's `MemoryManagementInfo`, if initialized.
 /// If not, it returns None.
 pub fn get_kernel_mmi_ref() -> Option<MmiRef> {
-    KERNEL_MMI.try().cloned()
+    KERNEL_MMI.r#try().cloned()
 }
 
 
@@ -77,17 +77,17 @@ pub type FrameAllocatorRef<A: FrameAllocator> = MutexIrqSafe<A>;
 /// 
 /// Currently, the system-wide allocator is an `AreaFrameAllocator` reference.
 pub fn get_frame_allocator_ref() -> Option<&'static FrameAllocatorRef<AreaFrameAllocator>> {
-    FRAME_ALLOCATOR.try()
+    FRAME_ALLOCATOR.r#try()
 }
 
 /// Convenience method for allocating a new Frame.
 pub fn allocate_frame() -> Option<Frame> {
-    FRAME_ALLOCATOR.try().and_then(|fa| fa.lock().allocate_frame())
+    FRAME_ALLOCATOR.r#try().and_then(|fa| fa.lock().allocate_frame())
 }
 
 /// Convenience method for allocating several contiguous Frames.
 pub fn allocate_frames(num_frames: usize) -> Option<FrameRange> {
-    FRAME_ALLOCATOR.try().and_then(|fa| fa.lock().allocate_frames(num_frames))
+    FRAME_ALLOCATOR.r#try().and_then(|fa| fa.lock().allocate_frames(num_frames))
 }
 
 
@@ -141,7 +141,7 @@ pub fn create_mapping(size_in_bytes: usize, flags: EntryFlags) -> Result<MappedP
     let kernel_mmi_ref = get_kernel_mmi_ref().ok_or("create_contiguous_mapping(): KERNEL_MMI was not yet initialized!")?;
     let mut kernel_mmi = kernel_mmi_ref.lock();
 
-    let mut frame_allocator = FRAME_ALLOCATOR.try()
+    let mut frame_allocator = FRAME_ALLOCATOR.r#try()
         .ok_or("create_contiguous_mapping(): couldnt get FRAME_ALLOCATOR")?
         .lock();
     
@@ -256,7 +256,7 @@ pub fn init_post_heap(page_table: PageTable, mut higher_half_mapped_pages: [Opti
     // because they will be auto-unmapped from the new page table upon return, causing all execution to stop.  
 
     page_allocator::convert_to_heap_allocated();
-    FRAME_ALLOCATOR.try().ok_or("BUG: FRAME_ALLOCATOR not initialized")?.lock().alloc_ready();
+    FRAME_ALLOCATOR.r#try().ok_or("BUG: FRAME_ALLOCATOR not initialized")?.lock().alloc_ready();
 
     let mut higher_half_mapped_pages: Vec<MappedPages> = higher_half_mapped_pages.iter_mut().filter_map(|opt| opt.take()).collect();
     higher_half_mapped_pages.push(heap_mapped_pages);

--- a/kernel/memory/src/paging/entry.rs
+++ b/kernel/memory/src/paging/entry.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use super::super::{Frame, EntryFlags};
-use PhysicalAddress;
+use crate::PhysicalAddress;
 use bit_field::BitField;
 use kernel_config::memory::PAGE_SHIFT;
 use zerocopy::FromBytes;

--- a/kernel/memory/src/paging/mapper.rs
+++ b/kernel/memory/src/paging/mapper.rs
@@ -11,9 +11,9 @@ use core::mem;
 use core::ops::Deref;
 use core::ptr::Unique;
 use core::slice;
-use {BROADCAST_TLB_SHOOTDOWN_FUNC, VirtualAddress, PhysicalAddress, get_frame_allocator_ref, FrameRange, Page, Frame, FrameAllocator, AllocatedPages}; 
-use paging::{PageRange, get_current_p4};
-use paging::table::{P4, Table, Level4};
+use crate::{BROADCAST_TLB_SHOOTDOWN_FUNC, VirtualAddress, PhysicalAddress, get_frame_allocator_ref, FrameRange, Page, Frame, FrameAllocator, AllocatedPages}; 
+use crate::paging::{PageRange, get_current_p4};
+use crate::paging::table::{P4, Table, Level4};
 use kernel_config::memory::{ENTRIES_PER_PAGE_TABLE, PAGE_SIZE};
 use irq_safety::MutexIrqSafe;
 use super::{EntryFlags, tlb_flush_virt_addr};
@@ -306,7 +306,7 @@ impl MappedPages {
     pub fn deep_copy<A: FrameAllocator>(&self, new_flags: Option<EntryFlags>, active_table_mapper: &mut Mapper, allocator: &mut A) -> Result<MappedPages, &'static str> {
         let size_in_pages = self.size_in_pages();
 
-        use paging::allocate_pages;
+        use crate::paging::allocate_pages;
         let new_pages = allocate_pages(size_in_pages).ok_or_else(|| "Couldn't allocate_pages()")?;
 
         // we must temporarily map the new pages as Writable, since we're about to copy data into them
@@ -357,7 +357,7 @@ impl MappedPages {
             tlb_flush_virt_addr(page.start_address());
         }
         
-        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.try() {
+        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.r#try() {
             func(self.pages.deref().clone());
         }
 
@@ -391,7 +391,7 @@ impl MappedPages {
     
         #[cfg(not(bm_map))]
         {
-            if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.try() {
+            if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.r#try() {
                 func(self.pages.deref().clone());
             }
         }

--- a/kernel/memory/src/paging/temporary_page.rs
+++ b/kernel/memory/src/paging/temporary_page.rs
@@ -7,8 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use {FrameRange};
-use paging::{PageTable, MappedPages};
+use crate::{FrameRange};
+use crate::paging::{PageTable, MappedPages};
 use super::table::{Table, Level1};
 use super::{Frame, FrameAllocator, VirtualAddress};
 use kernel_config::memory::{TEMPORARY_PAGE_VIRT_ADDR, PAGE_SIZE};

--- a/kernel/memory_initialization/Cargo.toml
+++ b/kernel/memory_initialization/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Ramla Ijaz <ijazramla@gmail.com>"]
 name = "memory_initialization"
 description = "Initialization routine for the virtual memory subsystem."
 version = "0.1.0"
+edition = "2018"
 
 [dependencies]
 multiboot2 = "0.7.1"

--- a/kernel/memory_structs/Cargo.toml
+++ b/kernel/memory_structs/Cargo.toml
@@ -4,6 +4,7 @@ name = "memory_structs"
 description = "Common types used in the memory management subsystem"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 multiboot2 = "0.7.1"

--- a/kernel/memory_x86_64/Cargo.toml
+++ b/kernel/memory_x86_64/Cargo.toml
@@ -4,6 +4,7 @@ name = "memory_x86_64"
 description = "The memory subsystem interfaces on x86_64."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 multiboot2 = "0.7.1"

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -4,6 +4,7 @@ name = "mod_mgmt"
 description = "Module management, including parsing, loading, linking, unloading, and metadata management."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -67,7 +67,7 @@ static INITIAL_KERNEL_NAMESPACE: Once<Arc<CrateNamespace>> = Once::new();
 /// which must exist because it contains the initially-loaded kernel crates. 
 /// Returns None if the default namespace hasn't yet been initialized.
 pub fn get_initial_kernel_namespace() -> Option<&'static Arc<CrateNamespace>> {
-    INITIAL_KERNEL_NAMESPACE.try()
+    INITIAL_KERNEL_NAMESPACE.r#try()
 }
 
 /// Returns the top-level directory that contains all of the namespaces. 

--- a/kernel/mouse/Cargo.toml
+++ b/kernel/mouse/Cargo.toml
@@ -3,6 +3,7 @@ name = "mouse"
 version = "0.1.0"
 authors = ["Bowen Liu <liubowenbob@hotmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -113,7 +113,7 @@ pub fn handle_mouse_input(readdata: u32) -> Result<(), &'static str> {
     // mouse_to_print(&mouse_event);  // use this to debug
     let event = Event::MouseMovementEvent(mouse_event);
 
-    if let Some(producer) = MOUSE_PRODUCER.try() {
+    if let Some(producer) = MOUSE_PRODUCER.r#try() {
         producer.push(event).map_err(|_e| "Fail to enqueue the mouse event")
     } else {
         warn!("handle_keyboard_input(): MOUSE_PRODUCER wasn't yet initialized, dropping keyboard event {:?}.", event);

--- a/kernel/multicore_bringup/Cargo.toml
+++ b/kernel/multicore_bringup/Cargo.toml
@@ -4,6 +4,7 @@ name = "multicore_bringup"
 description = "Support for bringing up other CPU cores (APs) from the main core (BSP)"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/multiple_heaps/Cargo.toml
+++ b/kernel/multiple_heaps/Cargo.toml
@@ -4,6 +4,7 @@ name = "multiple_heaps"
 description = "Allocator which uses multiple heaps"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 intrusive-collections = "0.9.0"

--- a/kernel/multiple_heaps/src/lib.rs
+++ b/kernel/multiple_heaps/src/lib.rs
@@ -376,7 +376,7 @@ if #[cfg(unsafe_heap)] {
         /// # Warning
         /// The new mapped pages must start from the virtual address that the current heap mapped pages end at.
         fn extend_heap_mp(&self, mp: MappedPages) -> Result<(), &'static str> {
-            if let Some(heap_mp) = self.mp.try() {
+            if let Some(heap_mp) = self.mp.r#try() {
                 heap_mp.lock().merge(mp).map_err(|(e, _mp)| e)?;
             } else {
                 self.mp.call_once(|| MutexIrqSafe::new(mp));

--- a/kernel/mutex_sleep/Cargo.toml
+++ b/kernel/mutex_sleep/Cargo.toml
@@ -4,6 +4,7 @@ name = "mutex_sleep"
 description = "A Mutex abstraction that puts a Task to sleep while waiting for the lock"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -5,6 +5,7 @@ description = "The minimalist crate that takes over after the bootloader and is 
 version = "0.1.0"
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/network_interface_card/Cargo.toml
+++ b/kernel/network_interface_card/Cargo.toml
@@ -4,6 +4,7 @@ name = "network_interface_card"
 description = "A set of abstractions for a Network Interface Card"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/network_manager/Cargo.toml
+++ b/kernel/network_manager/Cargo.toml
@@ -4,6 +4,7 @@ name = "network_manager"
 description = "A crate for managing network interfaces"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/nic_buffers/Cargo.toml
+++ b/kernel/nic_buffers/Cargo.toml
@@ -4,6 +4,7 @@ description = "Structs for network transmit and receive buffers"
 version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 owning_ref = { git = "https://github.com/kevinaboos/owning-ref-rs" }

--- a/kernel/nic_initialization/Cargo.toml
+++ b/kernel/nic_initialization/Cargo.toml
@@ -4,6 +4,7 @@ name = "nic_initialization"
 description = "A set of functions used to initialize a Network Interface Card"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 owning_ref = { git = "https://github.com/kevinaboos/owning-ref-rs" }

--- a/kernel/nic_queues/Cargo.toml
+++ b/kernel/nic_queues/Cargo.toml
@@ -4,6 +4,7 @@ description = "Defines structs that hold all information related to nic receive 
 version = "0.1.0"
 authors = ["Ramla-I <ijazramla@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 owning_ref = { git = "https://github.com/kevinaboos/owning-ref-rs" }

--- a/kernel/ota_update_client/Cargo.toml
+++ b/kernel/ota_update_client/Cargo.toml
@@ -4,6 +4,7 @@ name = "ota_update_client"
 description = "Implements network communication with a build server to acquire live updates over the air"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 owning_ref = { git = "https://github.com/kevinaboos/owning-ref-rs" }

--- a/kernel/page_allocator/Cargo.toml
+++ b/kernel/page_allocator/Cargo.toml
@@ -4,6 +4,7 @@ name = "page_allocator"
 description = "The allocator for virtual memory pages."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/page_allocator/src/lib.rs
+++ b/kernel/page_allocator/src/lib.rs
@@ -29,7 +29,7 @@ use core::{borrow::Borrow, cmp::Ordering, fmt, ops::Deref};
 use kernel_config::memory::*;
 use memory_structs::{VirtualAddress, Page, PageRange};
 use spin::Mutex;
-use static_array_rb_tree::*;
+use crate::static_array_rb_tree::*;
 
 
 /// Regions that are pre-designated for special usage, specifically the kernel's initial identity mapping.

--- a/kernel/panic_entry/Cargo.toml
+++ b/kernel/panic_entry/Cargo.toml
@@ -4,6 +4,7 @@ name = "panic_entry"
 description = "Contains the lang items and entry points for panics and other errors/exceptions, as required by the Rust compiler."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/panic_entry/src/lib.rs
+++ b/kernel/panic_entry/src/lib.rs
@@ -17,7 +17,9 @@ extern crate mod_mgmt;
 #[cfg(not(loadable))] extern crate panic_wrapper;
 #[cfg(not(loadable))] extern crate unwind;
 
+#[cfg(not(test))]
 use core::panic::PanicInfo;
+
 
 /// The singular entry point for a language-level panic.
 /// 

--- a/kernel/panic_wrapper/Cargo.toml
+++ b/kernel/panic_wrapper/Cargo.toml
@@ -4,6 +4,7 @@ name = "panic_wrapper"
 description = "Wrapper functions for handling and propagating panics"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/path/Cargo.toml
+++ b/kernel/path/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Andrew Pham <apham727@gmail.com>, Christine Wang <chrissywang54@gmail.com"]
 description = "contains functions for navigating the filesystem / getting pointers to specific directories via the Path struct"
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.5"

--- a/kernel/pci/Cargo.toml
+++ b/kernel/pci/Cargo.toml
@@ -4,6 +4,7 @@ name = "pci"
 description = "Basic PCI support for Theseus, x86 only."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/physical_nic/Cargo.toml
+++ b/kernel/physical_nic/Cargo.toml
@@ -4,6 +4,7 @@ name = "physical_nic"
 description = "A trait that defines functions a physical NIC has to implement to support virtualization"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/pic/Cargo.toml
+++ b/kernel/pic/Cargo.toml
@@ -4,6 +4,7 @@ name = "pic"
 description = "PIC (Programmable Interrupt Controller), support for a legacy device that isn't used much"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 # x86_64 = { git = "https://github.com/kevinaboos/x86_64" }

--- a/kernel/pit_clock/Cargo.toml
+++ b/kernel/pit_clock/Cargo.toml
@@ -4,6 +4,7 @@ name = "pit_clock"
 description = "PIT (Programmable Interval Timer) support for Theseus, x86 only."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/pmu_x86/Cargo.toml
+++ b/kernel/pmu_x86/Cargo.toml
@@ -4,6 +4,7 @@ name = "pmu_x86"
 description = "Diagnostic tools, specifically provides acccess to performance monitoring unit on x86 Nehalem and above."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/pmu_x86/src/lib.rs
+++ b/kernel/pmu_x86/src/lib.rs
@@ -177,11 +177,11 @@ fn num_general_purpose_counters() -> u8 {
 }
 
 fn get_pmcs_available() -> Result<&'static Vec<AtomicU8>, &'static str>{
-    Ok(PMCS_AVAILABLE.try().ok_or("pmu_x86: The variable storing the available counters for each core hasn't been initialized")?)
+    Ok(PMCS_AVAILABLE.r#try().ok_or("pmu_x86: The variable storing the available counters for each core hasn't been initialized")?)
 }
 
 fn get_pmcs_available_for_core(core_id: u8) -> Result<&'static AtomicU8, &'static str>{
-    let pmc = PMCS_AVAILABLE.try().ok_or("pmu_x86: The variable storing the available counters for each core hasn't been initialized")?;
+    let pmc = PMCS_AVAILABLE.r#try().ok_or("pmu_x86: The variable storing the available counters for each core hasn't been initialized")?;
     Ok(&pmc[core_id as usize])
 }
 

--- a/kernel/print/Cargo.toml
+++ b/kernel/print/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Andrew Pham <apham727@gmail.com>"]
 description = "offers kernel crates the ability to print to the default terminal"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/print/src/lib.rs
+++ b/kernel/print/src/lib.rs
@@ -43,7 +43,7 @@ macro_rules! print {
 /// Enqueues the given `fmt_args` as a String onto the default printing output queue,
 /// which is typically the default terminal application's input queue
 pub fn print_to_default_output(fmt_args: fmt::Arguments) {
-    if let Some(q) = DEFAULT_PRINT_OUTPUT.try() {
+    if let Some(q) = DEFAULT_PRINT_OUTPUT.r#try() {
         let _ = q.enqueue(Event::new_output_event(format!("{}", fmt_args)));
     }
 }

--- a/kernel/ps2/Cargo.toml
+++ b/kernel/ps2/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Drivers supporting the PS/2 interface, for legacy keyboard/mouse devices"
 authors = ["Bowen Liu <liubowenbob@hotmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/rendezvous/Cargo.toml
+++ b/kernel/rendezvous/Cargo.toml
@@ -4,6 +4,7 @@ name = "rendezvous"
 description = "Synchronous Inter-Task Communication using a rendezvous approach"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/root/Cargo.toml
+++ b/kernel/root/Cargo.toml
@@ -3,6 +3,7 @@ name = "root"
 version = "0.1.0"
 authors = ["Andrew Pham <apham727@gmail.com>"]
 description = "a special concrete implementation of the Directory trait; differs from VFSDirectory only in that there is no parent field, and any attempt to access a parent field will return some error value"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.5"

--- a/kernel/rsdp/Cargo.toml
+++ b/kernel/rsdp/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "Support for ACPI RSDP"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 owning_ref = { git = "https://github.com/kevinaboos/owning-ref-rs" }

--- a/kernel/rsdt/Cargo.toml
+++ b/kernel/rsdt/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "Support for ACPI RSDT and XSDT"
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/rtc/Cargo.toml
+++ b/kernel/rtc/Cargo.toml
@@ -4,6 +4,7 @@ name = "rtc"
 description = "Support for the Real-time Clock chip on x86 processors"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/runqueue/Cargo.toml
+++ b/kernel/runqueue/Cargo.toml
@@ -4,6 +4,7 @@ name = "runqueue"
 description = "Functions and types for handling runqueues, i.e., lists of tasks for scheduling purposes"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/runqueue_priority/Cargo.toml
+++ b/kernel/runqueue_priority/Cargo.toml
@@ -4,6 +4,7 @@ name = "runqueue_priority"
 description = "Functions and types for handling runqueues when priority scheduler is in use, i.e., lists of tasks for scheduling purposes"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/runqueue_round_robin/Cargo.toml
+++ b/kernel/runqueue_round_robin/Cargo.toml
@@ -4,6 +4,7 @@ name = "runqueue_round_robin"
 description = "Functions and types for handling runqueues, i.e., lists of tasks for scheduling purposes"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/scheduler/Cargo.toml
+++ b/kernel/scheduler/Cargo.toml
@@ -5,6 +5,7 @@ description = "Provides scheduling functionality for selecting the next task and
 version = "0.1.0"
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/scheduler_priority/Cargo.toml
+++ b/kernel/scheduler_priority/Cargo.toml
@@ -4,6 +4,7 @@ name = "scheduler_priority"
 description = "Provides priority scheduling functionality and picks the next task"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/scheduler_round_robin/Cargo.toml
+++ b/kernel/scheduler_round_robin/Cargo.toml
@@ -4,6 +4,7 @@ name = "scheduler_round_robin"
 description = "Provides Round robin scheduling functionality and picks the next task"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/sdt/Cargo.toml
+++ b/kernel/sdt/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "Support for ACPI SDT and other descriptor tables"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 zerocopy = "0.3.0"

--- a/kernel/serial_port/Cargo.toml
+++ b/kernel/serial_port/Cargo.toml
@@ -4,6 +4,7 @@ name = "serial_port"
 description = "Basic driver for the serial port, e.g., COM1, COM2"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies.port_io]
 path = "../../libs/port_io"

--- a/kernel/shapes/Cargo.toml
+++ b/kernel/shapes/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "define the basic shapes used in display subsystem"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/simd_personality/Cargo.toml
+++ b/kernel/simd_personality/Cargo.toml
@@ -4,6 +4,7 @@ name = "simd_personality"
 description = "Support for multiple kernel personalities: SIMD and non-SIMD"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 cfg-if = "0.1.6"

--- a/kernel/simd_test/Cargo.toml
+++ b/kernel/simd_test/Cargo.toml
@@ -4,6 +4,7 @@ name = "simd_test"
 description = "Test code for SIMD instructions"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 cfg-if = "0.1.6"

--- a/kernel/simple_ipc/Cargo.toml
+++ b/kernel/simple_ipc/Cargo.toml
@@ -4,6 +4,7 @@ name = "simple_ipc"
 description = "An extremely basic mechanism for IPC that uses a lock-free shared buffer"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 bit_field = "0.7.0"

--- a/kernel/single_simd_task_optimization/Cargo.toml
+++ b/kernel/single_simd_task_optimization/Cargo.toml
@@ -4,6 +4,7 @@ name = "single_simd_task_optimization"
 description = "Support for a special optimization that allows a SIMD task to avoid saving SIMD registers when context switching, if it is the only SIMD task on its core"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 cfg-if = "0.1.6"

--- a/kernel/slabmalloc/Cargo.toml
+++ b/kernel/slabmalloc/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Gerd Zellweger <mail@gerdzellweger.com>", "Ramla Ijaz <ijazramla@gma
 description = "Simple slab based malloc implementation in rust. Edited to work more closely with Theseus's memory management abstractions"
 
 keywords = ["os", "malloc", "slab", "alloc", "memory"]
+edition = "2018"
 
 [features]
 unstable = []

--- a/kernel/slabmalloc/src/lib.rs
+++ b/kernel/slabmalloc/src/lib.rs
@@ -31,9 +31,9 @@ mod pages;
 mod sc;
 mod zone;
 
-pub use pages::*;
-pub use sc::*;
-pub use zone::*;
+pub use crate::pages::*;
+pub use crate::sc::*;
+pub use crate::zone::*;
 
 use core::alloc::Layout;
 use core::fmt;

--- a/kernel/slabmalloc_safe/Cargo.toml
+++ b/kernel/slabmalloc_safe/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://github.com/gz/rust-slabmalloc"
 license = "MIT"
 
 keywords = ["os", "malloc", "slab", "alloc", "memory"]
+edition = "2018"
 
 [features]
 unstable = []

--- a/kernel/slabmalloc_safe/src/lib.rs
+++ b/kernel/slabmalloc_safe/src/lib.rs
@@ -36,9 +36,9 @@ mod pages;
 mod sc;
 mod zone;
 
-pub use pages::*;
-pub use sc::*;
-pub use zone::*;
+pub use crate::pages::*;
+pub use crate::sc::*;
+pub use crate::zone::*;
 
 use core::alloc::Layout;
 use core::mem;

--- a/kernel/slabmalloc_unsafe/Cargo.toml
+++ b/kernel/slabmalloc_unsafe/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Gerd Zellweger <mail@gerdzellweger.com>", "Ramla Ijaz <ijazramla@gma
 description = "Simple slab based malloc implementation in rust"
 
 keywords = ["os", "malloc", "slab", "alloc", "memory"]
+edition = "2018"
 
 [features]
 unstable = []

--- a/kernel/slabmalloc_unsafe/src/lib.rs
+++ b/kernel/slabmalloc_unsafe/src/lib.rs
@@ -32,9 +32,9 @@ mod pages;
 mod sc;
 mod zone;
 
-pub use pages::*;
-pub use sc::*;
-pub use zone::*;
+pub use crate::pages::*;
+pub use crate::sc::*;
+pub use crate::zone::*;
 
 use core::alloc::Layout;
 use core::fmt;

--- a/kernel/smoltcp_helper/Cargo.toml
+++ b/kernel/smoltcp_helper/Cargo.toml
@@ -4,6 +4,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "helper functions to establish and use a tcp connection with a smoltcp device"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/smoltcp_helper/src/lib.rs
+++ b/kernel/smoltcp_helper/src/lib.rs
@@ -36,7 +36,7 @@ pub fn millis_since(start_time: u64) -> Result<u64, &'static str> {
     const FEMTOSECONDS_PER_MILLISECOND: u64 = 1_000_000_000_000;
     static HPET_PERIOD_FEMTOSECONDS: Once<u32> = Once::new();
 
-    let hpet_freq = match HPET_PERIOD_FEMTOSECONDS.try() {
+    let hpet_freq = match HPET_PERIOD_FEMTOSECONDS.r#try() {
         Some(period) => period,
         _ => {
             let freq = get_hpet().as_ref().ok_or("couldn't get HPET")?.counter_period_femtoseconds();

--- a/kernel/spawn/Cargo.toml
+++ b/kernel/spawn/Cargo.toml
@@ -5,6 +5,7 @@ description = "Functions and wrappers for spawning new Tasks, both kernel thread
 version = "0.1.0"
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/stack/Cargo.toml
+++ b/kernel/stack/Cargo.toml
@@ -4,6 +4,7 @@ name = "stack"
 description = "Defines the Stack type (a task's stack memory) and functions to allocate them"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/stack_trace/Cargo.toml
+++ b/kernel/stack_trace/Cargo.toml
@@ -4,6 +4,7 @@ name = "stack_trace"
 description = "The default stack trace (backtrace) functionality, which uses DWARF debugging info"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 fallible-iterator = { version = "0.2.0", default-features = false }

--- a/kernel/stack_trace_frame_pointers/Cargo.toml
+++ b/kernel/stack_trace_frame_pointers/Cargo.toml
@@ -4,6 +4,7 @@ name = "stack_trace_frame_pointers"
 description = "Stack trace (backtrace) functionality using frame pointers (non-default choice)"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 cfg-if = "0.1.6"

--- a/kernel/state_store/Cargo.toml
+++ b/kernel/state_store/Cargo.toml
@@ -4,6 +4,7 @@ name = "state_store"
 description = "Database-like storage for static, system-wide states, which allows other crates to remain stateless"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 # typemap = "0.3.3"

--- a/kernel/state_store/src/lib.rs
+++ b/kernel/state_store/src/lib.rs
@@ -82,7 +82,7 @@ pub fn init() {
 // /// If the map did not previously have a SystemState of this type, `None` is returned.
 // /// If the map did previously have one, the value is updated, and the old value is returned.
 pub fn insert_state<S: Any>(state: S) -> Option<S> {
-	let old_val: Option<Box<dyn Any>> = SYSTEM_STATE.try().expect("SYSTEM_STATE uninited").0.insert(
+	let old_val: Option<Box<dyn Any>> = SYSTEM_STATE.r#try().expect("SYSTEM_STATE uninited").0.insert(
 		TypeId::of::<S>(), 
 		Box::new( Arc::new(state) ) // Arc<S> is the type that is represented by Any
 	);
@@ -158,7 +158,7 @@ pub fn get_state<S: Any>() -> SSCached<S> {
 
 
 fn get_state_internal<S: Any>() -> Option<Weak<S>> {
-	SYSTEM_STATE.try().expect("SYSTEM_STATE uninited").0
+	SYSTEM_STATE.r#try().expect("SYSTEM_STATE uninited").0
 		.get(&TypeId::of::<S>())                       // get the Option<Arc<Any>> value
 		.and_then( |g| g.downcast_ref::<Arc<S>>())    // if it's Some(g), then downcast g to S
 		.map( |dcast_arc| Arc::downgrade(dcast_arc))  // transform result of downcast to weak ptr

--- a/kernel/state_transfer/Cargo.toml
+++ b/kernel/state_transfer/Cargo.toml
@@ -4,6 +4,7 @@ name = "state_transfer"
 description = "state transfer functions for applying during evolutionary crate swapping"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/state_transfer/src/lib.rs
+++ b/kernel/state_transfer/src/lib.rs
@@ -93,7 +93,7 @@ pub fn prio_sched(_old_namespace: &Arc<CrateNamespace>, _new_namespace: &CrateNa
 
 /// Just like core::convert::From
 trait MyFrom<T>: Sized {
-    fn from(T) -> Self;
+    fn from(_: T) -> Self;
 }
 
 /// Just like core::convert::Into

--- a/kernel/storage_device/Cargo.toml
+++ b/kernel/storage_device/Cargo.toml
@@ -4,6 +4,7 @@ name = "storage_device"
 description = "Traits for storage devices and storage controllers"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/storage_manager/Cargo.toml
+++ b/kernel/storage_manager/Cargo.toml
@@ -4,6 +4,7 @@ name = "storage_manager"
 description = "A crate for managing storage devices/drives"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/task/Cargo.toml
+++ b/kernel/task/Cargo.toml
@@ -4,6 +4,7 @@ name = "task"
 description = "Task types and structure definitions"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 # x86_64 = { git = "https://github.com/kevinaboos/x86_64" }

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -752,7 +752,7 @@ impl TaskRef {
         #[cfg(runqueue_spillful)] 
         {   
             let task_on_rq = { self.0.deref().0.lock().on_runqueue.clone() };
-            if let Some(remove_from_runqueue) = RUNQUEUE_REMOVAL_FUNCTION.try() {
+            if let Some(remove_from_runqueue) = RUNQUEUE_REMOVAL_FUNCTION.r#try() {
                 if let Some(rq) = task_on_rq {
                     remove_from_runqueue(self, rq)?;
                 }

--- a/kernel/task_fs/Cargo.toml
+++ b/kernel/task_fs/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Andrew Pham <apham727@gmail.com>, Christine Wang <chrissywang54@gmail.com"]
 description = "contains the structs VFSDirectory and VFSFile, which are the most basic, generic implementers of the traits Directory and File, respectively. "
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.5"

--- a/kernel/terminal_print/Cargo.toml
+++ b/kernel/terminal_print/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Andrew Pham <apham727@gmail.com>"]
 description = "Offers applications the ability to print to the terminal via the print! and println! macros"
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/tlb_shootdown/Cargo.toml
+++ b/kernel/tlb_shootdown/Cargo.toml
@@ -4,6 +4,7 @@ name = "tlb_shootdown"
 description = "Routines for handling TLB shootdowns"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 # x86_64 = { git = "https://github.com/kevinaboos/x86_64" }

--- a/kernel/tsc/Cargo.toml
+++ b/kernel/tsc/Cargo.toml
@@ -4,6 +4,7 @@ name = "tsc"
 description = "TSC (TimeStamp Counter) support for performance counters on x86. Basically a wrapper around rdtsc."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 # x86_64 = { git = "https://github.com/kevinaboos/x86_64" }

--- a/kernel/tss/Cargo.toml
+++ b/kernel/tss/Cargo.toml
@@ -4,6 +4,7 @@ name = "tss"
 description = "TSS (Task State Segment support (x86 only) for Theseus"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/unified_channel/Cargo.toml
+++ b/kernel/unified_channel/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "A cfg-based wrapper that unifies rendezvous channels and async channels, for evaluation purposes"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 cfg-if = "0.1.6"

--- a/kernel/unwind/Cargo.toml
+++ b/kernel/unwind/Cargo.toml
@@ -4,6 +4,7 @@ name = "unwind"
 description = "Routines for unwinding the call stack and running cleanup handlers for Theseus tasks"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 fallible-iterator = { version = "0.2.0", default-features = false }

--- a/kernel/unwind/src/lib.rs
+++ b/kernel/unwind/src/lib.rs
@@ -72,7 +72,7 @@ use gimli::{
     RegisterRule,
     X86_64
 };
-use registers::{Registers, LandingRegisters, SavedRegs};
+use crate::registers::{Registers, LandingRegisters, SavedRegs};
 use fallible_iterator::FallibleIterator;
 use mod_mgmt::{
     CrateNamespace,

--- a/kernel/unwind/src/lsda.rs
+++ b/kernel/unwind/src/lsda.rs
@@ -5,7 +5,7 @@
 
 use core::ops::Range;
 use gimli::{Reader, DwEhPe, Endianity, EndianSlice, constants::*, };
-use FallibleIterator;
+use crate::FallibleIterator;
 
 /// `GccExceptTableArea` contains the contents of the Language-Specific Data Area (LSDA)
 /// that is used to locate cleanup (run destructors for) a given function during stack unwinding. 

--- a/kernel/vfs_node/Cargo.toml
+++ b/kernel/vfs_node/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Andrew Pham <apham727@gmail.com>, Christine Wang <chrissywang54@gmail.com"]
 description = "contains the structs VFSDirectory and VFSFile, which are the most basic, generic implementers of the traits Directory and File, respectively. "
 
+edition = "2018"
 
 [dependencies]
 spin = "0.4.5"

--- a/kernel/vga_buffer/Cargo.toml
+++ b/kernel/vga_buffer/Cargo.toml
@@ -4,6 +4,7 @@ name = "vga_buffer"
 description = "Support for the simple 80x25 text-only VGA display mode"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/virtual_nic/Cargo.toml
+++ b/kernel/virtual_nic/Cargo.toml
@@ -4,6 +4,7 @@ name = "virtual_nic"
 description = "A structure that contains a subset of physical NIC resources that are sufficient to send/receive packets without kernel mediation."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 

--- a/kernel/wait_condition/Cargo.toml
+++ b/kernel/wait_condition/Cargo.toml
@@ -9,6 +9,7 @@ build = "../../build.rs"
 # [dependencies.log]
 # default-features = false
 # version = "0.4.8"
+edition = "2018"
 
 [dependencies.task]
 path = "../task"

--- a/kernel/wait_queue/Cargo.toml
+++ b/kernel/wait_queue/Cargo.toml
@@ -5,6 +5,7 @@ description = "The WaitQueue type that can block/sleep and wake up tasks"
 version = "0.1.0"
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/window/Cargo.toml
+++ b/kernel/window/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Yue Wu <wuyue16@pku.edu.cn>", "Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "an easy-to-use window object owned by application"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/window/src/lib.rs
+++ b/kernel/window/src/lib.rs
@@ -116,7 +116,7 @@ impl Window {
         height: usize,
         initial_background: Color,
     ) -> Result<Window, &'static str> {
-        let wm_ref = window_manager::WINDOW_MANAGER.try().ok_or("The window manager is not initialized")?;
+        let wm_ref = window_manager::WINDOW_MANAGER.r#try().ok_or("The window manager is not initialized")?;
 
         // Create a new virtual framebuffer to hold this window's contents only,
         // and fill it with the initial background color.
@@ -180,7 +180,7 @@ impl Window {
         let mut need_to_set_active = false;
         let mut need_refresh_three_button = false;
 
-        let wm_ref = window_manager::WINDOW_MANAGER.try().ok_or("The window manager is not initialized")?;
+        let wm_ref = window_manager::WINDOW_MANAGER.r#try().ok_or("The window manager is not initialized")?;
         
         let is_active = {
             let wm = wm_ref.lock();
@@ -337,7 +337,7 @@ impl Window {
             }
         }
 
-        let wm_ref = WINDOW_MANAGER.try().ok_or("The static window manager was not yet initialized")?;
+        let wm_ref = WINDOW_MANAGER.r#try().ok_or("The static window manager was not yet initialized")?;
 
         // Convert the given relative `bounding_box` to an absolute one (relative to the screen, not the window).
         let coordinate = {
@@ -372,7 +372,7 @@ impl Window {
     /// 
     /// Obtains the lock on the window manager instance. 
     pub fn is_active(&self) -> bool {
-        WINDOW_MANAGER.try()
+        WINDOW_MANAGER.r#try()
             .map(|wm| wm.lock().is_active(&self.inner))
             .unwrap_or(false)
     }
@@ -500,7 +500,7 @@ impl Window {
 
 impl Drop for Window{
     fn drop(&mut self){
-        if let Some(wm) = WINDOW_MANAGER.try() {
+        if let Some(wm) = WINDOW_MANAGER.r#try() {
             if let Err(err) = wm.lock().delete_window(&self.inner) {
                 error!("Failed to delete_window upon drop: {:?}", err);
             }

--- a/kernel/window_inner/Cargo.toml
+++ b/kernel/window_inner/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Yue Wu <wuyue16@pku.edu.cn>", "Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "allocate new windows and manage a list of existing windows"
 build = "../../build.rs"
 
+edition = "2018"
 
 [dependencies.mpmc]
 path = "../../libs/mpmc"

--- a/kernel/window_manager/Cargo.toml
+++ b/kernel/window_manager/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Yue Wu <wuyue16@pku.edu.cn>", "Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "allocate new windows and manage a list of existing windows"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.4.10"

--- a/kernel/window_manager/src/lib.rs
+++ b/kernel/window_manager/src/lib.rs
@@ -723,7 +723,7 @@ fn window_manager_loop(
                     }
                     if x != 0 || y != 0 {
                         let mut wm = WINDOW_MANAGER
-                            .try()
+                            .r#try()
                             .ok_or("The static window manager was not yet initialized")?
                             .lock();
                         wm.move_mouse(
@@ -742,7 +742,7 @@ fn window_manager_loop(
 
 /// handle keyboard event, push it to the active window if one exists
 fn keyboard_handle_application(key_input: KeyEvent) -> Result<(), &'static str> {
-    let win_mgr = WINDOW_MANAGER.try().ok_or("The window manager was not yet initialized")?;
+    let win_mgr = WINDOW_MANAGER.r#try().ok_or("The window manager was not yet initialized")?;
     
     // First, we handle keyboard shortcuts understood by the window manager.
     
@@ -818,7 +818,7 @@ fn keyboard_handle_application(key_input: KeyEvent) -> Result<(), &'static str> 
 
 /// handle mouse event, push it to related window or anyone asked for it
 fn cursor_handle_application(mouse_event: MouseEvent) -> Result<(), &'static str> {
-    let wm = WINDOW_MANAGER.try().ok_or("The static window manager was not yet initialized")?.lock();
+    let wm = WINDOW_MANAGER.r#try().ok_or("The static window manager was not yet initialized")?.lock();
     if let Err(_) = wm.pass_mouse_event_to_window(mouse_event) {
         // the mouse event should be passed to the window that satisfies:
         // 1. the mouse position is currently in the window area


### PR DESCRIPTION
I was reading up on editions and wanted to see if Theseus could build on the 2018 edition. After the automated cargo fixes, everything seems to run fine.

I think the `r#try` syntax is quite ugly, and we need to upgrade spin to get rid of it. I have done that in #347 