### PR TITLE
Avoid unaligned memory access in the RSDT/XSDT ACPI tables

### DIFF
--- a/kernel/rsdt/src/lib.rs
+++ b/kernel/rsdt/src/lib.rs
@@ -4,6 +4,13 @@
 //! XSDT is the Extended System Descriptor Table. 
 //! They are identical except that the XSDT uses 64-bit physical addresses
 //! to point to other ACPI SDTs, while the RSDT uses 32-bit physical addresses.
+//!
+//! # Note about alignment
+//! Technically the RSDT contains a list of 32-bit addresses (`u32`) and the XSDT has 64-bit addresses (`u64`),
+//! but the ACPI tables often aren't aligned to 4-byte and 8-byte addresses. 
+//! This lack of alignment causes problems with Rust's slice type, which requires proper alignment.
+//! Thus, we store them as slices of individual bytes (`u8`) and calculate the physical addresses
+//! on demand when requested in the `RsdtXsdt::addresses()` iterator function.
 
 #![no_std]
 
@@ -28,9 +35,10 @@ pub fn handle(
     length: usize,
     phys_addr: PhysicalAddress
 ) -> Result<(), &'static str> {
+    // See the crate-level docs for an explanation of why this is always `u8`.
     let slice_element_size = match &signature {
-        RSDT_SIGNATURE => size_of::<u32>(),
-        XSDT_SIGNATURE => size_of::<u64>(),
+        RSDT_SIGNATURE => size_of::<u8>(),
+        XSDT_SIGNATURE => size_of::<u8>(),
         _ => return Err("unexpected ACPI table signature (not RSDT or XSDT)"),
     };
 
@@ -40,19 +48,29 @@ pub fn handle(
 }
 
 
-/// The Root/Extended System Descriptor Table,
-/// which primarily contains an array of physical addresses
-/// (32-bit if the regular RSDT, 64-bit if the extended XSDT)
+/// The Root/Extended System Descriptor Table, RSDT or XSDT. 
+/// This table primarily contains an array of physical addresses
 /// where other ACPI SDTs can be found.
+///
+/// Use the `addresses()` method to obtain an iterator over those physical addresses.
 pub struct RsdtXsdt<'t>(RsdtOrXsdt<'t>);
+enum RsdtOrXsdt<'t> {
+    /// RSDT, which contains 32-bit addresses.
+    Regular(Rsdt<'t>),
+    /// XSDT, which contains 64-bit addresses.
+    Extended(Xsdt<'t>),
+}
+
+type Rsdt<'t> = (&'t Sdt, &'t [u8]);
+type Xsdt<'t> = (&'t Sdt, &'t [u8]);
 
 impl<'t> RsdtXsdt<'t> {
     /// Finds the RSDT or XSDT in the given `AcpiTables` and returns a reference to it.
     pub fn get(acpi_tables: &'t AcpiTables) -> Option<RsdtXsdt<'t>> {
-        if let (Ok(sdt), Ok(addrs)) = (acpi_tables.table::<Sdt>(&RSDT_SIGNATURE), acpi_tables.table_slice::<u32>(&RSDT_SIGNATURE)) {
+        if let (Ok(sdt), Ok(addrs)) = (acpi_tables.table::<Sdt>(&RSDT_SIGNATURE), acpi_tables.table_slice::<u8>(&RSDT_SIGNATURE)) {
             Some(RsdtXsdt(RsdtOrXsdt::Regular((sdt, addrs))))
         }
-        else if let (Ok(sdt), Ok(addrs)) = (acpi_tables.table::<Sdt>(&XSDT_SIGNATURE), acpi_tables.table_slice::<u64>(&XSDT_SIGNATURE)) {
+        else if let (Ok(sdt), Ok(addrs)) = (acpi_tables.table::<Sdt>(&XSDT_SIGNATURE), acpi_tables.table_slice::<u8>(&XSDT_SIGNATURE)) {
             Some(RsdtXsdt(RsdtOrXsdt::Extended((sdt, addrs))))
         } 
         else {
@@ -71,40 +89,23 @@ impl<'t> RsdtXsdt<'t> {
     /// Returns an iterator over the `PhysicalAddress`es of the SDT entries
     /// included in this RSDT or XSDT.
     pub fn addresses<'r>(&'r self) -> impl Iterator<Item = PhysicalAddress> + 'r {
-        // Ideally, we would do something like this, but Rust doesn't allow match arms to have different types (iterator map closures are types...)
-        // match &self.0 {
-        //     RsdtOrXsdt::Regular(ref r)  => r.1.iter().map(|paddr| PhysicalAddress::new_canonical(*paddr as usize)),
-        //     RsdtOrXsdt::Extended(ref x) => x.1.iter().map(|paddr| PhysicalAddress::new_canonical(*paddr as usize)),
-        // }
-        //
-        // So, instead, we use a little trick inspired by this post:
-        // https://stackoverflow.com/questions/29760668/conditionally-iterate-over-one-of-several-possible-iterators
+        let mut rsdt_iter = None;
+        let mut xsdt_iter = None;
+        match &self.0 {
+            RsdtOrXsdt::Regular(ref rsdt)  => rsdt_iter = Some(
+                rsdt.1.chunks_exact(size_of::<u32>()).map(|bytes| {
+                    let arr = [bytes[0], bytes[1], bytes[2], bytes[3]];
+                    PhysicalAddress::new_canonical(u32::from_le_bytes(arr) as usize)
+                })
+            ),
+            RsdtOrXsdt::Extended(ref xsdt) => xsdt_iter = Some(
+                xsdt.1.chunks_exact(size_of::<u64>()).map(|bytes| {
+                    let arr = [bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]];
+                    PhysicalAddress::new_canonical(usize::from_le_bytes(arr))
+                })
+            ),
+        }
 
-        let r_iter = if let RsdtOrXsdt::Regular(ref r) = self.0 {
-            Some(r.1.iter().map(|paddr| PhysicalAddress::new_canonical(*paddr as usize)))
-        } else {
-            None
-        };
-        let x_iter = if let RsdtOrXsdt::Extended(ref x) = self.0 {
-            Some(x.1.iter().map(|paddr| PhysicalAddress::new_canonical(*paddr as usize)))
-        } else {
-            None
-        };
-        r_iter.into_iter().flatten().chain(x_iter.into_iter().flatten())
+        rsdt_iter.into_iter().flatten().chain(xsdt_iter.into_iter().flatten())
     }
 }
-
-
-/// Either an RSDT or an XSDT. 
-/// The RSDT specifies that there are a variable number of 
-/// 32-bit physical addresses following the SDT header,
-/// while the XSDT is the same but with 64-bit physical addresses.
-enum RsdtOrXsdt<'t> {
-    /// RSDT
-    Regular(Rsdt<'t>),
-    /// XSDT
-    Extended(Xsdt<'t>),
-}
-
-type Rsdt<'t> = (&'t Sdt, &'t [u32]);
-type Xsdt<'t> = (&'t Sdt, &'t [u64]);


### PR DESCRIPTION
Treat the dynamically-sized address part of the RSDT and XSDT ACPI tables as a slice of bytes rather than a slice of unaligned 32-bit/64-bit addresses