### PR TITLE
Upgrade to hashbrown 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
 name = "ap_start"
 version = "0.1.0"
 dependencies = [
@@ -889,12 +895,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.1.8"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
- "byteorder",
- "scopeguard",
+ "ahash",
 ]
 
 [[package]]
@@ -2220,12 +2225,6 @@ dependencies = [
  "spin",
  "task",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 
 [[package]]
 name = "scroll"

--- a/Makefile
+++ b/Makefile
@@ -591,9 +591,8 @@ orun_pause:
 	@qemu-system-x86_64 $(QEMU_FLAGS) -S
 
 
-### Currently, loadable module mode requires release build mode
+### builds and runs Theseus in loadable mode, where all crates are dynamically loaded.
 loadable : export override THESEUS_CONFIG += loadable
-loadable : export BUILD_MODE = release
 loadable: run
 
 

--- a/applications/ping/Cargo.toml
+++ b/applications/ping/Cargo.toml
@@ -23,7 +23,7 @@ path = "../upd"
 path = "../../kernel/hpet"
 
 [dependencies.hashbrown]
-version = "0.1.8"
+version = "0.9.1"
 features = ["nightly"]
 
 [dependencies.network_manager]

--- a/kernel/block_io/Cargo.toml
+++ b/kernel/block_io/Cargo.toml
@@ -15,7 +15,7 @@ features = ["spin_no_std", "nightly"]
 version = "1.2.0"
 
 [dependencies.hashbrown]
-version = "0.1.8"
+version = "0.9.1"
 features = ["nightly"]
 
 [dependencies.storage_device]

--- a/kernel/crate_metadata/Cargo.toml
+++ b/kernel/crate_metadata/Cargo.toml
@@ -24,7 +24,7 @@ features = ["elf64"]
 path = "../../libs/cow_arc"
 
 [dependencies.hashbrown]
-version = "0.1.8"
+version = "0.9.1"
 features = ["nightly"]
 
 [dependencies.memory]

--- a/kernel/crate_swap/Cargo.toml
+++ b/kernel/crate_swap/Cargo.toml
@@ -20,7 +20,7 @@ features = ["spin_no_std", "nightly"]
 version = "1.2.0"
 
 [dependencies.hashbrown]
-version = "0.1.8"
+version = "0.9.1"
 features = ["nightly"]
 
 [dependencies.memory]

--- a/kernel/debug_info/Cargo.toml
+++ b/kernel/debug_info/Cargo.toml
@@ -26,7 +26,7 @@ default-features = false
 features = ["elf64"]
 
 [dependencies.hashbrown]
-version = "0.1.8"
+version = "0.9.1"
 features = ["nightly"]
 
 [dependencies.util]

--- a/kernel/framebuffer_compositor/Cargo.toml
+++ b/kernel/framebuffer_compositor/Cargo.toml
@@ -22,7 +22,7 @@ features = ["spin_no_std", "nightly"]
 version = "1.2.0"
 
 [dependencies.hashbrown]
-version = "0.1.8"
+version = "0.9.1"
 features = ["nightly"]
 
 [lib]

--- a/kernel/ixgbe/Cargo.toml
+++ b/kernel/ixgbe/Cargo.toml
@@ -14,7 +14,7 @@ zerocopy = "0.3.0"
 static_assertions = "1.1.0"
 
 [dependencies.hashbrown]
-version = "0.1.8"
+version = "0.9.1"
 features = ["nightly"]
 
 [dependencies.log]

--- a/kernel/libtest/Cargo.toml
+++ b/kernel/libtest/Cargo.toml
@@ -34,7 +34,7 @@ path = "../hpet"
 path = "../pmu_x86"
 
 [dependencies.hashbrown]
-version = "0.1.8"
+version = "0.9.1"
 features = ["nightly"]
 
 [lib]

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -44,7 +44,7 @@ path = "../root"
 path = "../fs_node"
 
 [dependencies.hashbrown]
-version = "0.1.8"
+version = "0.9.1"
 features = ["nightly"]
 
 [dependencies.vfs_node]

--- a/kernel/multiple_heaps/Cargo.toml
+++ b/kernel/multiple_heaps/Cargo.toml
@@ -43,5 +43,5 @@ path = "../slabmalloc_unsafe"
 path = "../heap"
 
 [dependencies.hashbrown]
-version = "0.1.8"
+version = "0.9.1"
 features = ["nightly"]


### PR DESCRIPTION
Fixes an incorrect alignment debug assertion that existed in version 0.1.8