### PR TITLE
Disable spell check for markdown code blocks.

### DIFF
--- a/book/cspell.json
+++ b/book/cspell.json
@@ -1,6 +1,16 @@
 {
     "version": "0.1",
     "language": "en",
+    "languageSettings": [
+        {
+            "languageId": "markdown",
+            "ignoreRegExpList": ["CodeBlock"],
+            "patterns": [{
+                "name": "CodeBlock",
+                "pattern": "^```[\\w\\W]+?^```$"
+            }]
+        }
+    ],
     "ignorePaths": [
         "*.svg"
     ],


### PR DESCRIPTION
Everything between fenced code blocks is ignored by `cspell`. This change makes many of the words added to the `ignoreWords` array unnecessary.