### PR TITLE
Simplify view-book makefile target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,11 +502,7 @@ endif
 ### Opens the Theseus book.
 view-book: book
 	@echo -e "Opening the Theseus book in your browser..."
-ifneq ($(IS_WSL), )
-	wslview "$(shell realpath --relative-to="$(ROOT_DIR)" "$(BOOK_OUT_FILE)")" &
-else
-	@xdg-open $(BOOK_OUT_FILE) > /dev/null 2>&1 || open $(BOOK_OUT_FILE) &
-endif
+	@mdbook build --open $(BOOK_SRC) -d $(BOOK_OUT)
 
 
 ### Removes all built documentation

--- a/Makefile
+++ b/Makefile
@@ -591,6 +591,7 @@ help:
 	@echo -e "\t Builds the Theseus book using the mdbook Markdown tool."
 	@echo -e "   view-book:"
 	@echo -e "\t Builds the Theseus book and then opens it in your default browser."
+	@echo -e "\t If the book doesn't open in your browser, install the latest version of mdbook."
 	@echo -e "   clean-doc:"
 	@echo -e "\t Remove all generated documentation files."
 	@echo ""

--- a/book/README.md
+++ b/book/README.md
@@ -8,7 +8,7 @@ The book is written in Markdown and uses [mdBook](https://rust-lang-nursery.gith
 
 ## Building the book
 
-First, install `mdbook`:
+First, install `mdbook`, version `0.4.13` or higher:
 ```sh
 cargo +stable install mdbook
 ```


### PR DESCRIPTION
Utilize the functionality of mdbook to open the Theseus book. The make dependency on book can be removed as the book is rebuild before opening. The check for a mdbook install would also be removed in this case. A somewhat useful error is still printed if mdbook cannot be found.

The `build` command could also be replaced with a `watch` command which rebuilds the book whenever the source changes.

```shell
@(&> /dev/null mdbook watch --open $(BOOK_SRC) -d $(BOOK_OUT) &)
```

The method used to suppress the output may not be portable.