### PR TITLE
Force the `pause` instruction to be used in spinlocks and other busy-wait loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "fadt",
  "hpet",
  "ioapic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -61,7 +61,7 @@ version = "0.1.0"
 dependencies = [
  "apic",
  "interrupts",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -80,7 +80,7 @@ dependencies = [
  "atomic",
  "atomic_linked_list",
  "bit_field 0.7.0",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -285,7 +285,7 @@ dependencies = [
  "exceptions_full",
  "first_application",
  "interrupts",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "keycodes_ascii",
  "log",
@@ -569,7 +569,7 @@ dependencies = [
 name = "dfqueue"
 version = "0.1.0"
 dependencies = [
- "spin 0.9.0",
+ "spin 0.4.10",
 ]
 
 [[package]]
@@ -603,7 +603,7 @@ dependencies = [
  "apic",
  "intel_ethernet",
  "interrupts",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -651,7 +651,7 @@ dependencies = [
 name = "ethernet_smoltcp_device"
 version = "0.1.0"
 dependencies = [
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "memory",
@@ -748,7 +748,7 @@ name = "fault_log"
 version = "0.1.0"
 dependencies = [
  "apic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "memory",
@@ -907,7 +907,7 @@ name = "heap"
 version = "0.1.0"
 dependencies = [
  "block_allocator",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "log",
  "memory",
@@ -919,7 +919,7 @@ name = "heapfile"
 version = "0.1.0"
 dependencies = [
  "fs_node",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "memory",
  "spin 0.9.0",
@@ -1005,7 +1005,7 @@ dependencies = [
  "apic",
  "exceptions_early",
  "gdt",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "keyboard",
  "lazy_static",
@@ -1051,6 +1051,16 @@ dependencies = [
 [[package]]
 name = "irq_safety"
 version = "0.1.1"
+source = "git+https://github.com/kevinaboos/irq_safety#9c6d7633b0462b645f67b7f9928fdc26646a4c81"
+dependencies = [
+ "owning_ref",
+ "spin 0.9.0",
+ "stable_deref_trait 1.1.1 (git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin)",
+]
+
+[[package]]
+name = "irq_safety"
+version = "0.1.1"
 source = "git+https://github.com/theseus-os/irq_safety#9c6d7633b0462b645f67b7f9928fdc26646a4c81"
 dependencies = [
  "owning_ref",
@@ -1078,7 +1088,7 @@ dependencies = [
  "hpet",
  "intel_ethernet",
  "interrupts",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -1286,7 +1296,7 @@ dependencies = [
  "acpi_table",
  "apic",
  "ioapic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "memory",
  "pic",
@@ -1305,7 +1315,7 @@ name = "mapper_spillful"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -1329,7 +1339,7 @@ name = "memfs"
 version = "0.1.0"
 dependencies = [
  "fs_node",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "memory",
  "spin 0.9.0",
@@ -1353,7 +1363,7 @@ dependencies = [
  "bit_field 0.7.0",
  "bitflags",
  "frame_allocator",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -1373,7 +1383,7 @@ name = "memory_initialization"
 version = "0.1.0"
 dependencies = [
  "heap",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "log",
  "memory",
@@ -1498,7 +1508,7 @@ dependencies = [
  "acpi",
  "ap_start",
  "apic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "log",
  "madt",
@@ -1521,7 +1531,7 @@ dependencies = [
  "hashbrown",
  "heap",
  "intrusive-collections",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "log",
  "memory",
@@ -1551,7 +1561,7 @@ version = "0.1.0"
 dependencies = [
  "captain",
  "exceptions_early",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "log",
  "logger",
@@ -1664,7 +1674,7 @@ dependencies = [
  "hpet",
  "http_client",
  "httparse",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "itertools",
  "log",
  "network_manager",
@@ -1856,7 +1866,7 @@ dependencies = [
  "apic",
  "atomic",
  "bit_field 0.10.0",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "memory",
@@ -2056,7 +2066,7 @@ version = "0.1.0"
 dependencies = [
  "debugit",
  "hpet",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "scheduler",
  "spin 0.9.0",
@@ -2125,7 +2135,7 @@ dependencies = [
 name = "rtc"
 version = "0.1.0"
 dependencies = [
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -2140,7 +2150,7 @@ name = "runqueue"
 version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "runqueue_priority",
@@ -2154,7 +2164,7 @@ name = "runqueue_priority"
 version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "single_simd_task_optimization",
@@ -2166,7 +2176,7 @@ name = "runqueue_round_robin"
 version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "single_simd_task_optimization",
@@ -2193,7 +2203,7 @@ name = "scheduler"
 version = "0.1.0"
 dependencies = [
  "apic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "runqueue",
  "scheduler_priority",
@@ -2276,7 +2286,7 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 name = "serial_port"
 version = "0.1.0"
 dependencies = [
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "port_io",
 ]
 
@@ -2422,7 +2432,7 @@ dependencies = [
  "fault_crate_swap",
  "fault_log",
  "fs_node",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "memory",
@@ -2444,8 +2454,7 @@ checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
 [[package]]
 name = "spin"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87bbf98cb81332a56c1ee8929845836f85e8ddd693157c30d76660196014478"
+source = "git+https://github.com/theseus-os/spin-rs#8770942ba1790fa536f659e4e07548f0e5da2eb6"
 dependencies = [
  "lock_api",
 ]
@@ -2510,7 +2519,7 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "hpet",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "lazy_static",
  "log",
  "memory",
@@ -2617,7 +2626,7 @@ version = "0.1.0"
 dependencies = [
  "context_switch",
  "environment",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "kernel_config",
  "lazy_static",
  "log",
@@ -2737,7 +2746,7 @@ name = "tlb_shootdown"
 version = "0.1.0"
 dependencies = [
  "apic",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "memory",
  "pause",
@@ -2884,7 +2893,7 @@ name = "virtual_nic"
 version = "0.1.0"
 dependencies = [
  "intel_ethernet",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "network_interface_card",
  "nic_buffers",
  "nic_queues",
@@ -2917,7 +2926,7 @@ dependencies = [
 name = "wait_queue"
 version = "0.1.0"
 dependencies = [
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/theseus-os/irq_safety)",
  "log",
  "scheduler",
  "task",
@@ -2984,7 +2993,7 @@ version = "0.1.2"
 dependencies = [
  "bit_field 0.7.0",
  "bitflags",
- "irq_safety",
+ "irq_safety 0.1.1 (git+https://github.com/kevinaboos/irq_safety)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ exclude = [
 
 
 [patch.crates-io]
+### Patch `spin` to use busy wait loops with the `pause` asm instruction  `core::hint::spin_loop()` by default.
+spin = { git = "https://github.com/theseus-os/spin-rs" }
 ### use our own version of volatile which supports zerocopy
 volatile = { git = "https://github.com/theseus-os/volatile" }
 ### use our own no_std-compatilbe getopts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ exclude = [
 
 
 [patch.crates-io]
-### Patch `spin` to use busy wait loops with the `pause` asm instruction  `core::hint::spin_loop()` by default.
+### Patch `spin` to use the `pause` asm instruction in busy-wait loops,
+### because the `core::hint::spin_loop()` only uses it if "sse2" is enabled.
 spin = { git = "https://github.com/theseus-os/spin-rs" }
 ### use our own version of volatile which supports zerocopy
 volatile = { git = "https://github.com/theseus-os/volatile" }

--- a/kernel/pause/src/lib.rs
+++ b/kernel/pause/src/lib.rs
@@ -1,16 +1,20 @@
-//! Offers the 'pause' instruction, which rustc used to use for 
+//! Offers the `pause` instruction, which rustc used to use for 
 //! `spin_loop_hint()` and `spin_loop()` before March 15th, 2019. 
 //! 
 //! For some reason, their current implementation of those functions
-//! uses the `_mm_pause()` intrinsic, which harms Theseus's performance
-//! within the QEMU emulator. No effect is noticeable on KVM or on real hardware.
+//! emits the `_mm_pause()` intrinsic *only when* "sse2" is enabled,
+//! instead of always emitting it regardless of configuration.
+//! The lack of `pause` harms Theseus's performance within the QEMU emulator.
+//! No effect is noticeable on KVM or on real hardware.
 
 #![no_std]
 #![feature(llvm_asm)]
 
 /// A wrapper around the `pause` x86 ASM function. 
-/// On non-x86 architectures, this is a no-op (empty function).
+/// On non-x86_64 architectures, this is a no-op (empty function).
+#[inline(always)]
 pub fn spin_loop_hint() {
+    // core::hint::spin_loop();
     #[cfg(target_arch = "x86_64")]
-    unsafe { llvm_asm!("pause" ::: "memory" : "volatile"); };
+    unsafe { llvm_asm!("pause" ::: "memory" : "volatile"); }
 }


### PR DESCRIPTION
The Rust core library only emits `pause` in its implementation of `core::hint::spin_loop()` if "sse2" is enabled, which hurts Theseus's performance especially in QEMU.