### PR TITLE
Upgrade spin to version 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "fadt",
  "hpet",
  "ioapic",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "lazy_static",
  "log",
@@ -22,7 +22,7 @@ dependencies = [
  "pit_clock",
  "rsdp",
  "rsdt",
- "spin 0.7.1",
+ "spin 0.9.0",
  "volatile",
 ]
 
@@ -61,14 +61,14 @@ version = "0.1.0"
 dependencies = [
  "apic",
  "interrupts",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "lazy_static",
  "log",
  "memory",
  "scheduler",
  "spawn",
- "spin 0.7.1",
+ "spin 0.9.0",
  "stack",
  "tlb_shootdown",
 ]
@@ -80,7 +80,7 @@ dependencies = [
  "atomic",
  "atomic_linked_list",
  "bit_field 0.7.0",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "lazy_static",
  "log",
@@ -88,7 +88,7 @@ dependencies = [
  "owning_ref",
  "pit_clock",
  "raw-cpuid",
- "spin 0.7.1",
+ "spin 0.9.0",
  "static_assertions",
  "volatile",
  "x86_64",
@@ -107,7 +107,7 @@ dependencies = [
  "log",
  "print",
  "serial_port",
- "spin 0.7.1",
+ "spin 0.9.0",
  "stdio",
  "task",
  "window_manager",
@@ -132,7 +132,7 @@ dependencies = [
  "hpet",
  "log",
  "mpmc",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
  "wait_queue",
 ]
@@ -145,7 +145,7 @@ dependencies = [
  "log",
  "pci",
  "port_io",
- "spin 0.7.1",
+ "spin 0.9.0",
  "storage_device",
 ]
 
@@ -285,7 +285,7 @@ dependencies = [
  "exceptions_full",
  "first_application",
  "interrupts",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "keycodes_ascii",
  "log",
@@ -417,7 +417,7 @@ name = "cow_arc"
 version = "0.1.0"
 dependencies = [
  "owning_ref",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -441,7 +441,7 @@ dependencies = [
  "hashbrown",
  "log",
  "memory",
- "spin 0.7.1",
+ "spin 0.9.0",
  "xmas-elf",
 ]
 
@@ -468,7 +468,7 @@ dependencies = [
  "mod_mgmt",
  "path",
  "qp-trie",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -528,7 +528,7 @@ dependencies = [
  "log",
  "memory",
  "mod_mgmt",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
  "terminal_print",
 ]
@@ -569,7 +569,7 @@ dependencies = [
 name = "dfqueue"
 version = "0.1.0"
 dependencies = [
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -588,7 +588,7 @@ dependencies = [
  "color",
  "framebuffer",
  "shapes",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -603,7 +603,7 @@ dependencies = [
  "apic",
  "intel_ethernet",
  "interrupts",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "lazy_static",
  "log",
@@ -616,7 +616,7 @@ dependencies = [
  "owning_ref",
  "pci",
  "pic",
- "spin 0.7.1",
+ "spin 0.9.0",
  "static_assertions",
  "volatile",
  "x86_64",
@@ -651,7 +651,7 @@ dependencies = [
 name = "ethernet_smoltcp_device"
 version = "0.1.0"
 dependencies = [
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "lazy_static",
  "log",
  "memory",
@@ -686,7 +686,7 @@ dependencies = [
  "gdt",
  "memory",
  "mod_mgmt",
- "spin 0.7.1",
+ "spin 0.9.0",
  "tss",
  "vga_buffer",
  "x86_64",
@@ -748,7 +748,7 @@ name = "fault_log"
 version = "0.1.0"
 dependencies = [
  "apic",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "lazy_static",
  "log",
  "memory",
@@ -771,7 +771,7 @@ dependencies = [
 name = "font"
 version = "0.1.0"
 dependencies = [
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -783,7 +783,7 @@ dependencies = [
  "log",
  "memory_structs",
  "page_table_entry",
- "spin 0.7.1",
+ "spin 0.9.0",
  "static_assertions",
 ]
 
@@ -808,7 +808,7 @@ dependencies = [
  "hashbrown",
  "lazy_static",
  "shapes",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -835,7 +835,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memory",
- "spin 0.7.1",
+ "spin 0.9.0",
  "x86_64",
 ]
 
@@ -849,7 +849,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memory",
- "spin 0.7.1",
+ "spin 0.9.0",
  "tss",
  "x86_64",
 ]
@@ -880,7 +880,7 @@ dependencies = [
  "arrayvec",
  "byteorder",
  "fallible-iterator",
- "stable_deref_trait 1.2.0",
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -907,11 +907,11 @@ name = "heap"
 version = "0.1.0"
 dependencies = [
  "block_allocator",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "log",
  "memory",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -919,10 +919,10 @@ name = "heapfile"
 version = "0.1.0"
 dependencies = [
  "fs_node",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "log",
  "memory",
- "spin 0.7.1",
+ "spin 0.9.0",
  "x86_64",
 ]
 
@@ -944,7 +944,7 @@ dependencies = [
  "memory",
  "owning_ref",
  "sdt",
- "spin 0.7.1",
+ "spin 0.9.0",
  "volatile",
  "zerocopy",
 ]
@@ -1005,7 +1005,7 @@ dependencies = [
  "apic",
  "exceptions_early",
  "gdt",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "keyboard",
  "lazy_static",
@@ -1017,7 +1017,7 @@ dependencies = [
  "port_io",
  "ps2",
  "scheduler",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
  "tlb_shootdown",
  "tss",
@@ -1043,7 +1043,7 @@ dependencies = [
  "log",
  "memory",
  "owning_ref",
- "spin 0.7.1",
+ "spin 0.9.0",
  "volatile",
  "zerocopy",
 ]
@@ -1051,21 +1051,11 @@ dependencies = [
 [[package]]
 name = "irq_safety"
 version = "0.1.1"
-source = "git+https://github.com/kevinaboos/irq_safety#d7903a8f064170fae58a3da477300469faaf28d2"
+source = "git+https://github.com/theseus-os/irq_safety#9c6d7633b0462b645f67b7f9928fdc26646a4c81"
 dependencies = [
  "owning_ref",
- "spin 0.4.10",
- "stable_deref_trait 1.1.1",
-]
-
-[[package]]
-name = "irq_safety"
-version = "0.1.1"
-source = "git+https://github.com/theseus-os/irq_safety#d7903a8f064170fae58a3da477300469faaf28d2"
-dependencies = [
- "owning_ref",
- "spin 0.4.10",
- "stable_deref_trait 1.1.1",
+ "spin 0.9.0",
+ "stable_deref_trait 1.1.1 (git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin)",
 ]
 
 [[package]]
@@ -1088,7 +1078,7 @@ dependencies = [
  "hpet",
  "intel_ethernet",
  "interrupts",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "lazy_static",
  "log",
@@ -1105,7 +1095,7 @@ dependencies = [
  "pit_clock",
  "rand",
  "runqueue",
- "spin 0.7.1",
+ "spin 0.9.0",
  "static_assertions",
  "virtual_nic",
  "volatile",
@@ -1132,7 +1122,7 @@ dependencies = [
  "log",
  "mpmc",
  "ps2",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -1185,7 +1175,7 @@ dependencies = [
  "libterm",
  "log",
  "path",
- "spin 0.7.1",
+ "spin 0.9.0",
  "stdio",
  "task",
 ]
@@ -1239,7 +1229,7 @@ dependencies = [
  "memory",
  "pmu_x86",
  "runqueue",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
  "x86_64",
 ]
@@ -1249,6 +1239,15 @@ name = "linked_list_allocator"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84565678e403453d1a27a0886882b3b271701e65146d972d9d7d9a4c4a0ff498"
+
+[[package]]
+name = "lock_api"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1265,7 +1264,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "serial_port",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -1287,7 +1286,7 @@ dependencies = [
  "acpi_table",
  "apic",
  "ioapic",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "log",
  "memory",
  "pic",
@@ -1306,7 +1305,7 @@ name = "mapper_spillful"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "lazy_static",
  "log",
@@ -1330,10 +1329,10 @@ name = "memfs"
 version = "0.1.0"
 dependencies = [
  "fs_node",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "log",
  "memory",
- "spin 0.7.1",
+ "spin 0.9.0",
  "x86_64",
 ]
 
@@ -1354,7 +1353,7 @@ dependencies = [
  "bit_field 0.7.0",
  "bitflags",
  "frame_allocator",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "lazy_static",
  "log",
@@ -1363,7 +1362,7 @@ dependencies = [
  "multiboot2",
  "page_allocator",
  "page_table_entry",
- "spin 0.7.1",
+ "spin 0.9.0",
  "x86_64",
  "xmas-elf",
  "zerocopy",
@@ -1374,7 +1373,7 @@ name = "memory_initialization"
 version = "0.1.0"
 dependencies = [
  "heap",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "log",
  "memory",
@@ -1457,7 +1456,7 @@ dependencies = [
  "qp-trie",
  "root",
  "rustc-demangle",
- "spin 0.7.1",
+ "spin 0.9.0",
  "util",
  "vfs_node",
  "xmas-elf",
@@ -1472,7 +1471,7 @@ dependencies = [
  "mouse_data",
  "mpmc",
  "ps2",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -1499,7 +1498,7 @@ dependencies = [
  "acpi",
  "ap_start",
  "apic",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "log",
  "madt",
@@ -1507,7 +1506,7 @@ dependencies = [
  "mod_mgmt",
  "pause",
  "pit_clock",
- "spin 0.7.1",
+ "spin 0.9.0",
  "stack",
  "volatile",
  "zerocopy",
@@ -1522,7 +1521,7 @@ dependencies = [
  "hashbrown",
  "heap",
  "intrusive-collections",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "log",
  "memory",
@@ -1530,7 +1529,7 @@ dependencies = [
  "slabmalloc",
  "slabmalloc_safe",
  "slabmalloc_unsafe",
- "spin 0.7.1",
+ "spin 0.9.0",
  "static_assertions",
 ]
 
@@ -1540,8 +1539,8 @@ version = "0.1.0"
 dependencies = [
  "log",
  "owning_ref",
- "spin 0.7.1",
- "stable_deref_trait 1.1.1",
+ "spin 0.9.0",
+ "stable_deref_trait 1.1.1 (git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin)",
  "task",
  "wait_queue",
 ]
@@ -1552,7 +1551,7 @@ version = "0.1.0"
 dependencies = [
  "captain",
  "exceptions_early",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "log",
  "logger",
@@ -1561,7 +1560,7 @@ dependencies = [
  "mod_mgmt",
  "multiboot2",
  "panic_entry",
- "spin 0.7.1",
+ "spin 0.9.0",
  "stack",
  "state_store",
  "vga_buffer",
@@ -1584,7 +1583,7 @@ dependencies = [
  "log",
  "owning_ref",
  "smoltcp",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -1665,7 +1664,7 @@ dependencies = [
  "hpet",
  "http_client",
  "httparse",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "itertools",
  "log",
  "network_manager",
@@ -1681,11 +1680,11 @@ dependencies = [
 
 [[package]]
 name = "owning_ref"
-version = "0.4.0"
-source = "git+https://github.com/theseus-os/owning-ref-rs#ce14b539e3aa891ff463c6f5e28617b27bc2510b"
+version = "0.4.1"
+source = "git+https://github.com/theseus-os/owning-ref-rs#0d2dcdcffd75b80157d0e72fb82593a8696a9c49"
 dependencies = [
- "spin 0.4.10",
- "stable_deref_trait 1.1.1",
+ "spin 0.9.0",
+ "stable_deref_trait 1.1.1 (git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin)",
 ]
 
 [[package]]
@@ -1706,7 +1705,7 @@ dependencies = [
  "kernel_config",
  "log",
  "memory_structs",
- "spin 0.7.1",
+ "spin 0.9.0",
  "static_assertions",
 ]
 
@@ -1755,7 +1754,7 @@ dependencies = [
  "lazy_static",
  "log",
  "root",
- "spin 0.7.1",
+ "spin 0.9.0",
  "vfs_node",
  "x86_64",
 ]
@@ -1772,7 +1771,7 @@ dependencies = [
  "log",
  "memory",
  "port_io",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -1821,7 +1820,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "port_io",
- "spin 0.7.1",
+ "spin 0.9.0",
  "x86_64",
 ]
 
@@ -1857,7 +1856,7 @@ dependencies = [
  "apic",
  "atomic",
  "bit_field 0.10.0",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "lazy_static",
  "log",
  "memory",
@@ -1865,7 +1864,7 @@ dependencies = [
  "pit_clock",
  "port_io",
  "raw-cpuid",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
  "x86_64",
 ]
@@ -1881,7 +1880,7 @@ dependencies = [
  "dfqueue",
  "event_types",
  "log",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -1925,7 +1924,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "port_io",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -2057,10 +2056,10 @@ version = "0.1.0"
 dependencies = [
  "debugit",
  "hpet",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "log",
  "scheduler",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
  "wait_queue",
 ]
@@ -2085,7 +2084,7 @@ dependencies = [
  "fs_node",
  "lazy_static",
  "log",
- "spin 0.7.1",
+ "spin 0.9.0",
  "x86_64",
 ]
 
@@ -2126,12 +2125,12 @@ dependencies = [
 name = "rtc"
 version = "0.1.0"
 dependencies = [
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "lazy_static",
  "log",
  "port_io",
- "spin 0.7.1",
+ "spin 0.9.0",
  "state_store",
  "x86_64",
 ]
@@ -2141,7 +2140,7 @@ name = "runqueue"
 version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "lazy_static",
  "log",
  "runqueue_priority",
@@ -2155,7 +2154,7 @@ name = "runqueue_priority"
 version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "lazy_static",
  "log",
  "single_simd_task_optimization",
@@ -2167,7 +2166,7 @@ name = "runqueue_round_robin"
 version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "lazy_static",
  "log",
  "single_simd_task_optimization",
@@ -2194,12 +2193,12 @@ name = "scheduler"
 version = "0.1.0"
 dependencies = [
  "apic",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "log",
  "runqueue",
  "scheduler_priority",
  "scheduler_round_robin",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
 ]
 
@@ -2221,7 +2220,7 @@ dependencies = [
  "log",
  "runqueue",
  "runqueue_priority",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
 ]
 
@@ -2232,9 +2231,15 @@ dependencies = [
  "log",
  "runqueue",
  "runqueue_round_robin",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"
@@ -2271,7 +2276,7 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 name = "serial_port"
 version = "0.1.0"
 dependencies = [
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "port_io",
 ]
 
@@ -2312,7 +2317,7 @@ dependencies = [
  "runqueue",
  "scheduler",
  "spawn",
- "spin 0.7.1",
+ "spin 0.9.0",
  "stdio",
  "task",
  "terminal_print",
@@ -2403,7 +2408,7 @@ dependencies = [
  "log",
  "network_manager",
  "smoltcp",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -2417,7 +2422,7 @@ dependencies = [
  "fault_crate_swap",
  "fault_log",
  "fs_node",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "lazy_static",
  "log",
  "memory",
@@ -2438,23 +2443,26 @@ checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
 
 [[package]]
 name = "spin"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13287b4da9d1207a4f4929ac390916d64eacfe236a487e9a9f5b3be392be5162"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
-source = "git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin#82478940fa89747f48523bfbcb0ab700fd1cbe7b"
+checksum = "b87bbf98cb81332a56c1ee8929845836f85e8ddd693157c30d76660196014478"
 dependencies = [
- "spin 0.4.10",
+ "lock_api",
 ]
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin#e006c79280042e27c4f16c7d29633eb2273752ee"
+dependencies = [
+ "spin 0.9.0",
+]
 
 [[package]]
 name = "stack"
@@ -2465,7 +2473,7 @@ dependencies = [
  "memory",
  "memory_structs",
  "page_allocator",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -2493,7 +2501,7 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "lazy_static",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -2502,14 +2510,14 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "hpet",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "lazy_static",
  "log",
  "memory",
  "mod_mgmt",
  "runqueue_priority",
  "runqueue_round_robin",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
 ]
 
@@ -2525,7 +2533,7 @@ version = "0.1.0"
 dependencies = [
  "bare-io",
  "keycodes_ascii",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -2537,7 +2545,7 @@ dependencies = [
  "log",
  "owning_ref",
  "pci",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -2549,7 +2557,7 @@ dependencies = [
  "log",
  "owning_ref",
  "pci",
- "spin 0.7.1",
+ "spin 0.9.0",
  "storage_device",
 ]
 
@@ -2609,14 +2617,14 @@ version = "0.1.0"
 dependencies = [
  "context_switch",
  "environment",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "kernel_config",
  "lazy_static",
  "log",
  "memory",
  "mod_mgmt",
  "root",
- "spin 0.7.1",
+ "spin 0.9.0",
  "stack",
  "tss",
  "x86_64",
@@ -2631,7 +2639,7 @@ dependencies = [
  "memory",
  "path",
  "root",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
  "x86_64",
 ]
@@ -2644,7 +2652,7 @@ dependencies = [
  "event_types",
  "lazy_static",
  "serial_port",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
  "x86_64",
 ]
@@ -2660,7 +2668,7 @@ dependencies = [
  "rendezvous",
  "scheduler",
  "spawn",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
  "terminal_print",
 ]
@@ -2683,7 +2691,7 @@ dependencies = [
  "scheduler",
  "shapes",
  "spawn",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
  "terminal_print",
  "unified_channel",
@@ -2707,7 +2715,7 @@ dependencies = [
  "lazy_static",
  "log",
  "spawn",
- "spin 0.7.1",
+ "spin 0.9.0",
  "terminal_print",
 ]
 
@@ -2721,7 +2729,7 @@ dependencies = [
  "framebuffer",
  "framebuffer_printer",
  "shapes",
- "spin 0.7.1",
+ "spin 0.9.0",
 ]
 
 [[package]]
@@ -2729,7 +2737,7 @@ name = "tlb_shootdown"
 version = "0.1.0"
 dependencies = [
  "apic",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "log",
  "memory",
  "pause",
@@ -2754,7 +2762,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memory",
- "spin 0.7.1",
+ "spin 0.9.0",
  "x86_64",
 ]
 
@@ -2840,7 +2848,7 @@ dependencies = [
  "ota_update_client",
  "path",
  "smoltcp",
- "spin 0.7.1",
+ "spin 0.9.0",
  "task",
  "terminal_print",
  "vfs_node",
@@ -2857,7 +2865,7 @@ dependencies = [
  "fs_node",
  "log",
  "memory",
- "spin 0.7.1",
+ "spin 0.9.0",
  "x86_64",
 ]
 
@@ -2867,7 +2875,7 @@ version = "0.1.0"
 dependencies = [
  "kernel_config",
  "serial_port",
- "spin 0.7.1",
+ "spin 0.9.0",
  "volatile",
 ]
 
@@ -2876,7 +2884,7 @@ name = "virtual_nic"
 version = "0.1.0"
 dependencies = [
  "intel_ethernet",
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "network_interface_card",
  "nic_buffers",
  "nic_queues",
@@ -2909,7 +2917,7 @@ dependencies = [
 name = "wait_queue"
 version = "0.1.0"
 dependencies = [
- "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
+ "irq_safety",
  "log",
  "scheduler",
  "task",
@@ -2930,7 +2938,7 @@ dependencies = [
  "path",
  "shapes",
  "spawn",
- "spin 0.7.1",
+ "spin 0.9.0",
  "window_inner",
  "window_manager",
 ]
@@ -2966,7 +2974,7 @@ dependencies = [
  "scheduler",
  "shapes",
  "spawn",
- "spin 0.7.1",
+ "spin 0.9.0",
  "window_inner",
 ]
 
@@ -2976,7 +2984,7 @@ version = "0.1.2"
 dependencies = [
  "bit_field 0.7.0",
  "bitflags",
- "irq_safety 0.1.1 (git+https://github.com/kevinaboos/irq_safety)",
+ "irq_safety",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "fadt",
  "hpet",
  "ioapic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -22,7 +22,7 @@ dependencies = [
  "pit_clock",
  "rsdp",
  "rsdt",
- "spin",
+ "spin 0.7.1",
  "volatile",
 ]
 
@@ -61,14 +61,14 @@ version = "0.1.0"
 dependencies = [
  "apic",
  "interrupts",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
  "memory",
  "scheduler",
  "spawn",
- "spin",
+ "spin 0.7.1",
  "stack",
  "tlb_shootdown",
 ]
@@ -80,7 +80,7 @@ dependencies = [
  "atomic",
  "atomic_linked_list",
  "bit_field 0.7.0",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -88,7 +88,7 @@ dependencies = [
  "owning_ref",
  "pit_clock",
  "raw-cpuid",
- "spin",
+ "spin 0.7.1",
  "static_assertions",
  "volatile",
  "x86_64",
@@ -107,7 +107,7 @@ dependencies = [
  "log",
  "print",
  "serial_port",
- "spin",
+ "spin 0.7.1",
  "stdio",
  "task",
  "window_manager",
@@ -132,7 +132,7 @@ dependencies = [
  "hpet",
  "log",
  "mpmc",
- "spin",
+ "spin 0.7.1",
  "task",
  "wait_queue",
 ]
@@ -145,7 +145,7 @@ dependencies = [
  "log",
  "pci",
  "port_io",
- "spin",
+ "spin 0.7.1",
  "storage_device",
 ]
 
@@ -285,7 +285,7 @@ dependencies = [
  "exceptions_full",
  "first_application",
  "interrupts",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "keycodes_ascii",
  "log",
@@ -417,7 +417,7 @@ name = "cow_arc"
 version = "0.1.0"
 dependencies = [
  "owning_ref",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -441,7 +441,7 @@ dependencies = [
  "hashbrown",
  "log",
  "memory",
- "spin",
+ "spin 0.7.1",
  "xmas-elf",
 ]
 
@@ -468,7 +468,7 @@ dependencies = [
  "mod_mgmt",
  "path",
  "qp-trie",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -528,7 +528,7 @@ dependencies = [
  "log",
  "memory",
  "mod_mgmt",
- "spin",
+ "spin 0.7.1",
  "task",
  "terminal_print",
 ]
@@ -569,7 +569,7 @@ dependencies = [
 name = "dfqueue"
 version = "0.1.0"
 dependencies = [
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -588,7 +588,7 @@ dependencies = [
  "color",
  "framebuffer",
  "shapes",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -603,7 +603,7 @@ dependencies = [
  "apic",
  "intel_ethernet",
  "interrupts",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -616,7 +616,7 @@ dependencies = [
  "owning_ref",
  "pci",
  "pic",
- "spin",
+ "spin 0.7.1",
  "static_assertions",
  "volatile",
  "x86_64",
@@ -651,7 +651,7 @@ dependencies = [
 name = "ethernet_smoltcp_device"
 version = "0.1.0"
 dependencies = [
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "memory",
@@ -686,7 +686,7 @@ dependencies = [
  "gdt",
  "memory",
  "mod_mgmt",
- "spin",
+ "spin 0.7.1",
  "tss",
  "vga_buffer",
  "x86_64",
@@ -748,7 +748,7 @@ name = "fault_log"
 version = "0.1.0"
 dependencies = [
  "apic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "memory",
@@ -771,7 +771,7 @@ dependencies = [
 name = "font"
 version = "0.1.0"
 dependencies = [
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -783,7 +783,7 @@ dependencies = [
  "log",
  "memory_structs",
  "page_table_entry",
- "spin",
+ "spin 0.7.1",
  "static_assertions",
 ]
 
@@ -808,7 +808,7 @@ dependencies = [
  "hashbrown",
  "lazy_static",
  "shapes",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -835,7 +835,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memory",
- "spin",
+ "spin 0.7.1",
  "x86_64",
 ]
 
@@ -849,7 +849,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memory",
- "spin",
+ "spin 0.7.1",
  "tss",
  "x86_64",
 ]
@@ -880,7 +880,7 @@ dependencies = [
  "arrayvec",
  "byteorder",
  "fallible-iterator",
- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stable_deref_trait 1.2.0",
 ]
 
 [[package]]
@@ -907,11 +907,11 @@ name = "heap"
 version = "0.1.0"
 dependencies = [
  "block_allocator",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "log",
  "memory",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -919,10 +919,10 @@ name = "heapfile"
 version = "0.1.0"
 dependencies = [
  "fs_node",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "memory",
- "spin",
+ "spin 0.7.1",
  "x86_64",
 ]
 
@@ -944,7 +944,7 @@ dependencies = [
  "memory",
  "owning_ref",
  "sdt",
- "spin",
+ "spin 0.7.1",
  "volatile",
  "zerocopy",
 ]
@@ -1005,7 +1005,7 @@ dependencies = [
  "apic",
  "exceptions_early",
  "gdt",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "keyboard",
  "lazy_static",
@@ -1017,7 +1017,7 @@ dependencies = [
  "port_io",
  "ps2",
  "scheduler",
- "spin",
+ "spin 0.7.1",
  "task",
  "tlb_shootdown",
  "tss",
@@ -1043,9 +1043,19 @@ dependencies = [
  "log",
  "memory",
  "owning_ref",
- "spin",
+ "spin 0.7.1",
  "volatile",
  "zerocopy",
+]
+
+[[package]]
+name = "irq_safety"
+version = "0.1.1"
+source = "git+https://github.com/kevinaboos/irq_safety#d7903a8f064170fae58a3da477300469faaf28d2"
+dependencies = [
+ "owning_ref",
+ "spin 0.4.10",
+ "stable_deref_trait 1.1.1",
 ]
 
 [[package]]
@@ -1054,8 +1064,8 @@ version = "0.1.1"
 source = "git+https://github.com/theseus-os/irq_safety#d7903a8f064170fae58a3da477300469faaf28d2"
 dependencies = [
  "owning_ref",
- "spin",
- "stable_deref_trait 1.1.1 (git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin)",
+ "spin 0.4.10",
+ "stable_deref_trait 1.1.1",
 ]
 
 [[package]]
@@ -1078,7 +1088,7 @@ dependencies = [
  "hpet",
  "intel_ethernet",
  "interrupts",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -1095,7 +1105,7 @@ dependencies = [
  "pit_clock",
  "rand",
  "runqueue",
- "spin",
+ "spin 0.7.1",
  "static_assertions",
  "virtual_nic",
  "volatile",
@@ -1122,7 +1132,7 @@ dependencies = [
  "log",
  "mpmc",
  "ps2",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -1160,7 +1170,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 dependencies = [
- "spin",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -1175,7 +1185,7 @@ dependencies = [
  "libterm",
  "log",
  "path",
- "spin",
+ "spin 0.7.1",
  "stdio",
  "task",
 ]
@@ -1229,7 +1239,7 @@ dependencies = [
  "memory",
  "pmu_x86",
  "runqueue",
- "spin",
+ "spin 0.7.1",
  "task",
  "x86_64",
 ]
@@ -1255,7 +1265,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "serial_port",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -1277,7 +1287,7 @@ dependencies = [
  "acpi_table",
  "apic",
  "ioapic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "memory",
  "pic",
@@ -1296,7 +1306,7 @@ name = "mapper_spillful"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -1320,10 +1330,10 @@ name = "memfs"
 version = "0.1.0"
 dependencies = [
  "fs_node",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "memory",
- "spin",
+ "spin 0.7.1",
  "x86_64",
 ]
 
@@ -1344,7 +1354,7 @@ dependencies = [
  "bit_field 0.7.0",
  "bitflags",
  "frame_allocator",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -1353,7 +1363,7 @@ dependencies = [
  "multiboot2",
  "page_allocator",
  "page_table_entry",
- "spin",
+ "spin 0.7.1",
  "x86_64",
  "xmas-elf",
  "zerocopy",
@@ -1364,7 +1374,7 @@ name = "memory_initialization"
 version = "0.1.0"
 dependencies = [
  "heap",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "log",
  "memory",
@@ -1447,7 +1457,7 @@ dependencies = [
  "qp-trie",
  "root",
  "rustc-demangle",
- "spin",
+ "spin 0.7.1",
  "util",
  "vfs_node",
  "xmas-elf",
@@ -1462,7 +1472,7 @@ dependencies = [
  "mouse_data",
  "mpmc",
  "ps2",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -1489,7 +1499,7 @@ dependencies = [
  "acpi",
  "ap_start",
  "apic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "log",
  "madt",
@@ -1497,7 +1507,7 @@ dependencies = [
  "mod_mgmt",
  "pause",
  "pit_clock",
- "spin",
+ "spin 0.7.1",
  "stack",
  "volatile",
  "zerocopy",
@@ -1512,7 +1522,7 @@ dependencies = [
  "hashbrown",
  "heap",
  "intrusive-collections",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "log",
  "memory",
@@ -1520,7 +1530,7 @@ dependencies = [
  "slabmalloc",
  "slabmalloc_safe",
  "slabmalloc_unsafe",
- "spin",
+ "spin 0.7.1",
  "static_assertions",
 ]
 
@@ -1530,8 +1540,8 @@ version = "0.1.0"
 dependencies = [
  "log",
  "owning_ref",
- "spin",
- "stable_deref_trait 1.1.1 (git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin)",
+ "spin 0.7.1",
+ "stable_deref_trait 1.1.1",
  "task",
  "wait_queue",
 ]
@@ -1542,7 +1552,7 @@ version = "0.1.0"
 dependencies = [
  "captain",
  "exceptions_early",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "log",
  "logger",
@@ -1551,7 +1561,7 @@ dependencies = [
  "mod_mgmt",
  "multiboot2",
  "panic_entry",
- "spin",
+ "spin 0.7.1",
  "stack",
  "state_store",
  "vga_buffer",
@@ -1574,7 +1584,7 @@ dependencies = [
  "log",
  "owning_ref",
  "smoltcp",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -1655,7 +1665,7 @@ dependencies = [
  "hpet",
  "http_client",
  "httparse",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "itertools",
  "log",
  "network_manager",
@@ -1674,8 +1684,8 @@ name = "owning_ref"
 version = "0.4.0"
 source = "git+https://github.com/theseus-os/owning-ref-rs#ce14b539e3aa891ff463c6f5e28617b27bc2510b"
 dependencies = [
- "spin",
- "stable_deref_trait 1.1.1 (git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin)",
+ "spin 0.4.10",
+ "stable_deref_trait 1.1.1",
 ]
 
 [[package]]
@@ -1696,7 +1706,7 @@ dependencies = [
  "kernel_config",
  "log",
  "memory_structs",
- "spin",
+ "spin 0.7.1",
  "static_assertions",
 ]
 
@@ -1745,7 +1755,7 @@ dependencies = [
  "lazy_static",
  "log",
  "root",
- "spin",
+ "spin 0.7.1",
  "vfs_node",
  "x86_64",
 ]
@@ -1762,7 +1772,7 @@ dependencies = [
  "log",
  "memory",
  "port_io",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -1811,7 +1821,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "port_io",
- "spin",
+ "spin 0.7.1",
  "x86_64",
 ]
 
@@ -1847,7 +1857,7 @@ dependencies = [
  "apic",
  "atomic",
  "bit_field 0.10.0",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "memory",
@@ -1855,7 +1865,7 @@ dependencies = [
  "pit_clock",
  "port_io",
  "raw-cpuid",
- "spin",
+ "spin 0.7.1",
  "task",
  "x86_64",
 ]
@@ -1871,7 +1881,7 @@ dependencies = [
  "dfqueue",
  "event_types",
  "log",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -1915,7 +1925,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "port_io",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -2047,10 +2057,10 @@ version = "0.1.0"
 dependencies = [
  "debugit",
  "hpet",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "scheduler",
- "spin",
+ "spin 0.7.1",
  "task",
  "wait_queue",
 ]
@@ -2075,7 +2085,7 @@ dependencies = [
  "fs_node",
  "lazy_static",
  "log",
- "spin",
+ "spin 0.7.1",
  "x86_64",
 ]
 
@@ -2116,12 +2126,12 @@ dependencies = [
 name = "rtc"
 version = "0.1.0"
 dependencies = [
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
  "port_io",
- "spin",
+ "spin 0.7.1",
  "state_store",
  "x86_64",
 ]
@@ -2131,7 +2141,7 @@ name = "runqueue"
 version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "runqueue_priority",
@@ -2145,7 +2155,7 @@ name = "runqueue_priority"
 version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "single_simd_task_optimization",
@@ -2157,7 +2167,7 @@ name = "runqueue_round_robin"
 version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "single_simd_task_optimization",
@@ -2184,12 +2194,12 @@ name = "scheduler"
 version = "0.1.0"
 dependencies = [
  "apic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "runqueue",
  "scheduler_priority",
  "scheduler_round_robin",
- "spin",
+ "spin 0.7.1",
  "task",
 ]
 
@@ -2211,7 +2221,7 @@ dependencies = [
  "log",
  "runqueue",
  "runqueue_priority",
- "spin",
+ "spin 0.7.1",
  "task",
 ]
 
@@ -2222,7 +2232,7 @@ dependencies = [
  "log",
  "runqueue",
  "runqueue_round_robin",
- "spin",
+ "spin 0.7.1",
  "task",
 ]
 
@@ -2261,7 +2271,7 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 name = "serial_port"
 version = "0.1.0"
 dependencies = [
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "port_io",
 ]
 
@@ -2302,7 +2312,7 @@ dependencies = [
  "runqueue",
  "scheduler",
  "spawn",
- "spin",
+ "spin 0.7.1",
  "stdio",
  "task",
  "terminal_print",
@@ -2393,7 +2403,7 @@ dependencies = [
  "log",
  "network_manager",
  "smoltcp",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -2407,7 +2417,7 @@ dependencies = [
  "fault_crate_swap",
  "fault_log",
  "fs_node",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "memory",
@@ -2427,18 +2437,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
+name = "spin"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+checksum = "13287b4da9d1207a4f4929ac390916d64eacfe236a487e9a9f5b3be392be5162"
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin#82478940fa89747f48523bfbcb0ab700fd1cbe7b"
 dependencies = [
- "spin",
+ "spin 0.4.10",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stack"
@@ -2449,7 +2465,7 @@ dependencies = [
  "memory",
  "memory_structs",
  "page_allocator",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -2477,7 +2493,7 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "lazy_static",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -2486,14 +2502,14 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "hpet",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "memory",
  "mod_mgmt",
  "runqueue_priority",
  "runqueue_round_robin",
- "spin",
+ "spin 0.7.1",
  "task",
 ]
 
@@ -2509,7 +2525,7 @@ version = "0.1.0"
 dependencies = [
  "bare-io",
  "keycodes_ascii",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -2521,7 +2537,7 @@ dependencies = [
  "log",
  "owning_ref",
  "pci",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -2533,7 +2549,7 @@ dependencies = [
  "log",
  "owning_ref",
  "pci",
- "spin",
+ "spin 0.7.1",
  "storage_device",
 ]
 
@@ -2593,14 +2609,14 @@ version = "0.1.0"
 dependencies = [
  "context_switch",
  "environment",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
  "memory",
  "mod_mgmt",
  "root",
- "spin",
+ "spin 0.7.1",
  "stack",
  "tss",
  "x86_64",
@@ -2615,7 +2631,7 @@ dependencies = [
  "memory",
  "path",
  "root",
- "spin",
+ "spin 0.7.1",
  "task",
  "x86_64",
 ]
@@ -2628,7 +2644,7 @@ dependencies = [
  "event_types",
  "lazy_static",
  "serial_port",
- "spin",
+ "spin 0.7.1",
  "task",
  "x86_64",
 ]
@@ -2644,7 +2660,7 @@ dependencies = [
  "rendezvous",
  "scheduler",
  "spawn",
- "spin",
+ "spin 0.7.1",
  "task",
  "terminal_print",
 ]
@@ -2667,7 +2683,7 @@ dependencies = [
  "scheduler",
  "shapes",
  "spawn",
- "spin",
+ "spin 0.7.1",
  "task",
  "terminal_print",
  "unified_channel",
@@ -2691,7 +2707,7 @@ dependencies = [
  "lazy_static",
  "log",
  "spawn",
- "spin",
+ "spin 0.7.1",
  "terminal_print",
 ]
 
@@ -2705,7 +2721,7 @@ dependencies = [
  "framebuffer",
  "framebuffer_printer",
  "shapes",
- "spin",
+ "spin 0.7.1",
 ]
 
 [[package]]
@@ -2713,7 +2729,7 @@ name = "tlb_shootdown"
 version = "0.1.0"
 dependencies = [
  "apic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "memory",
  "pause",
@@ -2738,7 +2754,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memory",
- "spin",
+ "spin 0.7.1",
  "x86_64",
 ]
 
@@ -2824,7 +2840,7 @@ dependencies = [
  "ota_update_client",
  "path",
  "smoltcp",
- "spin",
+ "spin 0.7.1",
  "task",
  "terminal_print",
  "vfs_node",
@@ -2841,7 +2857,7 @@ dependencies = [
  "fs_node",
  "log",
  "memory",
- "spin",
+ "spin 0.7.1",
  "x86_64",
 ]
 
@@ -2851,7 +2867,7 @@ version = "0.1.0"
 dependencies = [
  "kernel_config",
  "serial_port",
- "spin",
+ "spin 0.7.1",
  "volatile",
 ]
 
@@ -2860,7 +2876,7 @@ name = "virtual_nic"
 version = "0.1.0"
 dependencies = [
  "intel_ethernet",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "network_interface_card",
  "nic_buffers",
  "nic_queues",
@@ -2893,7 +2909,7 @@ dependencies = [
 name = "wait_queue"
 version = "0.1.0"
 dependencies = [
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "scheduler",
  "task",
@@ -2914,7 +2930,7 @@ dependencies = [
  "path",
  "shapes",
  "spawn",
- "spin",
+ "spin 0.7.1",
  "window_inner",
  "window_manager",
 ]
@@ -2950,7 +2966,7 @@ dependencies = [
  "scheduler",
  "shapes",
  "spawn",
- "spin",
+ "spin 0.7.1",
  "window_inner",
 ]
 
@@ -2960,7 +2976,7 @@ version = "0.1.2"
 dependencies = [
  "bit_field 0.7.0",
  "bitflags",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/kevinaboos/irq_safety)",
 ]
 
 [[package]]

--- a/applications/app_io/Cargo.toml
+++ b/applications/app_io/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" }
 bare-io = { version = "0.2.1", features = [ "alloc" ] }
 

--- a/applications/app_io/Cargo.toml
+++ b/applications/app_io/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" }
 bare-io = { version = "0.2.1", features = [ "alloc" ] }
 

--- a/applications/deps/Cargo.toml
+++ b/applications/deps/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/applications/deps/Cargo.toml
+++ b/applications/deps/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/applications/deps/src/lib.rs
+++ b/applications/deps/src/lib.rs
@@ -49,7 +49,7 @@ macro_rules! println_log {
 
 static VERBOSE: Once<bool> = Once::new();
 macro_rules! verbose {
-    () => (VERBOSE.try() == Some(&true));
+    () => (VERBOSE.get() == Some(&true));
 }
 
 

--- a/applications/heap_eval/src/lib.rs
+++ b/applications/heap_eval/src/lib.rs
@@ -175,7 +175,7 @@ fn overhead_of_accessing_multiple_heaps_inner() -> Result<u64, &'static str> {
     let hpet = get_hpet(); 
     let start = hpet.as_ref().ok_or("couldn't get HPET timer")?.get_counter();
  
-    let allocator = match ALLOCATOR.try() {
+    let allocator = match ALLOCATOR.get() {
         Some(allocator) => allocator,
         None => {
             error!("Multiple heaps not initialized!");

--- a/applications/heap_eval/src/shbench.rs
+++ b/applications/heap_eval/src/shbench.rs
@@ -91,7 +91,7 @@ fn worker(_:()) {
     // at the beginning, but the time it takes to do this once at the beginning of thread is
     // insignificant compared to the number of iterations we run. It also printed above.
     #[cfg(direct_access_to_multiple_heaps)]
-    let allocator = match ALLOCATOR.try() {
+    let allocator = match ALLOCATOR.get() {
         Some(allocator) => allocator,
         None => {
             error!("Multiple heaps not initialized!");

--- a/applications/heap_eval/src/threadtest.rs
+++ b/applications/heap_eval/src/threadtest.rs
@@ -86,7 +86,7 @@ fn worker(_:()) {
     // at the beginning, but the time it takes to do this once at the beginning of thread is
     // insignificant compared to the number of iterations we run. It also printed above.
     #[cfg(direct_access_to_multiple_heaps)]
-    let allocator = match ALLOCATOR.try() {
+    let allocator = match ALLOCATOR.get() {
         Some(allocator) => allocator,
         None => {
             error!("Multiple heaps not initialized!");

--- a/applications/less/Cargo.toml
+++ b/applications/less/Cargo.toml
@@ -6,7 +6,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.7.1"
+spin = "0.9.0"
 bare-io = { version = "0.2.1", features = [ "alloc" ] }
 
 [dependencies.task]

--- a/applications/less/Cargo.toml
+++ b/applications/less/Cargo.toml
@@ -6,7 +6,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.4.10"
+spin = "0.7.1"
 bare-io = { version = "0.2.1", features = [ "alloc" ] }
 
 [dependencies.task]

--- a/applications/rq_eval/src/lib.rs
+++ b/applications/rq_eval/src/lib.rs
@@ -168,7 +168,7 @@ fn run_single(iterations: usize) -> Result<(), &'static str> {
         #[cfg(runqueue_spillful)] 
         {   
             let task_on_rq = { taskref.lock().on_runqueue.clone() };
-            if let Some(remove_from_runqueue) = task::RUNQUEUE_REMOVAL_FUNCTION.try() {
+            if let Some(remove_from_runqueue) = task::RUNQUEUE_REMOVAL_FUNCTION.get() {
                 if let Some(rq) = task_on_rq {
                     remove_from_runqueue(&taskref, rq)?;
                 }

--- a/applications/shell/Cargo.toml
+++ b/applications/shell/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" }
 bare-io = { version = "0.2.1", features = [ "alloc" ] }
 

--- a/applications/shell/Cargo.toml
+++ b/applications/shell/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" }
 bare-io = { version = "0.2.1", features = [ "alloc" ] }
 

--- a/applications/test_channel/Cargo.toml
+++ b/applications/test_channel/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.terminal_print]
 path = "../../kernel/terminal_print"

--- a/applications/test_channel/Cargo.toml
+++ b/applications/test_channel/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.terminal_print]
 path = "../../kernel/terminal_print"

--- a/applications/test_channel/src/lib.rs
+++ b/applications/test_channel/src/lib.rs
@@ -25,13 +25,13 @@ use spin::Once;
 static VERBOSE: Once<bool> = Once::new();
 #[allow(unused)]
 macro_rules! verbose {
-    () => (VERBOSE.try() == Some(&true));
+    () => (VERBOSE.get() == Some(&true));
 }
 
 static PINNED: Once<bool> = Once::new();
 macro_rules! pin_task {
     ($tb:ident, $cpu:expr) => (
-        if PINNED.try() == Some(&true) {
+        if PINNED.get() == Some(&true) {
             $tb.pin_on_core($cpu)
         } else {
             $tb

--- a/applications/test_downtime/Cargo.toml
+++ b/applications/test_downtime/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.terminal_print]
 path = "../../kernel/terminal_print"

--- a/applications/test_downtime/Cargo.toml
+++ b/applications/test_downtime/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.terminal_print]
 path = "../../kernel/terminal_print"

--- a/applications/test_restartable/Cargo.toml
+++ b/applications/test_restartable/Cargo.toml
@@ -6,7 +6,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 default-features = false

--- a/applications/test_restartable/Cargo.toml
+++ b/applications/test_restartable/Cargo.toml
@@ -6,7 +6,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 default-features = false

--- a/applications/test_wait_queue/Cargo.toml
+++ b/applications/test_wait_queue/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/applications/test_wait_queue/Cargo.toml
+++ b/applications/test_wait_queue/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/applications/upd/Cargo.toml
+++ b/applications/upd/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.itertools]
 version = "0.7.9"

--- a/applications/upd/Cargo.toml
+++ b/applications/upd/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.itertools]
 version = "0.7.9"

--- a/applications/upd/src/lib.rs
+++ b/applications/upd/src/lib.rs
@@ -55,7 +55,7 @@ use ota_update_client::DIFF_FILE_NAME;
 
 static VERBOSE: Once<bool> = Once::new();
 macro_rules! verbose {
-    () => (VERBOSE.try() == Some(&true));
+    () => (VERBOSE.get() == Some(&true));
 }
 
 

--- a/kernel/acpi/Cargo.toml
+++ b/kernel/acpi/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 volatile = "0.2.7"
 
 

--- a/kernel/acpi/Cargo.toml
+++ b/kernel/acpi/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 volatile = "0.2.7"
 
 

--- a/kernel/ap_start/Cargo.toml
+++ b/kernel/ap_start/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.lazy_static]
 features = ["spin_no_std", "nightly"]

--- a/kernel/ap_start/Cargo.toml
+++ b/kernel/ap_start/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.lazy_static]
 features = ["spin_no_std", "nightly"]

--- a/kernel/apic/Cargo.toml
+++ b/kernel/apic/Cargo.toml
@@ -6,14 +6,16 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 volatile = "0.2.7"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 atomic = { version = "0.4.4", features = [ "nightly" ] }
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 bit_field = "0.7.0"
 zerocopy = "0.3.0"
 static_assertions = "1.1.0"
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/apic/Cargo.toml
+++ b/kernel/apic/Cargo.toml
@@ -6,16 +6,14 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 volatile = "0.2.7"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 atomic = { version = "0.4.4", features = [ "nightly" ] }
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 bit_field = "0.7.0"
 zerocopy = "0.3.0"
 static_assertions = "1.1.0"
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -58,7 +58,7 @@ lazy_static! {
 static BSP_PROCESSOR_ID: Once<u8> = Once::new(); 
 
 pub fn get_bsp_id() -> Option<u8> {
-    BSP_PROCESSOR_ID.try().cloned()
+    BSP_PROCESSOR_ID.get().cloned()
 }
 
 /// Returns true if the currently executing processor core is the bootstrap processor, 

--- a/kernel/async_channel/Cargo.toml
+++ b/kernel/async_channel/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 atomic = { version = "0.4.4", features = [ "nightly" ] }
 
 [dependencies.log]

--- a/kernel/async_channel/Cargo.toml
+++ b/kernel/async_channel/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 atomic = { version = "0.4.4", features = [ "nightly" ] }
 
 [dependencies.log]

--- a/kernel/ata/Cargo.toml
+++ b/kernel/ata/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 bitflags = "1.1.0"
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/ata/Cargo.toml
+++ b/kernel/ata/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 bitflags = "1.1.0"
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/crate_metadata/Cargo.toml
+++ b/kernel/crate_metadata/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 
 

--- a/kernel/crate_metadata/Cargo.toml
+++ b/kernel/crate_metadata/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 
 

--- a/kernel/crate_swap/Cargo.toml
+++ b/kernel/crate_swap/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 qp-trie = "0.7.3"
 by_address = "1.0.4"
 

--- a/kernel/crate_swap/Cargo.toml
+++ b/kernel/crate_swap/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 qp-trie = "0.7.3"
 by_address = "1.0.4"
 

--- a/kernel/debug_info/Cargo.toml
+++ b/kernel/debug_info/Cargo.toml
@@ -7,11 +7,9 @@ build = "../../build.rs"
 
 [dependencies]
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 by_address = "1.0.4"
 rustc-demangle = "0.1.14"
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/debug_info/Cargo.toml
+++ b/kernel/debug_info/Cargo.toml
@@ -7,9 +7,11 @@ build = "../../build.rs"
 
 [dependencies]
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 by_address = "1.0.4"
 rustc-demangle = "0.1.14"
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/displayable/Cargo.toml
+++ b/kernel/displayable/Cargo.toml
@@ -6,7 +6,7 @@ description = "provides a Displayable trait, which abstracts objects that can di
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.framebuffer]
 path = "../framebuffer"

--- a/kernel/displayable/Cargo.toml
+++ b/kernel/displayable/Cargo.toml
@@ -6,7 +6,7 @@ description = "provides a Displayable trait, which abstracts objects that can di
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.framebuffer]
 path = "../framebuffer"

--- a/kernel/displayable/text_display/Cargo.toml
+++ b/kernel/displayable/text_display/Cargo.toml
@@ -6,7 +6,7 @@ description = "a text display is a block of text which can display onto a frameb
 build = "../../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.framebuffer]
 path = "../../framebuffer"

--- a/kernel/displayable/text_display/Cargo.toml
+++ b/kernel/displayable/text_display/Cargo.toml
@@ -6,7 +6,7 @@ description = "a text display is a block of text which can display onto a frameb
 build = "../../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.framebuffer]
 path = "../../framebuffer"

--- a/kernel/e1000/Cargo.toml
+++ b/kernel/e1000/Cargo.toml
@@ -6,13 +6,15 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 volatile = "0.2.7"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
 static_assertions = "1.1.0"
 
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/e1000/Cargo.toml
+++ b/kernel/e1000/Cargo.toml
@@ -6,15 +6,13 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 volatile = "0.2.7"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
 static_assertions = "1.1.0"
 
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/e1000/src/lib.rs
+++ b/kernel/e1000/src/lib.rs
@@ -72,7 +72,7 @@ static E1000_NIC: Once<MutexIrqSafe<E1000Nic>> = Once::new();
 /// Returns a reference to the E1000Nic wrapped in a MutexIrqSafe,
 /// if it exists and has been initialized.
 pub fn get_e1000_nic() -> Option<&'static MutexIrqSafe<E1000Nic>> {
-    E1000_NIC.try()
+    E1000_NIC.get()
 }
 
 /// How many ReceiveBuffers are preallocated for this driver to use. 
@@ -422,7 +422,7 @@ impl E1000Nic {
 }
 
 extern "x86-interrupt" fn e1000_handler(_stack_frame: &mut ExceptionStackFrame) {
-    if let Some(ref e1000_nic_ref) = E1000_NIC.try() {
+    if let Some(ref e1000_nic_ref) = E1000_NIC.get() {
         let mut e1000_nic = e1000_nic_ref.lock();
         if let Err(e) = e1000_nic.handle_interrupt() {
             error!("e1000_handler(): error handling interrupt: {:?}", e);

--- a/kernel/e1000/src/test_e1000_driver.rs
+++ b/kernel/e1000/src/test_e1000_driver.rs
@@ -74,6 +74,6 @@ pub fn dhcp_request_packet() -> Result<(), &'static str> {
         let buffer: &mut [u8] = transmit_buffer.as_slice_mut(0, 314)?;
         buffer.copy_from_slice(&packet);
     }
-    let mut e1000_nc = E1000_NIC.try().ok_or("e1000 NIC hasn't been initialized yet")?.lock();
+    let mut e1000_nc = E1000_NIC.get().ok_or("e1000 NIC hasn't been initialized yet")?.lock();
     e1000_nc.send_packet(transmit_buffer)
 }

--- a/kernel/ethernet_smoltcp_device/Cargo.toml
+++ b/kernel/ethernet_smoltcp_device/Cargo.toml
@@ -6,8 +6,10 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/ethernet_smoltcp_device/Cargo.toml
+++ b/kernel/ethernet_smoltcp_device/Cargo.toml
@@ -6,10 +6,8 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/exceptions_early/Cargo.toml
+++ b/kernel/exceptions_early/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/exceptions_early/Cargo.toml
+++ b/kernel/exceptions_early/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/font/Cargo.toml
+++ b/kernel/font/Cargo.toml
@@ -6,7 +6,7 @@ description = "define and initialize the bitmaps of ASCII characters"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/font/Cargo.toml
+++ b/kernel/font/Cargo.toml
@@ -6,7 +6,7 @@ description = "define and initialize the bitmaps of ASCII characters"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/frame_allocator/Cargo.toml
+++ b/kernel/frame_allocator/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 intrusive-collections = "0.9.0"
 static_assertions = "1.1.0"
 

--- a/kernel/frame_allocator/Cargo.toml
+++ b/kernel/frame_allocator/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 intrusive-collections = "0.9.0"
 static_assertions = "1.1.0"
 

--- a/kernel/framebuffer/Cargo.toml
+++ b/kernel/framebuffer/Cargo.toml
@@ -6,8 +6,10 @@ description = "a framebuffer is a buffer of pixels which can be composited to an
 build = "../../build.rs"
 
 [dependencies]
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/framebuffer/Cargo.toml
+++ b/kernel/framebuffer/Cargo.toml
@@ -6,10 +6,8 @@ description = "a framebuffer is a buffer of pixels which can be composited to an
 build = "../../build.rs"
 
 [dependencies]
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/framebuffer_compositor/Cargo.toml
+++ b/kernel/framebuffer_compositor/Cargo.toml
@@ -6,7 +6,7 @@ description = "the framebuffer compositor composites multiple source framebuffer
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.framebuffer]
 path = "../framebuffer"

--- a/kernel/framebuffer_compositor/Cargo.toml
+++ b/kernel/framebuffer_compositor/Cargo.toml
@@ -6,7 +6,7 @@ description = "the framebuffer compositor composites multiple source framebuffer
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.framebuffer]
 path = "../framebuffer"

--- a/kernel/fs_node/Cargo.toml
+++ b/kernel/fs_node/Cargo.toml
@@ -6,7 +6,7 @@ description = "defines the traits for File and Directory. These files and direct
 
 
 [dependencies]
-spin = "0.4.5"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.lazy_static]

--- a/kernel/fs_node/Cargo.toml
+++ b/kernel/fs_node/Cargo.toml
@@ -6,7 +6,7 @@ description = "defines the traits for File and Directory. These files and direct
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.lazy_static]

--- a/kernel/gdt/Cargo.toml
+++ b/kernel/gdt/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 bit_field = "0.7.0"
 bitflags = "1.1.0"

--- a/kernel/gdt/Cargo.toml
+++ b/kernel/gdt/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 bit_field = "0.7.0"
 bitflags = "1.1.0"

--- a/kernel/gdt/src/lib.rs
+++ b/kernel/gdt/src/lib.rs
@@ -55,25 +55,25 @@ pub enum AvailableSegmentSelector {
 pub fn get_segment_selector(selector: AvailableSegmentSelector) -> SegmentSelector {
     let seg: &SegmentSelector = match selector {
         AvailableSegmentSelector::KernelCode => {
-            KERNEL_CODE_SELECTOR.try().expect("KERNEL_CODE_SELECTOR wasn't yet inited!")
+            KERNEL_CODE_SELECTOR.get().expect("KERNEL_CODE_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::KernelData => {
-            KERNEL_DATA_SELECTOR.try().expect("KERNEL_DATA_SELECTOR wasn't yet inited!")
+            KERNEL_DATA_SELECTOR.get().expect("KERNEL_DATA_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::UserCode32 => {
-            USER_CODE_32_SELECTOR.try().expect("USER_CODE_32_SELECTOR wasn't yet inited!")
+            USER_CODE_32_SELECTOR.get().expect("USER_CODE_32_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::UserData32 => {
-            USER_DATA_32_SELECTOR.try().expect("USER_DATA_32_SELECTOR wasn't yet inited!")
+            USER_DATA_32_SELECTOR.get().expect("USER_DATA_32_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::UserCode64 => {
-            USER_CODE_64_SELECTOR.try().expect("USER_CODE_64_SELECTOR wasn't yet inited!")
+            USER_CODE_64_SELECTOR.get().expect("USER_CODE_64_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::UserData64 => {
-            USER_DATA_64_SELECTOR.try().expect("USER_DATA_64_SELECTOR wasn't yet inited!")
+            USER_DATA_64_SELECTOR.get().expect("USER_DATA_64_SELECTOR wasn't yet inited!")
         }
         AvailableSegmentSelector::Tss => {
-            TSS_SELECTOR.try().expect("TSS_SELECTOR wasn't yet inited!")
+            TSS_SELECTOR.get().expect("TSS_SELECTOR wasn't yet inited!")
         }
     };
 

--- a/kernel/heap/Cargo.toml
+++ b/kernel/heap/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"

--- a/kernel/heap/Cargo.toml
+++ b/kernel/heap/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"

--- a/kernel/heap/src/lib.rs
+++ b/kernel/heap/src/lib.rs
@@ -75,7 +75,7 @@ impl Heap {
 unsafe impl GlobalAlloc for Heap {
 
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        match DEFAULT_ALLOCATOR.try() {
+        match DEFAULT_ALLOCATOR.get() {
             Some(allocator) => {
                 allocator.alloc(layout)
             }
@@ -90,7 +90,7 @@ unsafe impl GlobalAlloc for Heap {
             self.initial_allocator.lock().deallocate(ptr, layout);
         }
         else {
-            DEFAULT_ALLOCATOR.try()
+            DEFAULT_ALLOCATOR.get()
                 .expect("Ptr passed to dealloc is not within the initial allocator's range, and another allocator has not been set up")
                 .dealloc(ptr, layout);
         }

--- a/kernel/heapfile/Cargo.toml
+++ b/kernel/heapfile/Cargo.toml
@@ -6,7 +6,7 @@ description = "An implementation of in-memory files, backed by heap memory"
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.fs_node]

--- a/kernel/heapfile/Cargo.toml
+++ b/kernel/heapfile/Cargo.toml
@@ -6,7 +6,7 @@ description = "An implementation of in-memory files, backed by heap memory"
 
 
 [dependencies]
-spin = "0.4.5"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.fs_node]

--- a/kernel/hpet/Cargo.toml
+++ b/kernel/hpet/Cargo.toml
@@ -6,10 +6,12 @@ description = "Support for the x86 HPET: High Precision Event Timer"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 volatile = "0.2.7"
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/hpet/Cargo.toml
+++ b/kernel/hpet/Cargo.toml
@@ -6,12 +6,10 @@ description = "Support for the x86 HPET: High Precision Event Timer"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 volatile = "0.2.7"
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/hpet/src/lib.rs
+++ b/kernel/hpet/src/lib.rs
@@ -33,7 +33,7 @@ static HPET: Once<RwLock<BoxRefMut<MappedPages, Hpet>>> = Once::new();
 /// let counter_val = get_hpet().as_ref().unwrap().get_counter();
 /// ```
 pub fn get_hpet() -> Option<RwLockReadGuard<'static, BoxRefMut<MappedPages, Hpet>>> {
-    HPET.try().map(|h| h.read())
+    HPET.get().map(|h| h.read())
 }
 
 /// Returns a mutable reference to the HPET timer structure, wrapped in an Option,
@@ -43,7 +43,7 @@ pub fn get_hpet() -> Option<RwLockReadGuard<'static, BoxRefMut<MappedPages, Hpet
 /// get_hpet_mut().as_mut().unwrap().enable_counter(true);
 /// ```
 pub fn get_hpet_mut() -> Option<RwLockWriteGuard<'static, BoxRefMut<MappedPages, Hpet>>> {
-    HPET.try().map(|h| h.write())
+    HPET.get().map(|h| h.write())
 }
 
 

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 

--- a/kernel/ioapic/Cargo.toml
+++ b/kernel/ioapic/Cargo.toml
@@ -6,10 +6,12 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 volatile = "0.2.7"
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.lazy_static]
 features = ["spin_no_std", "nightly"]

--- a/kernel/ioapic/Cargo.toml
+++ b/kernel/ioapic/Cargo.toml
@@ -6,12 +6,10 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 volatile = "0.2.7"
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.lazy_static]
 features = ["spin_no_std", "nightly"]

--- a/kernel/ixgbe/Cargo.toml
+++ b/kernel/ixgbe/Cargo.toml
@@ -5,13 +5,15 @@ description = "Driver for the 10 GbE Intel 82599 NIC"
 authors = ["Ramla <ijazramla@gmail.com>"]
 
 [dependencies]
-spin = "0.4.5"
+spin = "0.7.1"
 volatile = "0.2.4"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 bit_field = "0.7.0"
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
 static_assertions = "1.1.0"
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.hashbrown]
 version = "0.9.1"

--- a/kernel/ixgbe/Cargo.toml
+++ b/kernel/ixgbe/Cargo.toml
@@ -5,15 +5,13 @@ description = "Driver for the 10 GbE Intel 82599 NIC"
 authors = ["Ramla <ijazramla@gmail.com>"]
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 volatile = "0.2.4"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 bit_field = "0.7.0"
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
 static_assertions = "1.1.0"
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.hashbrown]
 version = "0.9.1"

--- a/kernel/ixgbe/src/lib.rs
+++ b/kernel/ixgbe/src/lib.rs
@@ -122,7 +122,7 @@ pub static IXGBE_NICS: Once<Vec<MutexIrqSafe<IxgbeNic>>> = Once::new();
 /// Returns a reference to the IxgbeNic wrapped in a MutexIrqSafe, if it exists and has been initialized.
 /// Currently we use the pci location of the device as identification since it should not change after initialization.
 pub fn get_ixgbe_nic(id: PciLocation) -> Result<&'static MutexIrqSafe<IxgbeNic>, &'static str> {
-    let nics = IXGBE_NICS.try().ok_or("Ixgbe NICs weren't initialized")?;
+    let nics = IXGBE_NICS.get().ok_or("Ixgbe NICs weren't initialized")?;
     nics.iter()
         .find( |nic| { nic.lock().dev_id == id } )
         .ok_or("Ixgbe NIC with this ID does not exist")
@@ -130,7 +130,7 @@ pub fn get_ixgbe_nic(id: PciLocation) -> Result<&'static MutexIrqSafe<IxgbeNic>,
 
 /// Returns a reference to the list of all initialized ixgbe NICs
 pub fn get_ixgbe_nics_list() -> Option<&'static Vec<MutexIrqSafe<IxgbeNic>>> {
-    IXGBE_NICS.try()
+    IXGBE_NICS.get()
 }
 
 /// How many ReceiveBuffers are preallocated for this driver to use. 

--- a/kernel/keyboard/Cargo.toml
+++ b/kernel/keyboard/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 
 [dependencies.log]

--- a/kernel/keyboard/Cargo.toml
+++ b/kernel/keyboard/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 
 [dependencies.log]

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -115,7 +115,7 @@ pub fn handle_keyboard_input(scan_code: u8, extended: bool) -> Result<(), &'stat
             match keycode {
                 Some(keycode) => {
                     let event = Event::new_keyboard_event(KeyEvent::new(keycode, action, modifiers.clone()));
-                    if let Some(producer) = KEYBOARD_PRODUCER.try() {
+                    if let Some(producer) = KEYBOARD_PRODUCER.get() {
                         producer.push(event).map_err(|_e| "keyboard input queue is full")
                     }
                     else {

--- a/kernel/libterm/src/lib.rs
+++ b/kernel/libterm/src/lib.rs
@@ -422,7 +422,7 @@ impl Terminal {
 impl Terminal {
     /// Creates a new terminal and adds it to the window manager `wm_mutex`
     pub fn new() -> Result<Terminal, &'static str> {
-        let wm_ref = window_manager::WINDOW_MANAGER.try().ok_or("The window manager is not initialized")?;
+        let wm_ref = window_manager::WINDOW_MANAGER.get().ok_or("The window manager is not initialized")?;
         let (window_width, window_height) = {
             let wm = wm_ref.lock();
             wm.get_screen_size()

--- a/kernel/libtest/Cargo.toml
+++ b/kernel/libtest/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 bit_field = "0.10.0"
 atomic = "0.4.5"

--- a/kernel/libtest/Cargo.toml
+++ b/kernel/libtest/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 bit_field = "0.10.0"
 atomic = "0.4.5"

--- a/kernel/logger/Cargo.toml
+++ b/kernel/logger/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.serial_port]
 path = "../serial_port"

--- a/kernel/logger/Cargo.toml
+++ b/kernel/logger/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.serial_port]
 path = "../serial_port"

--- a/kernel/logger/src/lib.rs
+++ b/kernel/logger/src/lib.rs
@@ -88,7 +88,7 @@ impl Log for Logger {
         // If there was an error above, there's literally nothing we can do but ignore it,
         // because there is no other lower-level way to log errors than the serial port.
         
-        if let Some(func) = MIRROR_VGA_FUNC.try() {
+        if let Some(func) = MIRROR_VGA_FUNC.get() {
             // Currently printing to the VGA terminal doesn't support ANSI color escape sequences,
             // so we exclude the first and the last elements that set those colors.
             func(format_args!("{}{}:{}: {}",

--- a/kernel/mapper_spillful/src/lib.rs
+++ b/kernel/mapper_spillful/src/lib.rs
@@ -156,7 +156,7 @@ impl MapperSpillful {
             tlb_flush_virt_addr(page.start_address());
         }
         
-        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.try() {
+        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.get() {
             func(pages);
         }
 
@@ -189,7 +189,7 @@ impl MapperSpillful {
             tlb_flush_virt_addr(page.start_address());
         }
         
-        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.try() {
+        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.get() {
             func(pages);
         }
 

--- a/kernel/memfs/Cargo.toml
+++ b/kernel/memfs/Cargo.toml
@@ -6,7 +6,7 @@ description = "contains the MappedPages-backed implementation of the fs_node tra
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.fs_node]

--- a/kernel/memfs/Cargo.toml
+++ b/kernel/memfs/Cargo.toml
@@ -6,7 +6,7 @@ description = "contains the MappedPages-backed implementation of the fs_node tra
 
 
 [dependencies]
-spin = "0.4.5"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.fs_node]

--- a/kernel/memory/Cargo.toml
+++ b/kernel/memory/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 bitflags = "1.1.0"
 multiboot2 = "0.10.1"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }

--- a/kernel/memory/Cargo.toml
+++ b/kernel/memory/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 bitflags = "1.1.0"
 multiboot2 = "0.10.1"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -60,7 +60,7 @@ pub type MmiRef = Arc<MutexIrqSafe<MemoryManagementInfo>>;
 /// Returns a cloned reference to the kernel's `MemoryManagementInfo`, if initialized.
 /// If not, it returns None.
 pub fn get_kernel_mmi_ref() -> Option<MmiRef> {
-    KERNEL_MMI.try().cloned()
+    KERNEL_MMI.get().cloned()
 }
 
 

--- a/kernel/memory/src/paging/mapper.rs
+++ b/kernel/memory/src/paging/mapper.rs
@@ -440,7 +440,7 @@ impl MappedPages {
             tlb_flush_virt_addr(page.start_address());
         }
         
-        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.try() {
+        if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.get() {
             func(self.pages.deref().clone());
         }
 
@@ -563,7 +563,7 @@ impl MappedPages {
     
         #[cfg(not(bm_map))]
         {
-            if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.try() {
+            if let Some(func) = BROADCAST_TLB_SHOOTDOWN_FUNC.get() {
                 func(self.pages.deref().clone());
             }
         }

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 rustc-demangle = "0.1.14"
 qp-trie = "0.7.3"

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 rustc-demangle = "0.1.14"
 qp-trie = "0.7.3"

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -67,7 +67,7 @@ static INITIAL_KERNEL_NAMESPACE: Once<Arc<CrateNamespace>> = Once::new();
 /// which must exist because it contains the initially-loaded kernel crates. 
 /// Returns None if the default namespace hasn't yet been initialized.
 pub fn get_initial_kernel_namespace() -> Option<&'static Arc<CrateNamespace>> {
-    INITIAL_KERNEL_NAMESPACE.try()
+    INITIAL_KERNEL_NAMESPACE.get()
 }
 
 /// Returns the top-level directory that contains all of the namespaces. 

--- a/kernel/mouse/Cargo.toml
+++ b/kernel/mouse/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Bowen Liu <liubowenbob@hotmail.com>"]
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 
 [dependencies.log]

--- a/kernel/mouse/Cargo.toml
+++ b/kernel/mouse/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Bowen Liu <liubowenbob@hotmail.com>"]
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 
 [dependencies.log]

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -113,7 +113,7 @@ pub fn handle_mouse_input(readdata: u32) -> Result<(), &'static str> {
     // mouse_to_print(&mouse_event);  // use this to debug
     let event = Event::MouseMovementEvent(mouse_event);
 
-    if let Some(producer) = MOUSE_PRODUCER.try() {
+    if let Some(producer) = MOUSE_PRODUCER.get() {
         producer.push(event).map_err(|_e| "Fail to enqueue the mouse event")
     } else {
         warn!("handle_keyboard_input(): MOUSE_PRODUCER wasn't yet initialized, dropping keyboard event {:?}.", event);

--- a/kernel/multicore_bringup/Cargo.toml
+++ b/kernel/multicore_bringup/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 volatile = "0.2.7"
 zerocopy = "0.3.0"
 

--- a/kernel/multicore_bringup/Cargo.toml
+++ b/kernel/multicore_bringup/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 volatile = "0.2.7"
 zerocopy = "0.3.0"
 

--- a/kernel/multiple_heaps/Cargo.toml
+++ b/kernel/multiple_heaps/Cargo.toml
@@ -9,7 +9,7 @@ build = "../../build.rs"
 intrusive-collections = "0.9.0"
 static_assertions = "1.1.0"
 cfg-if = "0.1.6"
-spin = "0.4.10"
+spin = "0.7.1"
 
 
 [dependencies.irq_safety]

--- a/kernel/multiple_heaps/Cargo.toml
+++ b/kernel/multiple_heaps/Cargo.toml
@@ -9,7 +9,7 @@ build = "../../build.rs"
 intrusive-collections = "0.9.0"
 static_assertions = "1.1.0"
 cfg-if = "0.1.6"
-spin = "0.7.1"
+spin = "0.9.0"
 
 
 [dependencies.irq_safety]

--- a/kernel/multiple_heaps/src/lib.rs
+++ b/kernel/multiple_heaps/src/lib.rs
@@ -372,7 +372,7 @@ if #[cfg(unsafe_heap)] {
         /// # Warning
         /// The new mapped pages must start from the virtual address that the current heap mapped pages end at.
         fn extend_heap_mp(&self, mp: MappedPages) -> Result<(), &'static str> {
-            if let Some(heap_mp) = self.mp.try() {
+            if let Some(heap_mp) = self.mp.get() {
                 heap_mp.lock().merge(mp).map_err(|(e, _mp)| e)?;
             } else {
                 self.mp.call_once(|| MutexIrqSafe::new(mp));

--- a/kernel/mutex_sleep/Cargo.toml
+++ b/kernel/mutex_sleep/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/mutex_sleep/Cargo.toml
+++ b/kernel/mutex_sleep/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 multiboot2 = "0.10.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 

--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 multiboot2 = "0.10.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 

--- a/kernel/network_manager/Cargo.toml
+++ b/kernel/network_manager/Cargo.toml
@@ -6,9 +6,11 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
+spin = "0.7.1"
 
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/network_manager/Cargo.toml
+++ b/kernel/network_manager/Cargo.toml
@@ -6,11 +6,9 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/nic_buffers/Cargo.toml
+++ b/kernel/nic_buffers/Cargo.toml
@@ -6,8 +6,10 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
 
 [dependencies]
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/nic_buffers/Cargo.toml
+++ b/kernel/nic_buffers/Cargo.toml
@@ -6,10 +6,8 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 build = "../../build.rs"
 
 [dependencies]
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/nic_initialization/Cargo.toml
+++ b/kernel/nic_initialization/Cargo.toml
@@ -6,10 +6,8 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 volatile = "0.2.7"
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/nic_initialization/Cargo.toml
+++ b/kernel/nic_initialization/Cargo.toml
@@ -6,8 +6,10 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 volatile = "0.2.7"
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/nic_queues/Cargo.toml
+++ b/kernel/nic_queues/Cargo.toml
@@ -6,7 +6,9 @@ authors = ["Ramla-I <ijazramla@gmail.com>"]
 build = "../../build.rs"
 
 [dependencies]
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/nic_queues/Cargo.toml
+++ b/kernel/nic_queues/Cargo.toml
@@ -6,9 +6,7 @@ authors = ["Ramla-I <ijazramla@gmail.com>"]
 build = "../../build.rs"
 
 [dependencies]
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/ota_update_client/Cargo.toml
+++ b/kernel/ota_update_client/Cargo.toml
@@ -6,10 +6,12 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 httparse = { version = "1.3.3", default-features = false }
 sha3 = { version = "0.8.1", default-features = false }
 
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/ota_update_client/Cargo.toml
+++ b/kernel/ota_update_client/Cargo.toml
@@ -6,12 +6,10 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 httparse = { version = "1.3.3", default-features = false }
 sha3 = { version = "0.8.1", default-features = false }
 
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/page_allocator/Cargo.toml
+++ b/kernel/page_allocator/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 intrusive-collections = "0.9.0"
 static_assertions = "1.1.0"
 

--- a/kernel/page_allocator/Cargo.toml
+++ b/kernel/page_allocator/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 intrusive-collections = "0.9.0"
 static_assertions = "1.1.0"
 

--- a/kernel/page_allocator/src/lib.rs
+++ b/kernel/page_allocator/src/lib.rs
@@ -398,7 +398,7 @@ fn find_any_chunk<'list>(
 	list: &'list mut StaticArrayRBTree<Chunk>,
 	num_pages: usize
 ) -> Result<(AllocatedPages, DeferredAllocAction<'static>), AllocationError> {
-	let designated_low_end = DESIGNATED_PAGES_LOW_END.try().ok_or(AllocationError::NotInitialized)?;
+	let designated_low_end = DESIGNATED_PAGES_LOW_END.get().ok_or(AllocationError::NotInitialized)?;
 
 	// During the first pass, we ignore designated regions.
 	match list.0 {

--- a/kernel/path/Cargo.toml
+++ b/kernel/path/Cargo.toml
@@ -6,7 +6,7 @@ description = "contains functions for navigating the filesystem / getting pointe
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.lazy_static]

--- a/kernel/path/Cargo.toml
+++ b/kernel/path/Cargo.toml
@@ -6,7 +6,7 @@ description = "contains functions for navigating the filesystem / getting pointe
 
 
 [dependencies]
-spin = "0.4.5"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.lazy_static]

--- a/kernel/pci/Cargo.toml
+++ b/kernel/pci/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 bit_field = "0.7.0"
 
 [dependencies.log]

--- a/kernel/pci/Cargo.toml
+++ b/kernel/pci/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 bit_field = "0.7.0"
 
 [dependencies.log]

--- a/kernel/pit_clock/Cargo.toml
+++ b/kernel/pit_clock/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.log]

--- a/kernel/pit_clock/Cargo.toml
+++ b/kernel/pit_clock/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.log]

--- a/kernel/pmu_x86/Cargo.toml
+++ b/kernel/pmu_x86/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 bit_field = "0.10.0"
 atomic = "0.4.5"

--- a/kernel/pmu_x86/Cargo.toml
+++ b/kernel/pmu_x86/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 bit_field = "0.10.0"
 atomic = "0.4.5"

--- a/kernel/pmu_x86/src/lib.rs
+++ b/kernel/pmu_x86/src/lib.rs
@@ -177,11 +177,11 @@ fn num_general_purpose_counters() -> u8 {
 }
 
 fn get_pmcs_available() -> Result<&'static Vec<AtomicU8>, &'static str>{
-    Ok(PMCS_AVAILABLE.try().ok_or("pmu_x86: The variable storing the available counters for each core hasn't been initialized")?)
+    Ok(PMCS_AVAILABLE.get().ok_or("pmu_x86: The variable storing the available counters for each core hasn't been initialized")?)
 }
 
 fn get_pmcs_available_for_core(core_id: u8) -> Result<&'static AtomicU8, &'static str>{
-    let pmc = PMCS_AVAILABLE.try().ok_or("pmu_x86: The variable storing the available counters for each core hasn't been initialized")?;
+    let pmc = PMCS_AVAILABLE.get().ok_or("pmu_x86: The variable storing the available counters for each core hasn't been initialized")?;
     Ok(&pmc[core_id as usize])
 }
 

--- a/kernel/print/Cargo.toml
+++ b/kernel/print/Cargo.toml
@@ -6,7 +6,7 @@ description = "offers kernel crates the ability to print to the default terminal
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 
 [dependencies.dfqueue]

--- a/kernel/print/Cargo.toml
+++ b/kernel/print/Cargo.toml
@@ -6,7 +6,7 @@ description = "offers kernel crates the ability to print to the default terminal
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 
 [dependencies.dfqueue]

--- a/kernel/print/src/lib.rs
+++ b/kernel/print/src/lib.rs
@@ -43,7 +43,7 @@ macro_rules! print {
 /// Enqueues the given `fmt_args` as a String onto the default printing output queue,
 /// which is typically the default terminal application's input queue
 pub fn print_to_default_output(fmt_args: fmt::Arguments) {
-    if let Some(q) = DEFAULT_PRINT_OUTPUT.try() {
+    if let Some(q) = DEFAULT_PRINT_OUTPUT.get() {
         let _ = q.enqueue(Event::new_output_event(format!("{}", fmt_args)));
     }
 }

--- a/kernel/ps2/Cargo.toml
+++ b/kernel/ps2/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Bowen Liu <liubowenbob@hotmail.com>"]
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/ps2/Cargo.toml
+++ b/kernel/ps2/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Bowen Liu <liubowenbob@hotmail.com>"]
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/rendezvous/Cargo.toml
+++ b/kernel/rendezvous/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/rendezvous/Cargo.toml
+++ b/kernel/rendezvous/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/root/Cargo.toml
+++ b/kernel/root/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Andrew Pham <apham727@gmail.com>"]
 description = "a special concrete implementation of the Directory trait; differs from VFSDirectory only in that there is no parent field, and any attempt to access a parent field will return some error value"
 
 [dependencies]
-spin = "0.4.5"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.lazy_static]

--- a/kernel/root/Cargo.toml
+++ b/kernel/root/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Andrew Pham <apham727@gmail.com>"]
 description = "a special concrete implementation of the Directory trait; differs from VFSDirectory only in that there is no parent field, and any attempt to access a parent field will return some error value"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.lazy_static]

--- a/kernel/rsdp/Cargo.toml
+++ b/kernel/rsdp/Cargo.toml
@@ -6,8 +6,10 @@ description = "Support for ACPI RSDP"
 build = "../../build.rs"
 
 [dependencies]
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/rsdp/Cargo.toml
+++ b/kernel/rsdp/Cargo.toml
@@ -6,10 +6,8 @@ description = "Support for ACPI RSDP"
 build = "../../build.rs"
 
 [dependencies]
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/rtc/Cargo.toml
+++ b/kernel/rtc/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" }
 
 [dependencies.lazy_static]

--- a/kernel/rtc/Cargo.toml
+++ b/kernel/rtc/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" }
 
 [dependencies.lazy_static]

--- a/kernel/scheduler/Cargo.toml
+++ b/kernel/scheduler/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/scheduler/Cargo.toml
+++ b/kernel/scheduler/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/scheduler_priority/Cargo.toml
+++ b/kernel/scheduler_priority/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/scheduler_priority/Cargo.toml
+++ b/kernel/scheduler_priority/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/scheduler_round_robin/Cargo.toml
+++ b/kernel/scheduler_round_robin/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/scheduler_round_robin/Cargo.toml
+++ b/kernel/scheduler_round_robin/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/smoltcp_helper/Cargo.toml
+++ b/kernel/smoltcp_helper/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/smoltcp_helper/Cargo.toml
+++ b/kernel/smoltcp_helper/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/smoltcp_helper/src/lib.rs
+++ b/kernel/smoltcp_helper/src/lib.rs
@@ -36,7 +36,7 @@ pub fn millis_since(start_time: u64) -> Result<u64, &'static str> {
     const FEMTOSECONDS_PER_MILLISECOND: u64 = 1_000_000_000_000;
     static HPET_PERIOD_FEMTOSECONDS: Once<u32> = Once::new();
 
-    let hpet_freq = match HPET_PERIOD_FEMTOSECONDS.try() {
+    let hpet_freq = match HPET_PERIOD_FEMTOSECONDS.get() {
         Some(period) => period,
         _ => {
             let freq = get_hpet().as_ref().ok_or("couldn't get HPET")?.counter_period_femtoseconds();

--- a/kernel/stack/Cargo.toml
+++ b/kernel/stack/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/stack/Cargo.toml
+++ b/kernel/stack/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/state_store/Cargo.toml
+++ b/kernel/state_store/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 # typemap = "0.3.3"
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.lazy_static]
 features = ["spin_no_std", "nightly"]

--- a/kernel/state_store/Cargo.toml
+++ b/kernel/state_store/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 # typemap = "0.3.3"
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.lazy_static]
 features = ["spin_no_std", "nightly"]

--- a/kernel/state_store/src/lib.rs
+++ b/kernel/state_store/src/lib.rs
@@ -82,7 +82,7 @@ pub fn init() {
 // /// If the map did not previously have a SystemState of this type, `None` is returned.
 // /// If the map did previously have one, the value is updated, and the old value is returned.
 pub fn insert_state<S: Any>(state: S) -> Option<S> {
-	let old_val: Option<Box<dyn Any>> = SYSTEM_STATE.try().expect("SYSTEM_STATE uninited").0.insert(
+	let old_val: Option<Box<dyn Any>> = SYSTEM_STATE.get().expect("SYSTEM_STATE uninited").0.insert(
 		TypeId::of::<S>(), 
 		Box::new( Arc::new(state) ) // Arc<S> is the type that is represented by Any
 	);
@@ -158,7 +158,7 @@ pub fn get_state<S: Any>() -> SSCached<S> {
 
 
 fn get_state_internal<S: Any>() -> Option<Weak<S>> {
-	SYSTEM_STATE.try().expect("SYSTEM_STATE uninited").0
+	SYSTEM_STATE.get().expect("SYSTEM_STATE uninited").0
 		.get(&TypeId::of::<S>())                       // get the Option<Arc<Any>> value
 		.and_then( |g| g.downcast_ref::<Arc<S>>())    // if it's Some(g), then downcast g to S
 		.map( |dcast_arc| Arc::downgrade(dcast_arc))  // transform result of downcast to weak ptr

--- a/kernel/state_transfer/Cargo.toml
+++ b/kernel/state_transfer/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 
 [dependencies.log]

--- a/kernel/state_transfer/Cargo.toml
+++ b/kernel/state_transfer/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 
 [dependencies.log]

--- a/kernel/storage_device/Cargo.toml
+++ b/kernel/storage_device/Cargo.toml
@@ -6,11 +6,9 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 downcast-rs = "1.0.4"
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/storage_device/Cargo.toml
+++ b/kernel/storage_device/Cargo.toml
@@ -6,9 +6,11 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
+spin = "0.7.1"
 downcast-rs = "1.0.4"
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/storage_manager/Cargo.toml
+++ b/kernel/storage_manager/Cargo.toml
@@ -6,9 +6,11 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
+spin = "0.7.1"
 
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/storage_manager/Cargo.toml
+++ b/kernel/storage_manager/Cargo.toml
@@ -6,11 +6,9 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/task/Cargo.toml
+++ b/kernel/task/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.log]

--- a/kernel/task/Cargo.toml
+++ b/kernel/task/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.log]

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -742,7 +742,7 @@ impl TaskRef {
         #[cfg(runqueue_spillful)] 
         {   
             let task_on_rq = { self.0.deref().0.lock().on_runqueue.clone() };
-            if let Some(remove_from_runqueue) = RUNQUEUE_REMOVAL_FUNCTION.try() {
+            if let Some(remove_from_runqueue) = RUNQUEUE_REMOVAL_FUNCTION.get() {
                 if let Some(rq) = task_on_rq {
                     remove_from_runqueue(self, rq)?;
                 }

--- a/kernel/task_fs/Cargo.toml
+++ b/kernel/task_fs/Cargo.toml
@@ -6,7 +6,7 @@ description = "contains the structs VFSDirectory and VFSFile, which are the most
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.log]

--- a/kernel/task_fs/Cargo.toml
+++ b/kernel/task_fs/Cargo.toml
@@ -6,7 +6,7 @@ description = "contains the structs VFSDirectory and VFSFile, which are the most
 
 
 [dependencies]
-spin = "0.4.5"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.log]

--- a/kernel/terminal_print/Cargo.toml
+++ b/kernel/terminal_print/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" }
 
 [dependencies.dfqueue]

--- a/kernel/terminal_print/Cargo.toml
+++ b/kernel/terminal_print/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" }
 
 [dependencies.dfqueue]

--- a/kernel/tss/Cargo.toml
+++ b/kernel/tss/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 

--- a/kernel/tss/Cargo.toml
+++ b/kernel/tss/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 

--- a/kernel/vfs_node/Cargo.toml
+++ b/kernel/vfs_node/Cargo.toml
@@ -6,7 +6,7 @@ description = "contains the structs VFSDirectory and VFSFile, which are the most
 
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.log]

--- a/kernel/vfs_node/Cargo.toml
+++ b/kernel/vfs_node/Cargo.toml
@@ -6,7 +6,7 @@ description = "contains the structs VFSDirectory and VFSFile, which are the most
 
 
 [dependencies]
-spin = "0.4.5"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 [dependencies.log]

--- a/kernel/vga_buffer/Cargo.toml
+++ b/kernel/vga_buffer/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.volatile]
 version = "0.2.7"

--- a/kernel/vga_buffer/Cargo.toml
+++ b/kernel/vga_buffer/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.volatile]
 version = "0.2.7"

--- a/kernel/window/Cargo.toml
+++ b/kernel/window/Cargo.toml
@@ -6,10 +6,8 @@ description = "an easy-to-use window object owned by application"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
+spin = "0.9.0"
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/window/Cargo.toml
+++ b/kernel/window/Cargo.toml
@@ -6,8 +6,10 @@ description = "an easy-to-use window object owned by application"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
+spin = "0.7.1"
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/window/src/lib.rs
+++ b/kernel/window/src/lib.rs
@@ -116,7 +116,7 @@ impl Window {
         height: usize,
         initial_background: Color,
     ) -> Result<Window, &'static str> {
-        let wm_ref = window_manager::WINDOW_MANAGER.try().ok_or("The window manager is not initialized")?;
+        let wm_ref = window_manager::WINDOW_MANAGER.get().ok_or("The window manager is not initialized")?;
 
         // Create a new virtual framebuffer to hold this window's contents only,
         // and fill it with the initial background color.
@@ -180,7 +180,7 @@ impl Window {
         let mut need_to_set_active = false;
         let mut need_refresh_three_button = false;
 
-        let wm_ref = window_manager::WINDOW_MANAGER.try().ok_or("The window manager is not initialized")?;
+        let wm_ref = window_manager::WINDOW_MANAGER.get().ok_or("The window manager is not initialized")?;
         
         let is_active = {
             let wm = wm_ref.lock();
@@ -337,7 +337,7 @@ impl Window {
             }
         }
 
-        let wm_ref = WINDOW_MANAGER.try().ok_or("The static window manager was not yet initialized")?;
+        let wm_ref = WINDOW_MANAGER.get().ok_or("The static window manager was not yet initialized")?;
 
         // Convert the given relative `bounding_box` to an absolute one (relative to the screen, not the window).
         let coordinate = {
@@ -372,7 +372,7 @@ impl Window {
     /// 
     /// Obtains the lock on the window manager instance. 
     pub fn is_active(&self) -> bool {
-        WINDOW_MANAGER.try()
+        WINDOW_MANAGER.get()
             .map(|wm| wm.lock().is_active(&self.inner))
             .unwrap_or(false)
     }
@@ -500,7 +500,7 @@ impl Window {
 
 impl Drop for Window{
     fn drop(&mut self){
-        if let Some(wm) = WINDOW_MANAGER.try() {
+        if let Some(wm) = WINDOW_MANAGER.get() {
             if let Err(err) = wm.lock().delete_window(&self.inner) {
                 error!("Failed to delete_window upon drop: {:?}", err);
             }

--- a/kernel/window_manager/Cargo.toml
+++ b/kernel/window_manager/Cargo.toml
@@ -6,7 +6,7 @@ description = "allocate new windows and manage a list of existing windows"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/window_manager/Cargo.toml
+++ b/kernel/window_manager/Cargo.toml
@@ -6,7 +6,7 @@ description = "allocate new windows and manage a list of existing windows"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/window_manager/src/lib.rs
+++ b/kernel/window_manager/src/lib.rs
@@ -723,7 +723,7 @@ fn window_manager_loop(
                     }
                     if x != 0 || y != 0 {
                         let mut wm = WINDOW_MANAGER
-                            .try()
+                            .get()
                             .ok_or("The static window manager was not yet initialized")?
                             .lock();
                         wm.move_mouse(
@@ -742,7 +742,7 @@ fn window_manager_loop(
 
 /// handle keyboard event, push it to the active window if one exists
 fn keyboard_handle_application(key_input: KeyEvent) -> Result<(), &'static str> {
-    let win_mgr = WINDOW_MANAGER.try().ok_or("The window manager was not yet initialized")?;
+    let win_mgr = WINDOW_MANAGER.get().ok_or("The window manager was not yet initialized")?;
     
     // First, we handle keyboard shortcuts understood by the window manager.
     
@@ -818,7 +818,7 @@ fn keyboard_handle_application(key_input: KeyEvent) -> Result<(), &'static str> 
 
 /// handle mouse event, push it to related window or anyone asked for it
 fn cursor_handle_application(mouse_event: MouseEvent) -> Result<(), &'static str> {
-    let wm = WINDOW_MANAGER.try().ok_or("The static window manager was not yet initialized")?.lock();
+    let wm = WINDOW_MANAGER.get().ok_or("The static window manager was not yet initialized")?.lock();
     if let Err(_) = wm.pass_mouse_event_to_window(mouse_event) {
         // the mouse event should be passed to the window that satisfies:
         // 1. the mouse position is currently in the window area

--- a/libs/atomic_linked_list/Cargo.toml
+++ b/libs/atomic_linked_list/Cargo.toml
@@ -4,7 +4,7 @@ name = "atomic_linked_list"
 version = "0.1.0"
 
 [dependencies]
-# spin = "0.4.5"
+# spin = "0.7.1"
 # debugit = "0.1.2"
 
 # [dependencies.lazy_static]

--- a/libs/atomic_linked_list/Cargo.toml
+++ b/libs/atomic_linked_list/Cargo.toml
@@ -4,7 +4,6 @@ name = "atomic_linked_list"
 version = "0.1.0"
 
 [dependencies]
-# spin = "0.7.1"
 # debugit = "0.1.2"
 
 # [dependencies.lazy_static]

--- a/libs/cow_arc/Cargo.toml
+++ b/libs/cow_arc/Cargo.toml
@@ -7,5 +7,5 @@ categories = ["no-std", "memory-management"]
 license = "MIT"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }

--- a/libs/cow_arc/Cargo.toml
+++ b/libs/cow_arc/Cargo.toml
@@ -7,5 +7,5 @@ categories = ["no-std", "memory-management"]
 license = "MIT"
 
 [dependencies]
-spin = "0.4.5"
+spin = "0.7.1"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }

--- a/libs/stdio/Cargo.toml
+++ b/libs/stdio/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 bare-io = { version = "0.2.1", features = [ "alloc" ] }
 
 [dependencies.keycodes_ascii]

--- a/libs/stdio/Cargo.toml
+++ b/libs/stdio/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 bare-io = { version = "0.2.1", features = [ "alloc" ] }
 
 [dependencies.keycodes_ascii]

--- a/old_crates/dbus/Cargo.toml
+++ b/old_crates/dbus/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 
 
 [dependencies.log]

--- a/old_crates/dbus/Cargo.toml
+++ b/old_crates/dbus/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 
 
 [dependencies.log]

--- a/old_crates/spawn_userspace/Cargo.toml
+++ b/old_crates/spawn_userspace/Cargo.toml
@@ -7,10 +7,8 @@ build = "../../build.rs"
 
 [dependencies]
 atomic = { version = "0.4.4", features = [ "nightly" ] }
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/old_crates/spawn_userspace/Cargo.toml
+++ b/old_crates/spawn_userspace/Cargo.toml
@@ -7,8 +7,10 @@ build = "../../build.rs"
 
 [dependencies]
 atomic = { version = "0.4.4", features = [ "nightly" ] }
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 
+
+[dependencies.owning_ref]
+git = "https://github.com/theseus-os/owning-ref-rs.git"
 
 [dependencies.log]
 version = "0.4.8"

--- a/old_crates/syscall/Cargo.toml
+++ b/old_crates/syscall/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.4.10"
+spin = "0.7.1"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 

--- a/old_crates/syscall/Cargo.toml
+++ b/old_crates/syscall/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-spin = "0.7.1"
+spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 
 


### PR DESCRIPTION
Including all other submodule repos that depend on spin.

cc and thanks to @pingiun, this is a continuation of their PR #347