### PR TITLE
Update 'downcast-rs' to the latest version, which now supports no_std.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,8 +633,9 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.0.4"
-source = "git+https://github.com/theseus-os/downcast-rs#5d2c787a754b6d5aa44e7c91470d2bb160818617"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "e1000"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,6 @@ volatile = { git = "https://github.com/theseus-os/volatile" }
 getopts = { git = "https://github.com/theseus-os/getopts" }
 ### use our own no_std-compatible qp trie
 qp-trie = { git = "https://github.com/theseus-os/qp-trie-rs" }
-### use our own no_std-compatible downcast-rs
-downcast-rs = { git = "https://github.com/theseus-os/downcast-rs" }
 ### use the latest version of smoltcp from github; the one on crates.io is out of date
 smoltcp = { git = "https://github.com/m-labs/smoltcp" }
 

--- a/kernel/storage_device/Cargo.toml
+++ b/kernel/storage_device/Cargo.toml
@@ -8,7 +8,7 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
-downcast-rs = "1.0.4"
+downcast-rs = { version = "1.2.0", default-features = false }
 
 [dependencies.log]
 version = "0.4.8"

--- a/libtheseus/Cargo.toml
+++ b/libtheseus/Cargo.toml
@@ -47,8 +47,6 @@ volatile = { git = "https://github.com/theseus-os/volatile" }
 getopts = { git = "https://github.com/theseus-os/getopts" }
 ### use our own no_std-compatible qp trie
 qp-trie = { git = "https://github.com/theseus-os/qp-trie-rs" }
-### use our own no_std-compatible downcast-rs
-downcast-rs = { git = "https://github.com/theseus-os/downcast-rs" }
 ### use the latest version of smoltcp from github; the one on crates.io is out of date
 smoltcp = { git = "https://github.com/m-labs/smoltcp" }
 

--- a/tlibc/Cargo.toml
+++ b/tlibc/Cargo.toml
@@ -40,7 +40,5 @@ volatile = { git = "https://github.com/theseus-os/volatile" }
 getopts = { git = "https://github.com/theseus-os/getopts" }
 ### use our own no_std-compatible qp trie
 qp-trie = { git = "https://github.com/theseus-os/qp-trie-rs" }
-### use our own no_std-compatible downcast-rs
-downcast-rs = { git = "https://github.com/theseus-os/downcast-rs" }
 ### use the latest version of smoltcp from github; the one on crates.io is out of date
 smoltcp = { git = "https://github.com/m-labs/smoltcp" }


### PR DESCRIPTION
We can now delete the theseus-os fork of `downcast-rs`: https://github.com/theseus-os/downcast-rs