### PR TITLE
Improve graphical framebuffer mode querying and setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,7 @@ name = "framebuffer"
 version = "0.1.0"
 dependencies = [
  "color",
+ "log",
  "memory",
  "multicore_bringup",
  "owning_ref",

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,12 @@ $(nano_core_binary): cargo $(nano_core_static_lib) $(assembly_object_files) $(li
 ### This target is currently rebuilt every time to accommodate changing CFLAGS.
 $(NANO_CORE_BUILD_DIR)/boot/$(ARCH)/%.o: $(NANO_CORE_SRC_DIR)/boot/arch_$(ARCH)/%.asm
 	@mkdir -p $(shell dirname $@)
+    ## If the user chose to enable VGA text mode by means of setting `THESEUS_CONFIG`,
+    ## then we need to set CFLAGS such that the assembly code can know about it.
+    ## TODO: move this whole part about invoking `nasm` into a dedicated build.rs script in the nano_core.
+ifneq (,$(findstring vga_text_mode, $(THESEUS_CONFIG)))
+	$(eval CFLAGS += -DVGA_TEXT_MODE)
+endif
 	@nasm -felf64 $< -o $@ $(CFLAGS)
 
 

--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,11 @@ $(NANO_CORE_BUILD_DIR)/boot/$(ARCH)/%.o: $(NANO_CORE_SRC_DIR)/boot/arch_$(ARCH)/
 ifneq (,$(findstring vga_text_mode, $(THESEUS_CONFIG)))
 	$(eval CFLAGS += -DVGA_TEXT_MODE)
 endif
-	@nasm -felf64 $< -o $@ $(CFLAGS)
+	@nasm -f elf64 \
+		-i "$(NANO_CORE_SRC_DIR)/boot/arch_$(ARCH)/" \
+		$< \
+		-o $@ \
+		$(CFLAGS)
 
 
 

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ const CFG_PREFIX: &'static str = "cargo:rustc-cfg=";
 
 fn main() {
     println!("cargo:rerun-if-env-changed=THESEUS_CONFIG");
-    let configs = std::env::var("THESEUS_CONFIG").unwrap_or(String::new());
+    let configs = std::env::var("THESEUS_CONFIG").unwrap_or(String::new()).to_lowercase();
     
 	// here we just need to print out every provided config option
     for s in configs.split_whitespace() {

--- a/cfg/Config.mk
+++ b/cfg/Config.mk
@@ -27,8 +27,8 @@ APP_PREFIX    ?= a\#
 ## You can set these on the command line like so: "make run BUILD_MODE=release"
 BUILD_MODE ?= release
 ifeq ($(BUILD_MODE), debug)
-	## "debug" builds are the default in cargo, so don't change cargo options. 
-	## However, we do define the DEBUG value for CFLAGS, which is used in the assembly boot code.
+    ## "debug" builds are the default in cargo, so don't change cargo options. 
+    ## However, we do define the DEBUG value for CFLAGS, which is used in the assembly boot code.
 	export override CFLAGS += -DDEBUG
 else ifeq ($(BUILD_MODE), release)
 	export override CARGOFLAGS += --release

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -116,7 +116,12 @@ pub fn init(
     exceptions_full::init(idt);
     
     // boot up the other cores (APs)
-    let ap_count = multicore_bringup::handle_ap_cores(kernel_mmi_ref.clone(), ap_start_realmode_begin, ap_start_realmode_end)?;
+    let ap_count = multicore_bringup::handle_ap_cores(
+        kernel_mmi_ref.clone(),
+        ap_start_realmode_begin,
+        ap_start_realmode_end,
+        Some(kernel_config::display::FRAMEBUFFER_MAX_RESOLUTION),
+    )?;
     info!("Finished handling and booting up all {} AP cores.", ap_count);
 
     // //initialize the per core heaps

--- a/kernel/exceptions_full/src/lib.rs
+++ b/kernel/exceptions_full/src/lib.rs
@@ -239,6 +239,12 @@ pub extern "x86-interrupt" fn debug_handler(stack_frame: &mut ExceptionStackFram
 }
 
 /// exception 0x02, also used for TLB Shootdown IPIs and sampling interrupts
+///
+/// # Important Note
+/// Acquiring ANY locks in this function, even irq-safe ones, could cause a deadlock
+/// because this interrupt takes priority over everything else and can interrupt
+/// another regular interrupt. 
+/// This includes printing to the log (e.g., `debug!()`) or the screen.
 extern "x86-interrupt" fn nmi_handler(stack_frame: &mut ExceptionStackFrame) {
     let mut expected_nmi = false;
     

--- a/kernel/framebuffer/Cargo.toml
+++ b/kernel/framebuffer/Cargo.toml
@@ -6,6 +6,7 @@ description = "a framebuffer is a buffer of pixels which can be composited to an
 build = "../../build.rs"
 
 [dependencies]
+log = "0.4.8"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.3.0"
 

--- a/kernel/framebuffer/src/lib.rs
+++ b/kernel/framebuffer/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![no_std]
 
+#[macro_use] extern crate log;
 extern crate alloc;
 extern crate memory;
 extern crate multicore_bringup;
@@ -31,6 +32,7 @@ pub fn init<P: Pixel>() -> Result<Framebuffer<P>, &'static str> {
     let buffer_height: usize;
     {
         let graphic_info = multicore_bringup::GRAPHIC_INFO.lock();
+        info!("Using graphical framebuffer, {} x {}, at paddr {:#X}", graphic_info.width, graphic_info.height, graphic_info.physical_address);
         if graphic_info.physical_address == 0 {
             return Err("Fail to get graphic mode infomation!");
         }

--- a/kernel/kernel_config/src/display.rs
+++ b/kernel/kernel_config/src/display.rs
@@ -1,0 +1,4 @@
+/// The maximum resolution `(width, height)` of the graphical framebuffer, in pixels.
+/// This is a **requested limit** and does not control what the actual
+/// resolution of the graphical framebuffer will be.
+pub const FRAMEBUFFER_MAX_RESOLUTION: (u16, u16) = (1024, 768);

--- a/kernel/kernel_config/src/lib.rs
+++ b/kernel/kernel_config/src/lib.rs
@@ -2,3 +2,4 @@
 
 pub mod memory;
 pub mod time;
+pub mod display;

--- a/kernel/multicore_bringup/src/lib.rs
+++ b/kernel/multicore_bringup/src/lib.rs
@@ -58,10 +58,12 @@ pub static GRAPHIC_INFO: Mutex<GraphicInfo> = Mutex::new(GraphicInfo {
     physical_address: 0,
 });
 
-/// A structure to access framebuffer information 
-/// that was discovered and populated in the AP's real-mode 
-/// initialization seqeunce.
-/// TODO FIXME: remove this struct, find another way to obtain framebuffer info.
+/// A structure to access information about the graphical framebuffer mode
+/// that was discovered and chosen in the AP's real-mode initialization sequence.
+/// 
+/// # Struct format
+/// The layout of fields in this struct must be kept in sync with the code in 
+/// `ap_realmode.asm` that writes to this structure.
 #[derive(FromBytes, Clone, Debug)]
 pub struct GraphicInfo {
     pub width: u64,
@@ -73,13 +75,17 @@ pub struct GraphicInfo {
 /// (specifically the MADT (APIC) table).
 /// 
 /// # Arguments: 
-/// * kernel_mmi_ref: A reference to the locked MMI structure for the kernel.
-/// * ap_start_realmode_begin: the starting virtual address of where the ap_start realmode code is.
-/// * ap_start_realmode_end: the ending virtual address of where the ap_start realmode code is.
+/// * `kernel_mmi_ref`: A reference to the locked MMI structure for the kernel.
+/// * `ap_start_realmode_begin`: the starting virtual address of where the ap_start realmode code is.
+/// * `ap_start_realmode_end`: the ending virtual address of where the ap_start realmode code is.
+/// * `max_framebuffer_resolution`: the maximum resolution `(width, height)` of the graphical framebuffer
+///    that an AP should request from the BIOS when it boots up in 16-bit real mode.
+///    If `None`, there will be no maximum.
 pub fn handle_ap_cores(
     kernel_mmi_ref: Arc<MutexIrqSafe<MemoryManagementInfo>>,
     ap_start_realmode_begin: VirtualAddress,
-    ap_start_realmode_end: VirtualAddress
+    ap_start_realmode_end: VirtualAddress,
+    max_framebuffer_resolution: Option<(u16, u16)>,
 ) -> Result<usize, &'static str> {
     let ap_startup_size_in_bytes = ap_start_realmode_end.value() - ap_start_realmode_begin.value();
 
@@ -137,8 +143,14 @@ pub fn handle_ap_cores(
     }
     // Now, the AP startup code is at the PhysicalAddress `AP_STARTUP`.
 
-    let mut ap_count = 0;
+    let mut ap_count = 0; // the number of AP cores we have successfully booted.
     let ap_trampoline_data: &mut ApTrampolineData = trampoline_mapped_pages.as_type_mut(0)?;
+    // Here, we set up the data items that will be accessible to the APs when they boot up.
+    // We only set the values of fields that are the same for ALL APs here;
+    // values that change for each AP are set individually in `bring_up_ap()` below.
+    let (max_width, max_height) = max_framebuffer_resolution.unwrap_or((u16::MAX, u16::MAX));
+    ap_trampoline_data.ap_max_fb_width.write(max_width);
+    ap_trampoline_data.ap_max_fb_height.write(max_height);
 
     let acpi_tables = acpi::get_acpi_tables().lock();
     let madt = Madt::get(&acpi_tables)
@@ -187,6 +199,7 @@ pub fn handle_ap_cores(
     // Retrieve the graphic mode information written during the AP bootup sequence in `ap_realmode.asm`.
     {
         let graphic_info = trampoline_mapped_pages.as_type::<GraphicInfo>(GRAPHIC_INFO_OFFSET_FROM_TRAMPOLINE)?;
+        info!("Obtained graphic info from real mode: {:?}", graphic_info);
         *GRAPHIC_INFO.lock() = graphic_info.clone();
     }
     
@@ -204,9 +217,10 @@ pub fn handle_ap_cores(
 
 
 /// The data items used when an AP core is booting up in real mode.
+///
 /// # Important Layout Note
 /// The order of the members in this struct must exactly match how they are used
-/// in the AP bootup code (at the top of `ap_boot.asm`).
+/// and specified in the AP bootup code (at the top of `defines.asm`).
 #[derive(FromBytes)]
 #[repr(C)]
 struct ApTrampolineData {
@@ -225,7 +239,7 @@ struct ApTrampolineData {
     ap_stack_start:    Volatile<VirtualAddress>,
     /// The ending virtual address (top) of the stack that was allocated for the new AP.
     ap_stack_end:      Volatile<VirtualAddress>,
-    /// The virtual address of the Rust entry point that the new AP should jump to after 
+    /// The virtual address of the Rust entry point that the new AP should jump to after booting up.
     ap_code:           Volatile<VirtualAddress>,
     /// The NMI LINT (Non-Maskable Interrupt Local Interrupt) value for the new AP.
     ap_nmi_lint:       Volatile<u8>,
@@ -233,6 +247,14 @@ struct ApTrampolineData {
     /// The NMI (Non-Maskable Interrupt) flags value for the new AP.
     ap_nmi_flags:      Volatile<u16>,
     _padding3:         [u8; 6],
+    /// The maximum width in pixels of the graphical framebuffer that an AP should request
+    /// when changing graphical framebuffer modes in its 16-bit real-mode code. 
+    ap_max_fb_width:   Volatile<u16>,
+    _padding4:         [u8; 6],
+    /// The maximum height in pixels of the graphical framebuffer that an AP should request
+    /// when changing graphical framebuffer modes in its 16-bit real-mode code. 
+    ap_max_fb_height:  Volatile<u16>,
+    _padding5:         [u8; 6],
 }
 
 

--- a/kernel/nano_core/src/boot/arch_x86_64/ap_boot.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/ap_boot.asm
@@ -1,19 +1,4 @@
-; This must match the `ApTrampolineData` struct definitions used in `bring_up_ap()`.
-; See that struct definition for an explanation of how these are used.
-; The following are physical addresses.
-TRAMPOLINE          equ 0xF000
-AP_READY            equ TRAMPOLINE
-AP_PROCESSOR_ID     equ TRAMPOLINE + 8
-AP_APIC_ID          equ TRAMPOLINE + 16
-AP_PAGE_TABLE       equ TRAMPOLINE + 24
-AP_STACK_START      equ TRAMPOLINE + 32
-AP_STACK_END        equ TRAMPOLINE + 40
-AP_CODE             equ TRAMPOLINE + 48
-AP_NMI_LINT         equ TRAMPOLINE + 56
-AP_NMI_FLAGS        equ TRAMPOLINE + 64
-
-KERNEL_OFFSET equ 0xFFFFFFFF80000000
-
+%include "defines.asm"
 
 section .init.text32ap progbits alloc exec nowrite
 bits 32 ;We are still in protected mode

--- a/kernel/nano_core/src/boot/arch_x86_64/ap_realmode.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/ap_realmode.asm
@@ -1,3 +1,5 @@
+%include "defines.asm"
+
 ABSOLUTE 0x5000
 VBECardInfo:
 	.signature             resb 4
@@ -51,17 +53,21 @@ VBEModeInfo:
 
 ABSOLUTE 0x5400
 current:
-    .mode    resd 1
-    .pitch                 resw 1
-	.width                 resw 1
-	.height                resw 1
-    .bitsperpixel          resb 1
+    .mode                  resw 1
+
+; Keeps track of the "best" (highest-resolution) graphics mode so far
+best_mode:
+    .mode                  resw 1
+    .width                 resw 1
+    .height                resw 1
+    .physaddr              resd 1
+
 
 section .init.realmodetext16 progbits alloc exec nowrite
 bits 16 ; we're in real mode, that's how APs boot up
 
+; This is the entry point for APs when they first boot.
 global ap_start_realmode
-
 ap_start_realmode:
     cli
 
@@ -95,128 +101,166 @@ ap_start_realmode:
     mov al, "T"
     int 0x10
 
-;The graphic mode setting code is executed once. [0000:0900] indicates if it's the first time to run the code. If not, skip the graphic mode setting block.
+; We only need to execute the graphic mode setting code once, system-wide. 
+; We use the byte at [0000:0900] to indicate if another core has already run this code.
     mov ax, 0
     mov es, ax
     mov di, 0x900
     mov ax, [es:di]
     cmp ax, 5
-    je gdt
+    ; skip graphics mode setting code if it's already been done.
+    je create_gdt
 
-;Here we get the VESA information and set a VESA mode of a choosen resolution
-;We get a list of available modes, and pick the first mode of 32bit(RGB_) and whose x-resolution >= 1280
-;We put the mode information in physical address 0xF100 which can be read in Rust
-getcardinfo:            ;get super VGA information including available modes list
-    mov ax, 0x4F00      ;BIOS int 10, ax=4F00, get superVGA information
-    mov di, VBECardInfo ;di, buffer for returned information
-    int 0x10            ;BIOS int 10
-    cmp al, 0x4F        ;al=4f, function is supported
-    jne graphic_fail    ;if not supported, skip the VESA mode setting block
-    
-findmode:               ;initialize the mode pointer
-    mov si, [VBECardInfo.videomodeptr]
-    mov ax, [VBECardInfo.videomodeptr+2]
-    mov fs, ax          ;[fs:si] pointes to the first mode
-    sub si, 2           ;initilize the pointer [fs:si] to the index before the first mode
 
-;traverse the mode list to find the first mode of intended parameters
-.searchmodes:
-    add si, 2           ;[fs:si] points to the next mode
-    mov cx, [fs:si]     ;move current mode index to cx
-    cmp cx, 0xFFFF      
-    je graphic_fail     ;if the mode index extends the bound, skip the VESA mode setting block;
-
-.getmodeinfo:
-    push esi
-    mov [current.mode], cx  ;set current mode
-    mov ax, 0x4F01          ;BIOS int 10, ax=4f01, get current mode information. cx:mode address
-    mov di, VBEModeInfo     ;di: returned mode information buffer
-    int 0x10                ;BIOS int 10
-    pop esi
-    cmp al, 0x4F            ;al=4f, function is supported
-    jne graphic_fail        ;if not supported, skip the VESA mode setting block
-
-.foundmode:
-    ; we only support modes with 32-bit pixels
-    cmp byte [VBEModeInfo.bitsperpixel], 32
-    jne .searchmodes; if current mode is not 32-byte, continue to search the modes
-    cmp word [VBEModeInfo.width], 1024 ; 1280
-    jb .searchmodes; if current width is less than what we'd like, continue the search
-
-; store resolution and buffer address to [0000:F100] so that our Rust code can access it
-store_mode_info:    
+; This is the start of the graphics mode code. 
+; First, initialize both our "best" mode info and the Rust-visible GraphicInfo to all zeros.
+    mov word [best_mode.mode],       0
+    mov word [best_mode.width],      0
+    mov word [best_mode.height],     0
+    mov word [best_mode.physaddr],   0
+    mov word [best_mode.physaddr+2], 0
+    ; WARNING: the below code must be kept in sync with the `GraphicInfo` struct 
+    ;          in the `multicore_bringup` crate. 
     push di
     mov ax, 0
     mov es, ax
     mov di, 0xF100
-
-    ; move x resolution (width) to [0:F100]
-    mov word ax, [VBEModeInfo.width]
-    mov word [es:di+0], ax
-    mov word [es:di+2], 0
-    mov word [es:di+4], 0
-    mov word [es:di+6], 0
-
-    ; move y resolution (height) to [0:F108]
-    mov word ax, [VBEModeInfo.height]
-    mov word [es:di+ 8], ax
-    mov word [es:di+10], 0
-    mov word [es:di+12], 0
-    mov word [es:di+14], 0
-
-    ; move the framebuffer's 32-bit physical address to [0:F110]
-    mov word ax, [VBEModeInfo.physbaseptr]
-    mov word [es:di+16], ax
-    mov word ax, [VBEModeInfo.physbaseptr+2]
-    mov word [es:di+18], ax
-    mov word [es:di+20], 0
-    mov word [es:di+22], 0
-    pop di
-
-set_graphic_mode:
-    mov ax, 0x4f02;         ;BIOS int 10, ax=4f02, set graphic mode
-    mov bx, [current.mode]  ;bx: current mode 
-    int 0x10                ;BIOS int 10
-    jmp graphic_mode_complete  ; success!
-
-graphic_fail: 
-    ; write `0` to all graphic mode fields, indicating failure
-    push di
-    mov ax, 0
-    mov es, ax
-    mov di, 0xF100
-
-    ; set framebuffer width to zero
-    mov word [es:di],   0
-    mov word [es:di+2], 0
-    mov word [es:di+4], 0
-    mov word [es:di+6], 0
-
-    ; set framebuffer height to zero
+    ; set width to zero
+    mov word [es:di+0],  0
+    mov word [es:di+2],  0
+    mov word [es:di+4],  0
+    mov word [es:di+6],  0
+    ; set height to zero
     mov word [es:di+8],  0
     mov word [es:di+10], 0
     mov word [es:di+12], 0
     mov word [es:di+14], 0
-
-    ; set framebuffer physical address to zero
+    ; set physical address to zero
     mov word [es:di+16], 0
     mov word [es:di+18], 0
     mov word [es:di+20], 0
     mov word [es:di+22], 0
     pop di
 
-graphic_mode_complete:
-    ;Set the flag [0000:0900] indicating that the graphic mode is set
+; Next, we get the VBE card info such that we can iterate over the list of available modes. 
+; We then pick the highest-resolution mode, only considering modes with 32-bit pixels. 
+; If this runs successfully, we write the graphics mode details starting at physical address 0xF100
+; such that Rust code can read them later. 
+get_vbe_card_info:
+    mov ax, 0x4F00         ; 0x4F00 is the argument to the BIOS 0x10 interrupt used to request VGA/VESA information
+    mov di, VBECardInfo    ; Set `di` to the address where the VBE card info will be written
+    int 0x10
+    cmp al, 0x4F           ; The result is placed into `al`. A result of `0x4f` means the query was successful.
+    jne graphic_mode_done  ; A failure here means we can't set graphic modes, so just skip to the end. 
+    
+    ; initialize the mode pointer so we can iterate over the available graphics modes
+    mov si, [VBECardInfo.videomodeptr]
+    mov ax, [VBECardInfo.videomodeptr+2]
+    mov fs, ax          ; [fs:si] will point to the first mode in the list of modes
+    sub si, 2           ; initilize the pointer [fs:si] to the index before the first mode
+
+; Traverse the next mode in the list of available modes
+.next_mode:
+    add si, 2           ; [fs:si] points to the next mode
+    mov cx, [fs:si]     ; `cx` now holds the current mode index
+    cmp cx, 0xFFFF      ; A mode index of 0xFFFF indicates we are done iterating over the modes.
+    je mode_iter_done
+
+    ; Here, we attempt to get the mode info for the mode we just iterated to
+    push esi
+    mov [current.mode], cx  ; Store the current mode in `current.mode`
+    mov ax, 0x4F01          ; 0x4F01 is the argument fo the BIOS 0x10 interrupt used to get the currrent mode information
+    mov di, VBEModeInfo     ; Set `di` to the address where the mode information will be written
+    int 0x10
+    pop esi
+    cmp al, 0x4F            ; The result is placed into `al`. A result of `0x4f` means the query was successful.
+    jne .next_mode          ; We failed to get info about this mode. Go back and try the next mode.
+
+    ; We only support modes with 32-bit pixel sizes
+    cmp byte [VBEModeInfo.bitsperpixel], 32
+    jne .next_mode
+    ; Check whether the current mode is higher resolution than our maximum resolution.
+    ; If it is, then continue iterating through the modes.
+    mov word ax, [VBEModeInfo.width]
+    cmp word ax, [es:AP_MAX_FB_WIDTH]
+    ja .next_mode
+    mov word ax, [VBEModeInfo.height]
+    cmp word ax, [es:AP_MAX_FB_HEIGHT]
+    ja .next_mode
+    ; Check whether the current mode is higher resolution than the "best" mode thus far.
+    ; If not, continue iterating through the modes. 
+    mov word ax, [best_mode.width]
+    cmp word [VBEModeInfo.width], ax
+    jb .next_mode ; if current width is greater than or equal to best width, fall through.
+    mov word ax, [best_mode.height]
+    cmp word [VBEModeInfo.height], ax
+    jb .next_mode
+
+    ; Here, the current mode was higher resolution, so we update the "best" mode to that.
+    mov word ax, [current.mode]
+    mov word [best_mode.mode], ax
+    mov word ax, [VBEModeInfo.width]
+    mov word [best_mode.width], ax
+    mov word ax, [VBEModeInfo.height]
+    mov word [best_mode.height], ax
+    mov word ax, [VBEModeInfo.physbaseptr]
+    mov word [best_mode.physaddr], ax
+    mov word ax, [VBEModeInfo.physbaseptr+2]
+    mov word [best_mode.physaddr+2], ax
+    jmp .next_mode    ; we may find better modes later, so keep iterating!
+
+; Once we have iterated over all available graphic modes, we jump here to
+; store the details of the "best" mode that we found into [0000:F100]
+; such that our Rust code can access the details of the current graphic mode.
+mode_iter_done:
+    ; WARNING: the below code must be kept in sync with the `GraphicInfo` struct 
+    ;          in the `multicore_bringup` crate. 
+    push di
+    mov ax, 0
+    mov es, ax
+    mov di, 0xF100
+    ; copy the best mode's width to [0:F100]
+    mov word ax, [best_mode.width]
+    mov word [es:di+0], ax
+    mov word [es:di+2], 0
+    mov word [es:di+4], 0
+    mov word [es:di+6], 0
+    ; copy the best mode's height to [0:F108]
+    mov word ax, [best_mode.height]
+    mov word [es:di+ 8], ax
+    mov word [es:di+10], 0
+    mov word [es:di+12], 0
+    mov word [es:di+14], 0
+    ; move the best mode's 32-bit physical address to [0:F110]
+    mov word ax, [best_mode.physaddr]
+    mov word [es:di+16], ax
+    mov word ax, [best_mode.physaddr+2]
+    mov word [es:di+18], ax
+    mov word [es:di+20], 0
+    mov word [es:di+22], 0
+    pop di
+
+; Finally, once we have saved the info of the best graphical mode,
+; we must actually set the VGA card to use that mode. 
+; For this, we use BIOS int 0x10 with arguments `0x4F02` in `ax`
+; and the chosen mode index in `bx`. 
+    mov ax, 0x4F02
+    mov bx, [best_mode.mode]
+    int 0x10
+
+graphic_mode_done:
+    ; Set the byte at [0000:0900] to indicate that we've run the graphic mode setting code.
     mov ax, 0
     mov es, ax
     mov di, 0x900
     mov byte [es:di], 5
     ; move on (fall through) to the next step, setting up our GDT
 
-gdt:
-    ; here we're creating a GDT manually at address 0x800 by writing to addresses starting at 0x800
-    ; since this code will be forcibly loaded by GRUB multiboot above 1MB, and we're in 16-bit real mode,
-    ; we cannot create a gdt regularly. We have to 
+
+; Here, we create a GDT manually by writing its contents directly, starting at address 0x800.
+; Since this code will be forcibly loaded by the GRUB multiboot2 bootloader at an address above 1MB,
+; and because we're in 16-bit real mode, we cannot create a GDT regularly using assembler directives.
+create_gdt:
     ; Point es:di to the right memory section:
     mov   ax, 0
     mov   es, ax     ; segment of 0 since we're just accessing 0x800
@@ -274,7 +318,7 @@ load_gdt:
 clear_prefetch: 
     ; jump to protected mode. "dword" here tells nasm to generate a 32-bit instruction,
     ; even though we're still in 16-bit mode. GCC's "as" assembler can't do that! haha
-    ; 0x8 is for the newly-created kernel code segment from the above GDT
+    ; `0x8` is the newly-created kernel code segment from the above GDT
     jmp dword 0x8:prot_mode 
 
 
@@ -308,16 +352,6 @@ prot_mode:
 
 halt:
     jmp halt
-
-
-
-
-
-
-; real_mode_stack_bottom:
-;     resb 512
-; real_mode_stack_top:
-
 
 
 

--- a/kernel/nano_core/src/boot/arch_x86_64/boot.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/boot.asm
@@ -7,8 +7,7 @@
 ; This file may not be copied, modified, or distributed
 ; except according to those terms.
 
-; Kernel is linked to run at -2Gb
-KERNEL_OFFSET equ 0xFFFFFFFF80000000
+%include "defines.asm"
 
 ; Debug builds require a larger initial boot stack,
 ; because their code is larger and less optimized.

--- a/kernel/nano_core/src/boot/arch_x86_64/defines.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/defines.asm
@@ -1,0 +1,24 @@
+%ifndef __DEFINES_ASM
+%define __DEFINES_ASM
+
+; This must match the `ApTrampolineData` struct definitions used in `bring_up_ap()`.
+; See that struct definition for an explanation of how these are used.
+; The following are physical addresses.
+TRAMPOLINE          equ 0xF000
+AP_READY            equ TRAMPOLINE + 0
+AP_PROCESSOR_ID     equ TRAMPOLINE + 8
+AP_APIC_ID          equ TRAMPOLINE + 16
+AP_PAGE_TABLE       equ TRAMPOLINE + 24
+AP_STACK_START      equ TRAMPOLINE + 32
+AP_STACK_END        equ TRAMPOLINE + 40
+AP_CODE             equ TRAMPOLINE + 48
+AP_NMI_LINT         equ TRAMPOLINE + 56
+AP_NMI_FLAGS        equ TRAMPOLINE + 64
+AP_MAX_FB_WIDTH     equ TRAMPOLINE + 72
+AP_MAX_FB_HEIGHT    equ TRAMPOLINE + 80
+
+; Kernel is linked to run at -2Gb
+KERNEL_OFFSET equ 0xFFFFFFFF80000000
+
+
+%endif

--- a/kernel/nano_core/src/boot/arch_x86_64/multiboot_header.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/multiboot_header.asm
@@ -1,38 +1,36 @@
-; Copyright 2016 Phillip Oppermann, Calvin Lee and JJ Garzella.
-; See the README.md file at the top-level directory of this
-; distribution.
-;
-; Licensed under the MIT license <LICENSE or
-; http://opensource.org/licenses/MIT>, at your option.
-; This file may not be copied, modified, or distributed
-; except according to those terms.
-
-; Declare a multiboot header that marks the program as a kernel. These are magic
-; values that are documented in the multiboot standard. The bootloader will
-; search for this signature in the first 8 KiB of the kernel file, aligned at a
-; 32-bit boundary. The signature is in its own section so the header can be
-; forced to be within the first 8 KiB of the kernel file.
+; Declare a multiboot2-compliant header, which indicates this program iss a bootable kernel image.
+; This must be the first section in the kernel image, which is accomplished via our linker script. 
+; It must also be aligned to a 4-byte boundary. 
 section .multiboot_header ; Permissions are the same as .rodata by default
 align 4
-header_start:
-	dd 0xe85250d6					;Multiboot2 magic number
-	dd 0							;Run in protected i386 mode
-	dd header_end - header_start	;header length
-	;check sum
+multiboot_header_start:
+	dd 0xe85250d6					                   ; Multiboot2 header magic number
+	dd 0							                   ; Run in protected i386 (32-bit) mode
+	dd multiboot_header_end - multiboot_header_start   ; header length
+	; checksum
 	dd 0x100000000 - (0xe85250d6 + 0 + (header_end - header_start))
-
-	;optional tags
-	;framebuffer tags
-	;dw 5
-	;dw 0
-	;dd 20
-	;dd 640
-	;dd 400
-	;dd 32
+	; Place optional header tags here, after the checksum above. Documentation is here:
+	; <https://www.gnu.org/software/grub/manual/multiboot2/multiboot.html#Header-tags>
+	; Note: all tags must be aligned to 8-byte boundaries.
 
 
-	;end tags
-	dw 0	;type
-	dw 0	;flags
-	dd 8	;size
-header_end:
+; Below is the framebuffer tag, used to request a graphical (non-text) framebuffer and specify its size.
+; By default, we ask the bootloader to switch modes to a graphical framebuffer for us,
+; though this can be disabled by defining `VGA_TEXT_MODE`.
+%ifndef VGA_TEXT_MODE
+align 8
+	dw 5     ; type (5 means framebuffer tag)
+	dw 0     ; flags. Bit 0 = `1` means this tag is optional, Bit 0 = `0` means it's mandatory.
+	dd 20    ; size of this tag (20)
+	dd 1280  ; width (in pixels)
+	dd 1024  ; height (in pixels)
+	dd 32    ; depth (pixel size in bits)
+%endif
+
+
+; This marks the end of the tag region.
+align 8
+	dw 0	; type (0 means terminator tag)
+	dw 0	; flags
+	dd 8	; size of this tag
+multiboot_header_end:

--- a/kernel/nano_core/src/boot/arch_x86_64/multiboot_header.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/multiboot_header.asm
@@ -8,7 +8,7 @@ multiboot_header_start:
 	dd 0							                   ; Run in protected i386 (32-bit) mode
 	dd multiboot_header_end - multiboot_header_start   ; header length
 	; checksum
-	dd 0x100000000 - (0xe85250d6 + 0 + (header_end - header_start))
+	dd 0x100000000 - (0xe85250d6 + 0 + (multiboot_header_end - multiboot_header_start))
 	; Place optional header tags here, after the checksum above. Documentation is here:
 	; <https://www.gnu.org/software/grub/manual/multiboot2/multiboot.html#Header-tags>
 	; Note: all tags must be aligned to 8-byte boundaries.

--- a/kernel/nano_core/src/boot/arch_x86_64/multiboot_header.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/multiboot_header.asm
@@ -17,15 +17,19 @@ multiboot_header_start:
 ; Below is the framebuffer tag, used to request a graphical (non-text) framebuffer and specify its size.
 ; By default, we ask the bootloader to switch modes to a graphical framebuffer for us,
 ; though this can be disabled by defining `VGA_TEXT_MODE`.
-%ifndef VGA_TEXT_MODE
-align 8
-	dw 5     ; type (5 means framebuffer tag)
-	dw 0     ; flags. Bit 0 = `1` means this tag is optional, Bit 0 = `0` means it's mandatory.
-	dd 20    ; size of this tag (20)
-	dd 1280  ; width (in pixels)
-	dd 1024  ; height (in pixels)
-	dd 32    ; depth (pixel size in bits)
-%endif
+;
+; NOTE: TODO: uncomment the below sections when we are ready to enable
+;       early boot-time usage of the graphical framebuffer by default.
+;
+; %ifndef VGA_TEXT_MODE
+; align 8
+; 	dw 5     ; type (5 means framebuffer tag)
+; 	dw 0     ; flags. Bit 0 = `1` means this tag is optional, Bit 0 = `0` means it's mandatory.
+; 	dd 20    ; size of this tag (20)
+; 	dd 1280  ; width (in pixels)
+; 	dd 1024  ; height (in pixels)
+; 	dd 32    ; depth (pixel size in bits)
+; %endif
 
 
 ; This marks the end of the tag region.


### PR DESCRIPTION
See the latest commit for details:
* Choose the highest-resolution mode possible for the graphical framebuffer.

* This change occurs to the 16-bit realmode code that runs when each additional AP core boots up. This code has also been cleaned up and improved.

* A maximum framebuffer resolution is also specified in kernel_config/display too. Currently this is set to 1024x768 because our display code is slow, as it stupidly reads from the VGA memory (the final framebuffer).