### PR TITLE
Catch early double faults (e.g., stack overflow) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,8 +677,11 @@ dependencies = [
 name = "exceptions_early"
 version = "0.1.0"
 dependencies = [
+ "gdt",
  "memory",
  "mod_mgmt",
+ "spin",
+ "tss",
  "vga_buffer",
  "x86_64",
 ]

--- a/kernel/exceptions_early/Cargo.toml
+++ b/kernel/exceptions_early/Cargo.toml
@@ -7,6 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+spin = "0.4.10"
 
 [dependencies.memory]
 path = "../memory"
@@ -16,6 +17,12 @@ path = "../vga_buffer"
 
 [dependencies.mod_mgmt]
 path = "../mod_mgmt"
+
+[dependencies.tss]
+path = "../tss"
+
+[dependencies.gdt]
+path = "../gdt"
 
 
 [lib]

--- a/kernel/interrupts/src/lib.rs
+++ b/kernel/interrupts/src/lib.rs
@@ -257,7 +257,6 @@ static EXTENDED_SCANCODE: AtomicBool = AtomicBool::new(false);
 
 /// 0x21
 extern "x86-interrupt" fn ps2_keyboard_handler(_stack_frame: &mut ExceptionStackFrame) {
-	trace!("PS2_PORT keyboard interrupt");
 
     let indicator = ps2::ps2_status_register();
 
@@ -267,7 +266,7 @@ extern "x86-interrupt" fn ps2_keyboard_handler(_stack_frame: &mut ExceptionStack
         if indicator & 0x20 != 0x20 {
             // in this interrupt, we must read the PS2_PORT scancode register before acknowledging the interrupt.
             let scan_code = ps2::ps2_read_data();
-            trace!("PS2_PORT interrupt: raw scan_code {:#X}", scan_code);
+            // trace!("PS2_PORT interrupt: raw scan_code {:#X}", scan_code);
 
 
             let extended = EXTENDED_SCANCODE.load(Ordering::SeqCst);

--- a/kernel/nano_core/src/boot/arch_x86_64/boot.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/boot.asm
@@ -43,6 +43,7 @@ start:
 %endif
 
 	call set_up_page_tables
+	call unmap_guard_page
 	call enable_paging
 
 	; Load the 64-bit GDT
@@ -83,7 +84,7 @@ set_up_page_tables:
 
 .map_kernel_table:
 	mov eax, 0x200000  ; 2MiB
-	mul ecx            ; start address of ecx-th page
+	mul ecx            ; eax now holds the start address of the ecx-th page
 	or eax, 10000011b  ; present + writable + huge
 	mov [(kernel_table - KERNEL_OFFSET) + (ecx * 8)], eax ; map ecx-th entry
 
@@ -110,6 +111,18 @@ set_up_page_tables:
 	jne .map_megabyte_table ; else map the next entry
 
 	ret
+
+
+unmap_guard_page:
+	; put the address of the stack guard huge pages into ecx
+	mov ecx, (initial_bsp_stack_guard_page - 0x200000 - KERNEL_OFFSET)
+	shr ecx, 18      ; calculate p2 index
+	and ecx, 0x1FF  ; get p2 index by itself
+	; ecx now holds the index into the p2 page table of the entry we want to unmap
+	mov eax, 0x0  ; set huge page flag, clear all others
+	mov [(kernel_table - KERNEL_OFFSET) + (ecx)], eax ; unmap (clear) ecx-th entry
+	ret
+
 
 enable_paging:
 	; Enable:
@@ -320,9 +333,10 @@ start_high:
 	call puts
 	pop rdi
 
-	; Give rust the higher half address to the multiboot2 information structure
+	; First argument: the higher half address to the multiboot2 information structure
 	add rdi, KERNEL_OFFSET
-	
+	; Second argument: the higher half address to the multiboot2 information structure
+	mov rsi, initial_double_fault_stack_top
 	call nano_core_start
 
 	; rust main returned, print `OS returned!`
@@ -397,11 +411,20 @@ kernel_table:
 	resb 4096
 
 
+; Note that the linker script (`linker_higher_half.lf`) inserts a 2MiB space here 
+; in order to provide stack guard pages beneath the .stack section afterwards.
+; We don't really *need* to specify the section itself here, but it helps for clarity's sake.
+section .guard_huge_page nobits noalloc noexec nowrite
+
+
 ; Although x86 only requires 16-byte alignment for its stacks, 
 ; we use page alignment (4096B) for convenience and compatibility 
 ; with Theseus's stack abstractions in Rust. 
 ; We place the stack in its own sections for loading/parsing convenience.
 ; Currently, the stack is 16 pages in size, with a guard page beneath the bottom.
+; ---
+; Note that the `initial_bsp_stack_guard_page` is actually mapped by the boot-time page tables,
+; but that's okay because we have real guard pages above. 
 section .stack nobits alloc noexec write  ; same section flags as .bss
 align 4096 
 global initial_bsp_stack_guard_page
@@ -412,3 +435,5 @@ initial_bsp_stack_bottom:
 	resb 4096 * 16
 global initial_bsp_stack_top
 initial_bsp_stack_top:
+	resb 4096
+initial_double_fault_stack_top:

--- a/kernel/nano_core/src/boot/arch_x86_64/boot.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/boot.asm
@@ -120,7 +120,7 @@ unmap_guard_page:
 	and ecx, 0x1FF  ; get p2 index by itself
 	; ecx now holds the index into the p2 page table of the entry we want to unmap
 	mov eax, 0x0  ; set huge page flag, clear all others
-	mov [(kernel_table - KERNEL_OFFSET) + (ecx)], eax ; unmap (clear) ecx-th entry
+	mov [(kernel_table - KERNEL_OFFSET) + ecx], eax ; unmap (clear) ecx-th entry
 	ret
 
 

--- a/kernel/nano_core/src/boot/arch_x86_64/linker_higher_half.ld
+++ b/kernel/nano_core/src/boot/arch_x86_64/linker_higher_half.ld
@@ -57,6 +57,14 @@ SECTIONS {
 		*(.page_table)
 	}
 
+	/* 
+	 * Theseus's boot code uses 2MiB huge pages for its initial mapping,
+	 * so we waste a little bit of address space when setting up stack guard pages
+	 * in order to keep things simple with an easily-compatible 2MiB guard page.
+	 * If we ever use regular 4KiB pages in the boot code, then we can remove/shrink this.
+	 */
+	. = ALIGN(2M);
+	. = . + 2M; /* make space for a 2MiB stack guard page */
 	.stack ALIGN(4K) : AT(ADDR(.stack) - KERNEL_OFFSET)
 	{
 		*(.stack)

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -91,7 +91,10 @@ fn shutdown(msg: core::fmt::Arguments) -> ! {
 /// then change the [`captain::init`](../captain/fn.init.html) routine.
 /// 
 #[no_mangle]
-pub extern "C" fn nano_core_start(multiboot_information_virtual_address: usize) {
+pub extern "C" fn nano_core_start(
+    multiboot_information_virtual_address: usize,
+    early_double_fault_stack_top: usize,
+) {
     println_raw!("Entered nano_core_start()."); 
 	
 	// start the kernel with interrupts disabled
@@ -103,7 +106,7 @@ pub extern "C" fn nano_core_start(multiboot_information_virtual_address: usize) 
     println_raw!("nano_core_start(): initialized logger."); 
 
     // initialize basic exception handlers
-    exceptions_early::init(&EARLY_IDT);
+    exceptions_early::init(&EARLY_IDT, Some(VirtualAddress::new_canonical(early_double_fault_stack_top)));
     println_raw!("nano_core_start(): initialized early IDT with exception handlers."); 
 
     // safety-wise, we have to trust the multiboot address we get from the boot-up asm code, but we can check its validity


### PR DESCRIPTION
We accomplish this via the following:

* Early exceptions use an early GDT and TSS

* A dedicated double fault stack reserved by the boot code

* Specifically unmap the guard pages beneath the early boot code's stack