### PR TITLE
Fix SIMD personality builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_simd"
+version = "0.1.0"
+source = "git+https://github.com/rust-lang/stdsimd#57e67c905fe9fb3d45a1714d25baa5dfc143299c"
+
+[[package]]
 name = "cow_arc"
 version = "0.1.0"
 dependencies = [
@@ -1201,12 +1206,6 @@ checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
-
-[[package]]
-name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
@@ -1243,7 +1242,7 @@ dependencies = [
  "bit_field 0.10.0",
  "hashbrown",
  "hpet",
- "libm 0.2.1",
+ "libm",
  "log",
  "memory",
  "pmu_x86",
@@ -1460,7 +1459,7 @@ dependencies = [
  "getopts",
  "hpet",
  "kernel_config",
- "libm 0.2.1",
+ "libm",
  "libtest",
  "log",
  "mapper_spillful",
@@ -1720,16 +1719,6 @@ source = "git+https://github.com/theseus-os/owning-ref-rs#0d2dcdcffd75b80157d0e7
 dependencies = [
  "spin 0.9.0",
  "stable_deref_trait 1.1.1 (git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin)",
-]
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3278e0492f961fd4ae70909f56b2723a7e8d01a228427294e19cdfdebda89a17"
-dependencies = [
- "cfg-if",
- "libm 0.1.4",
 ]
 
 [[package]]
@@ -2379,8 +2368,8 @@ name = "simd_test"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
+ "core_simd",
  "log",
- "packed_simd_2",
  "pit_clock",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ $(iso): build
 ## Then, we give all kernel crate object files the KERNEL_PREFIX and all application crate object files the APP_PREFIX.
 build: $(nano_core_binary)
 ## Copy all object files into the main build directory and prepend the kernel or app prefix appropriately. 
-	cargo run --release --manifest-path $(ROOT_DIR)/tools/copy_latest_crate_objects/Cargo.toml -- \
+	@cargo run --release --manifest-path $(ROOT_DIR)/tools/copy_latest_crate_objects/Cargo.toml -- \
 		-i ./target/$(TARGET)/$(BUILD_MODE)/deps \
 		--output-objects $(OBJECT_FILES_BUILD_DIR) \
 		--output-deps $(DEPS_DIR) \
@@ -240,8 +240,8 @@ cargo: check_rustc
 $(nano_core_binary): cargo $(nano_core_static_lib) $(assembly_object_files) $(linker_script)
 	@mkdir -p $(BUILD_DIR)
 	@mkdir -p $(NANO_CORE_BUILD_DIR)
-	## If we remove the OBJECT_FILES_BUILD_DIR here, then the simd_personality_* builds do not work.
-	# @rm -rf $(OBJECT_FILES_BUILD_DIR)
+## If we remove the OBJECT_FILES_BUILD_DIR here, then the simd_personality_* builds do not work.
+# @rm -rf $(OBJECT_FILES_BUILD_DIR)
 	@mkdir -p $(OBJECT_FILES_BUILD_DIR)
 	@mkdir -p $(DEPS_DIR)
 
@@ -378,7 +378,7 @@ clean:
 ## The "normal" target must come last ('build_sse', THEN the regular 'build') to ensure that the final nano_core_binary is non-SIMD.
 simd_personality_sse : export TARGET := x86_64-theseus
 simd_personality_sse : export BUILD_MODE = release
-simd_personality_sse : export override THESEUS_CONFIG += simd_personality
+simd_personality_sse : export override THESEUS_CONFIG += simd_personality simd_personality_sse
 simd_personality_sse: build_sse build
 ## after building all the modules, copy the kernel boot image files
 	@echo -e "********* AT THE END OF SIMD_BUILD: TARGET = $(TARGET), KERNEL_PREFIX = $(KERNEL_PREFIX), APP_PREFIX = $(APP_PREFIX)"
@@ -397,7 +397,7 @@ simd_personality_sse: build_sse build
 ## The "normal" target must come last ('build_avx', THEN the regular 'build') to ensure that the final nano_core_binary is non-SIMD.
 simd_personality_avx : export TARGET := x86_64-theseus
 simd_personality_avx : export BUILD_MODE = release
-simd_personality_avx : export override THESEUS_CONFIG += simd_personality
+simd_personality_avx : export override THESEUS_CONFIG += simd_personality simd_personality_avx
 simd_personality_avx : export override CFLAGS += -DENABLE_AVX
 simd_personality_avx: build_avx build
 ## after building all the modules, copy the kernel boot image files
@@ -419,9 +419,7 @@ build_sse : export override RUSTFLAGS += -C no-vectorize-slp
 build_sse : export KERNEL_PREFIX := ksse\#
 build_sse : export APP_PREFIX := asse\#
 build_sse:
-	@echo -e "YO, starting build_sse: BUILD_MODE: $(BUILD_MODE), CARGOFLAGS: $(CARGOFLAGS)"
 	$(MAKE) build
-	@echo -e "YO, done with build_sse: BUILD_MODE: $(BUILD_MODE), CARGOFLAGS: $(CARGOFLAGS)"
 
 
 ### build_avx builds the kernel and applications with the x86_64-theseus-avx target.
@@ -432,9 +430,7 @@ build_avx : export override RUSTFLAGS += -C no-vectorize-slp
 build_avx : export KERNEL_PREFIX := kavx\#
 build_avx : export APP_PREFIX := aavx\#
 build_avx:
-	@echo -e "YO, starting build_avx: BUILD_MODE: $(BUILD_MODE), CARGOFLAGS: $(CARGOFLAGS)"
 	$(MAKE) build
-	@echo -e "YO, done with build_avx: BUILD_MODE: $(BUILD_MODE), CARGOFLAGS: $(CARGOFLAGS)"
 
 
 ### build_server is a target that builds Theseus into a regular ISO

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ $(iso): build
 ## Then, we give all kernel crate object files the KERNEL_PREFIX and all application crate object files the APP_PREFIX.
 build: $(nano_core_binary)
 ## Copy all object files into the main build directory and prepend the kernel or app prefix appropriately. 
-	@cargo run --release --manifest-path $(ROOT_DIR)/tools/copy_latest_crate_objects/Cargo.toml -- \
+	cargo run --release --manifest-path $(ROOT_DIR)/tools/copy_latest_crate_objects/Cargo.toml -- \
 		-i ./target/$(TARGET)/$(BUILD_MODE)/deps \
 		--output-objects $(OBJECT_FILES_BUILD_DIR) \
 		--output-deps $(DEPS_DIR) \
@@ -208,7 +208,7 @@ cargo: check_rustc
 	@echo -e "\t KERNEL_PREFIX: \"$(KERNEL_PREFIX)\""
 	@echo -e "\t APP_PREFIX: \"$(APP_PREFIX)\""
 	@echo -e "\t THESEUS_CONFIG (before build.rs script): \"$(THESEUS_CONFIG)\""
-	RUST_TARGET_PATH="$(CFG_DIR)" RUSTFLAGS="$(RUSTFLAGS)" cargo build  $(CARGOFLAGS) $(BUILD_STD_CARGOFLAGS) $(RUST_FEATURES) --all --target $(TARGET)
+	RUST_TARGET_PATH="$(CFG_DIR)" RUSTFLAGS="$(RUSTFLAGS)" cargo build $(CARGOFLAGS) $(BUILD_STD_CARGOFLAGS) $(RUST_FEATURES) --all --target $(TARGET)
 
 ## We tried using the "cargo rustc" command here instead of "cargo build" to avoid cargo unnecessarily rebuilding core/alloc crates,
 ## But it doesn't really seem to work (it's not the cause of cargo rebuilding everything).
@@ -412,25 +412,28 @@ simd_personality_avx: build_avx build
 
 ### build_sse builds the kernel and applications with the x86_64-theseus-sse target.
 ### It can serve as part of the simd_personality_sse target.
-build_sse : export TARGET := x86_64-theseus-sse
+build_sse : export override TARGET := x86_64-theseus-sse
 build_sse : export override RUSTFLAGS += -C no-vectorize-loops
 build_sse : export override RUSTFLAGS += -C no-vectorize-slp
 build_sse : export KERNEL_PREFIX := ksse\#
 build_sse : export APP_PREFIX := asse\#
 build_sse:
-	@$(MAKE) build
+	@echo -e "YO, starting build_sse: BUILD_MODE: $(BUILD_MODE), CARGOFLAGS: $(CARGOFLAGS)"
+	$(MAKE) build
+	@echo -e "YO, done with build_sse: BUILD_MODE: $(BUILD_MODE), CARGOFLAGS: $(CARGOFLAGS)"
 
 
 ### build_avx builds the kernel and applications with the x86_64-theseus-avx target.
 ### It can serve as part of the simd_personality_avx target.
-build_avx : export TARGET := x86_64-theseus-avx
+build_avx : export override TARGET := x86_64-theseus-avx
 build_avx : export override RUSTFLAGS += -C no-vectorize-loops
 build_avx : export override RUSTFLAGS += -C no-vectorize-slp
 build_avx : export KERNEL_PREFIX := kavx\#
 build_avx : export APP_PREFIX := aavx\#
 build_avx:
-	@$(MAKE) build
-
+	@echo -e "YO, starting build_avx: BUILD_MODE: $(BUILD_MODE), CARGOFLAGS: $(CARGOFLAGS)"
+	$(MAKE) build
+	@echo -e "YO, done with build_avx: BUILD_MODE: $(BUILD_MODE), CARGOFLAGS: $(CARGOFLAGS)"
 
 
 ### build_server is a target that builds Theseus into a regular ISO

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ $(iso): build
 ## This first invokes the make target that runs the actual compiler, and then copies all object files into the build dir.
 ## This also classifies crate object files into either "application" or "kernel" crates:
 ## -- an application crate is any executable application in the `applications/` directory, or a library crate that is ONLY used by other applications,
-## -- a kernel crate is any crate in the `kernel/` directory, or any other crates that are used 
+## -- a kernel crate is any crate in the `kernel/` directory, or any other crates that are used by kernel crates.
 ## Obviously, if a crate is used by both other application crates and by kernel crates, it is still a kernel crate. 
 ## Then, we give all kernel crate object files the KERNEL_PREFIX and all application crate object files the APP_PREFIX.
 build: $(nano_core_binary)
@@ -240,7 +240,8 @@ cargo: check_rustc
 $(nano_core_binary): cargo $(nano_core_static_lib) $(assembly_object_files) $(linker_script)
 	@mkdir -p $(BUILD_DIR)
 	@mkdir -p $(NANO_CORE_BUILD_DIR)
-	@rm -rf $(OBJECT_FILES_BUILD_DIR)
+	## If we remove the OBJECT_FILES_BUILD_DIR here, then the simd_personality_* builds do not work.
+	# @rm -rf $(OBJECT_FILES_BUILD_DIR)
 	@mkdir -p $(OBJECT_FILES_BUILD_DIR)
 	@mkdir -p $(DEPS_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ APP_CRATE_NAMES := $(filter-out build/. target/., $(APP_CRATE_NAMES))
 APP_CRATE_NAMES := $(filter-out .*/, $(APP_CRATE_NAMES))
 # remove the trailing /. on each name
 APP_CRATE_NAMES := $(patsubst %/., %, $(APP_CRATE_NAMES))
-APP_CRATE_NAMES += EXTRA_APP_CRATE_NAMES
+APP_CRATE_NAMES += $(EXTRA_APP_CRATE_NAMES)
 
 
 ### PHONY is the list of targets that *always* get rebuilt regardless of dependent files' modification timestamps.

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -132,9 +132,9 @@ For example, Theseus frequently uses options like:
 
 The advantage of these features is that they can also be used in `Cargo.toml` manifest files to conditionally set dependencies. For example:
 ```toml
-## Only include the `packed_simd` crate as a dependency when "sse2" is enabled.
-[target.'cfg(target_feature = "sse2")'.dependencies.packed_simd]
-version = "0.3.4"
+## Only include the `core_simd` crate as a dependency when "sse2" is enabled.
+[target.'cfg(target_feature = "sse2")'.dependencies.core_simd]
+...
 ```
 
 Unfortunately, you cannot use non-built-in cfg options to conditionally specify dependencies in `Cargo.toml` files, such as anything that comes from `THESEUS_CONFIG` values. 

--- a/cfg/Config.mk
+++ b/cfg/Config.mk
@@ -31,9 +31,12 @@ CARGOFLAGS ?=
 ifeq ($(BUILD_MODE),debug)
     ## "debug" builds are the default in cargo, so don't change cargo options. 
     ## However, we do define the DEBUG value for CFLAGS, which is used in the assembly boot code.
-	export override CFLAGS += -DDEBUG
+	export override CFLAGS+=-DDEBUG
 else ifeq ($(BUILD_MODE),release)
-	export override CARGOFLAGS += --release
+	## "release" builds require passing the `--release` flag, but it can only be passed once.
+	ifeq (,$(findstring --release,$(CARGOFLAGS)))
+		export override CARGOFLAGS+=--release
+	endif
 else 
 $(error 'BUILD_MODE' value of '$(BUILD_MODE)' is invalid, it must be either 'debug' or 'release')
 endif

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -141,12 +141,14 @@ pub fn init(
     drop(identity_mapped_pages);
     
     // create a SIMD personality
-    #[cfg(simd_personality)]
-    {
+    #[cfg(simd_personality)] {
+        #[cfg(simd_personality_sse)]
         let simd_ext = task::SimdExt::SSE;
+        #[cfg(simd_personality_avx)]
+        let simd_ext = task::SimdExt::AVX;
         warn!("SIMD_PERSONALITY FEATURE ENABLED, creating a new personality with {:?}!", simd_ext);
         spawn::new_task_builder(simd_personality::setup_simd_personality, simd_ext)
-            .name(alloc::string::String::from("setup_simd_personality"))
+            .name(alloc::format!("setup_simd_personality_{:?}", simd_ext))
             .spawn()?;
     }
 

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -145,7 +145,7 @@ pub fn init(
     {
         let simd_ext = task::SimdExt::SSE;
         warn!("SIMD_PERSONALITY FEATURE ENABLED, creating a new personality with {:?}!", simd_ext);
-        spawn::spawn::new_task_builder(simd_personality::setup_simd_personality, simd_ext)
+        spawn::new_task_builder(simd_personality::setup_simd_personality, simd_ext)
             .name(alloc::string::String::from("setup_simd_personality"))
             .spawn()?;
     }

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -646,7 +646,7 @@ impl CrateNamespace {
     /// 
     /// This is only necessary because I can't figure out how to make a generic function
     /// that accepts and returns either `&CrateNamespace` or `&Arc<CrateNamespace>`.
-    fn method_get_crate_object_files_starting_with(
+    pub fn method_get_crate_object_files_starting_with(
         &self,
         file_name_prefix: &str
     ) -> Vec<(FileRef, &CrateNamespace)> { 
@@ -673,7 +673,7 @@ impl CrateNamespace {
     /// 
     /// This is only necessary because I can't figure out how to make a generic function
     /// that accepts and returns either `&CrateNamespace` or `&Arc<CrateNamespace>`.
-    fn method_get_crate_object_file_starting_with(
+    pub fn method_get_crate_object_file_starting_with(
         &self,
         file_name_prefix: &str
     ) -> Option<(FileRef, &CrateNamespace)> { 

--- a/kernel/simd_personality/src/lib.rs
+++ b/kernel/simd_personality/src/lib.rs
@@ -75,9 +75,11 @@ extern crate apic;
 extern crate fs_node;
 
 
-use alloc::string::String;
-use mod_mgmt::{CrateNamespace, get_initial_kernel_namespace, get_namespaces_directory, NamespaceDirectorySet};
-use fs_node::FileOrDir; 
+use alloc::{
+	string::String,
+	sync::Arc,
+};
+use mod_mgmt::{CrateNamespace, CrateType, NamespaceDir, get_initial_kernel_namespace, get_namespaces_directory};
 use task::SimdExt;
 
 
@@ -97,7 +99,7 @@ pub fn setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str> {
 
 
 fn internal_setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str> {
-	let namespace_name = match simd_ext {
+	let namespace_prefix = match simd_ext {
 		SimdExt::AVX => "avx",
 		SimdExt::SSE => "sse",
 		SimdExt::None => return Err("Cannot create a new SIMD personality with SimdExt::None!"),
@@ -108,85 +110,88 @@ fn internal_setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str
 
 	// The `mod_mgmt::init()` function should have initialized the following directories, 
 	// for example, if 'sse' was the prefix used to build the SSE versions of each crate:
-	//     .../namespaces/sse/
-	//     .../namespaces/sse/kernel
-	//     .../namespaces/sse/application
-	//     .../namespaces/sse/userspace
+	//     .../namespaces/sse_kernel
+	//     .../namespaces/sse_application
 	let namespaces_dir = get_namespaces_directory().ok_or("top-level namespaces directory wasn't yet initialized")?;
-	let base_dir = namespaces_dir.lock().get_dir(namespace_name).ok_or("couldn't find directory at given path")?;
-	let mut simd_namespace = CrateNamespace::new(
-		String::from(namespace_name), 
-		NamespaceDirectorySet::from_existing_base_dir(base_dir).map_err(|e| {
-			error!("Couldn't find expected namespace directory {:?}, did you choose the correct SimdExt?", namespace_name);
-			e
-		})?,
-	);
+	
+	// Create the SIMD kernel namespace
+	let simd_kernel_namespace = {
+		let namespace_name = format!("{}{}", namespace_prefix, CrateType::Kernel.default_namespace_name());
+		let dir = namespaces_dir.lock().get_dir(&namespace_name).ok_or("couldn't find SIMD kernel namespace directory at given path")?;
+		Arc::new(CrateNamespace::new(
+			String::from(namespace_name), 
+			NamespaceDir::new(dir),
+			None,
+		))
+	};
+
+	// Then create the SIMD application namespace that is recursively backed by the simd_kernel_namespace
+	let mut simd_app_namespace = {
+		let namespace_name = format!("{}{}", namespace_prefix, CrateType::Application.default_namespace_name());
+		let dir = namespaces_dir.lock().get_dir(&namespace_name).ok_or("couldn't find SIMD application namespace directory at given path")?;
+		CrateNamespace::new(
+			String::from(namespace_name), 
+			NamespaceDir::new(dir),
+			Some(Arc::clone(&simd_kernel_namespace)),
+		)
+	};
 
 	// Load things that are specific (private) to the SIMD world, like core library and compiler builtins
-	let compiler_builtins_simd = simd_namespace.get_kernel_file_starting_with("compiler_builtins-")
+	let (compiler_builtins_simd, _ns) = CrateNamespace::get_crate_object_file_starting_with(&simd_kernel_namespace, "compiler_builtins-")
 		.ok_or_else(|| "couldn't find a single 'compiler_builtins' object file in simd_personality")?;
-	let core_lib_simd = simd_namespace.get_kernel_file_starting_with("core-")
+	let (core_lib_simd, _ns) = CrateNamespace::get_crate_object_file_starting_with(&simd_kernel_namespace, "core-")
 		.ok_or_else(|| "couldn't find a single 'core' object file in simd_personality")?;
-	let crate_files = vec![compiler_builtins_simd, core_lib_simd];
-	simd_namespace.load_crates(crate_files.iter(), Some(backup_namespace), &kernel_mmi_ref, false)?;
-
+	let crate_files = [compiler_builtins_simd, core_lib_simd];
+	simd_kernel_namespace.load_crates(crate_files.iter(), Some(backup_namespace), &kernel_mmi_ref, false)?;
+	
 
 	// load the actual crate that we want to run in the simd namespace, "simd_test"
-	let simd_test_file = simd_namespace.get_kernel_file_starting_with("simd_test-")
+	let (simd_test_file, _ns) = simd_app_namespace.method_get_crate_object_file_starting_with("simd_test-")
 		.ok_or_else(|| "couldn't find a single 'simd_test' object file in simd_personality")?;
-	simd_namespace.enable_fuzzy_symbol_matching();
-	simd_namespace.load_crate(&simd_test_file, Some(backup_namespace), &kernel_mmi_ref, false)?;
-	simd_namespace.disable_fuzzy_symbol_matching();
+	simd_app_namespace.enable_fuzzy_symbol_matching();
+	simd_app_namespace.load_crate(&simd_test_file, Some(backup_namespace), &kernel_mmi_ref, false)?;
+	simd_app_namespace.disable_fuzzy_symbol_matching();
 
 
 	let this_core = apic::get_my_apic_id();
 	
 	type SimdTestFunc = fn(());
-	let section_ref1 = simd_namespace.get_symbol_starting_with("simd_test::test1::")
+	let section_ref1 = simd_app_namespace.get_symbol_starting_with("simd_test::test1::")
 		.upgrade()
 		.ok_or("no single symbol matching \"simd_test::test1\"")?;
 	let mut space1 = 0;	
-	let (mapped_pages1, mapped_pages_offset1) = { 
-		let section = section_ref1.lock();
-		(section.mapped_pages.clone(), section.mapped_pages_offset)
-	};
+	let (mapped_pages1, mapped_pages_offset1) = (section_ref1.mapped_pages.clone(), section_ref1.mapped_pages_offset);
 	let func1: &SimdTestFunc = mapped_pages1.lock().as_func(mapped_pages_offset1, &mut space1)?;
-	let task1 = spawn::new_task_builder(func1, ())
-		.name(format!("simd_test_1-{}", namespace_name))
+	let _task1 = spawn::new_task_builder(func1, ())
+		.name(format!("simd_test_1-{}", simd_app_namespace.name()))
 		.pin_on_core(this_core)
 		.simd(simd_ext)
 		.spawn()?;
 	debug!("finished spawning simd_test::test1 task");
 
 
-	let section_ref2 = simd_namespace.get_symbol_starting_with("simd_test::test2::")
+	let section_ref2 = simd_app_namespace.get_symbol_starting_with("simd_test::test2::")
 		.upgrade()
 		.ok_or("no single symbol matching \"simd_test::test2\"")?;
 	let mut space2 = 0;	
-	let (mapped_pages2, mapped_pages_offset2) = { 
-		let section = section_ref2.lock();
-		(section.mapped_pages.clone(), section.mapped_pages_offset)
-	};
+	let (mapped_pages2, mapped_pages_offset2) = (section_ref2.mapped_pages.clone(), section_ref2.mapped_pages_offset);
 	let func: &SimdTestFunc = mapped_pages2.lock().as_func(mapped_pages_offset2, &mut space2)?;
-	let task2 = spawn::new_task_builder(func, ())
-		.name(format!("simd_test_2-{}", namespace_name))
+	let _task2 = spawn::new_task_builder(func, ())
+		.name(format!("simd_test_2-{}", simd_app_namespace.name()))
 		.pin_on_core(this_core)
 		.simd(simd_ext)
 		.spawn()?;
 	debug!("finished spawning simd_test::test2 task");
 
 
-	let section_ref3 = simd_namespace.get_symbol_starting_with("simd_test::test_short::")
+	let section_ref3 = simd_app_namespace.get_symbol_starting_with("simd_test::test_short::")
 		.upgrade()
 		.ok_or("no single symbol matching \"simd_test::test_short\"")?;
 	let mut space3 = 0;	
-	let (mapped_pages3, mapped_pages_offset3) = { 
-		let section = section_ref3.lock();
-		(section.mapped_pages.clone(), section.mapped_pages_offset)
-	};
+	let (mapped_pages3, mapped_pages_offset3) = (section_ref3.mapped_pages.clone(), section_ref3.mapped_pages_offset);
 	let func: &SimdTestFunc = mapped_pages3.lock().as_func(mapped_pages_offset3, &mut space3)?;
-	let task3 = spawn::new_task_builder(func, ())
-		.name(format!("simd_test_short-{}", namespace_name))
+	let _task3 = spawn::new_task_builder(func, ())
+		.name(format!("simd_test_short-{}", simd_app_namespace.name()))
 		.pin_on_core(this_core)
 		.simd(simd_ext)
 		.spawn()?;
@@ -201,9 +206,9 @@ fn internal_setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str
 
 	loop { }
 	
-	task1.join()?;
-	task2.join()?;
-	task3.join()?;
+	// _task1.join()?;
+	// _task2.join()?;
+	// _task3.join()?;
 
 	Ok(())
 }

--- a/kernel/simd_personality/src/lib.rs
+++ b/kernel/simd_personality/src/lib.rs
@@ -209,8 +209,7 @@ fn internal_setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str
 	// _task1.join()?;
 	// _task2.join()?;
 	// _task3.join()?;
-
-	Ok(())
+	// Ok(())
 }
 		
 }} // end of cfg_if block

--- a/kernel/simd_test/Cargo.toml
+++ b/kernel/simd_test/Cargo.toml
@@ -9,9 +9,8 @@ build = "../../build.rs"
 cfg-if = "0.1.6"
 
 ## Only include the SIMD crates when any SIMD extensions are enabled
-[target.'cfg(target_feature = "sse2")'.dependencies.packed_simd]
-version = "0.3.4"
-package = "packed_simd_2"
+[target.'cfg(target_feature = "sse2")'.dependencies.core_simd]
+git = "https://github.com/rust-lang/stdsimd"
 
 [dependencies.pit_clock]
 path = "../pit_clock"

--- a/kernel/simd_test/src/lib.rs
+++ b/kernel/simd_test/src/lib.rs
@@ -6,9 +6,9 @@ cfg_if! { if #[cfg(all(simd_personality, target_feature = "sse2"))] {
 
 #[macro_use] extern crate log;
 // extern crate pit_clock;
-extern crate packed_simd;
+extern crate core_simd;
 
-use packed_simd::f64x4;
+use core_simd::f64x4;
 
 pub fn test1(_: ()) {
     warn!("at the top of simd_test::test1! simd_personality: {}, sse2: {}, avx: {}", 
@@ -17,8 +17,8 @@ pub fn test1(_: ()) {
         cfg!(target_feature = "avx")
     );
 
-    let mut x = f64x4::new(1.111, 11.11, 111.1, 1111.0);
-    let y = f64x4::new(0.0, 0.0, 0.0, 0.0);
+    let mut x = f64x4::from_array([1.111, 11.11, 111.1, 1111.0]);
+    let y = f64x4::from_array([0.0, 0.0, 0.0, 0.0]);
 
     let mut loop_ctr = 0;
     loop {
@@ -39,8 +39,8 @@ pub fn test2(_: ()) {
         cfg!(target_feature = "sse2"),
         cfg!(target_feature = "avx")
     );
-    let mut x = f64x4::new(2.222, 22.22, 222.2, 2222.0);
-    let y = f64x4::new(0.0, 0.0, 0.0, 0.0);
+    let mut x = f64x4::from_array([2.222, 22.22, 222.2, 2222.0]);
+    let y = f64x4::from_array([0.0, 0.0, 0.0, 0.0]);
 
     let mut loop_ctr = 0;
     loop {
@@ -62,8 +62,8 @@ pub fn test_short(_: ()) {
         cfg!(target_feature = "sse2"),
         cfg!(target_feature = "avx")
     );
-    let mut x = f64x4::new(3.333, 33.33, 333.3, 3333.0);
-    let y = f64x4::new(0.0, 0.0, 0.0, 0.0);
+    let mut x = f64x4::from_array([3.333, 33.33, 333.3, 3333.0]);
+    let y = f64x4::from_array([0.0, 0.0, 0.0, 0.0]);
 
     for i in 0..10 {
         x = add(x, y);


### PR DESCRIPTION
The old `packed_simd_2` crate was causing documentation build errors, among other issues. 