### PR TITLE
Adjust safety of deallocate() functions

### DIFF
--- a/kernel/slabmalloc/src/lib.rs
+++ b/kernel/slabmalloc/src/lib.rs
@@ -32,7 +32,6 @@ mod sc;
 mod zone;
 
 pub use pages::*;
-pub use sc::*;
 pub use zone::*;
 
 use core::alloc::Layout;

--- a/kernel/slabmalloc/src/sc.rs
+++ b/kernel/slabmalloc/src/sc.rs
@@ -88,11 +88,6 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
         new_sc_allocator!(size)
     }
 
-    /// Returns the maximum supported object size of this allocator.
-    pub fn size(&self) -> usize {
-        self.size
-    }
-
     /// Add page to partial list.
     fn insert_partial_slab(&mut self, new_head: &'a mut P) {
         self.slabs.insert_front(new_head);

--- a/kernel/slabmalloc/src/sc.rs
+++ b/kernel/slabmalloc/src/sc.rs
@@ -308,7 +308,11 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
     /// May return an error in case an invalid `layout` is provided.
     /// The function may also move internal slab pages between lists partial -> empty
     /// or full -> partial lists.
-    pub fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
+    ///
+    /// # Safety
+    /// The caller must ensure that `ptr` argument is returned from [`Self::allocate()`]
+    /// and `layout` argument is correct.
+    pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
         assert!(layout.size() <= self.size);
         assert!(self.size <= (P::SIZE - CACHE_LINE_SIZE));
         // trace!(
@@ -323,8 +327,8 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
 
         // Figure out which page we are on and construct a reference to it
         // TODO: The linked list will have another &mut reference
-        let slab_page = unsafe { mem::transmute::<VAddr, &'a mut P>(page) };
-        let new_layout = unsafe { Layout::from_size_align_unchecked(self.size, layout.align()) };
+        let slab_page = mem::transmute::<VAddr, &'a mut P>(page);
+        let new_layout = Layout::from_size_align_unchecked(self.size, layout.align());
 
         let slab_page_was_full = slab_page.is_full();
         let ret = slab_page.deallocate(ptr, new_layout);

--- a/kernel/slabmalloc/src/zone.rs
+++ b/kernel/slabmalloc/src/zone.rs
@@ -3,6 +3,7 @@
 //! The ZoneAllocator achieves this by having many `SCAllocator`s
 
 use crate::*;
+use crate::sc::*;
 
 /// Creates an instance of a zone, we do this in a macro because we
 /// re-use the code in const and non-const functions
@@ -185,7 +186,11 @@ impl<'a> ZoneAllocator<'a> {
     /// # Arguments
     ///  * `ptr` - Address of the memory location to free.
     ///  * `layout` - Memory layout of the block pointed to by `ptr`.
-    pub fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
+    ///
+    /// # Safety
+    /// The caller must ensure that `ptr` argument is returned from [`Self::allocate()`]
+    /// and `layout` argument is correct.
+    pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
         match ZoneAllocator::get_slab(layout.size()) {
             Slab::Base(idx) => self.small_slabs[idx].deallocate(ptr, layout),
             Slab::Large(_idx) => Err("AllocationError::InvalidLayout"),

--- a/kernel/slabmalloc_safe/src/lib.rs
+++ b/kernel/slabmalloc_safe/src/lib.rs
@@ -37,7 +37,6 @@ mod sc;
 mod zone;
 
 pub use pages::*;
-pub use sc::*;
 pub use zone::*;
 
 use core::alloc::Layout;

--- a/kernel/slabmalloc_safe/src/sc.rs
+++ b/kernel/slabmalloc_safe/src/sc.rs
@@ -87,11 +87,6 @@ impl SCAllocator {
         new_sc_allocator!(size)
     }
 
-    /// Returns the maximum supported object size of this allocator.
-    pub fn size(&self) -> usize {
-        self.size
-    }
-
     /// Add a page to the partial list
     fn insert_partial(&mut self, new_page: MappedPages8k) {
         self.slabs.push(new_page);

--- a/kernel/slabmalloc_safe/src/zone.rs
+++ b/kernel/slabmalloc_safe/src/zone.rs
@@ -3,6 +3,7 @@
 //! The ZoneAllocator achieves this by having many `SCAllocator`
 
 use crate::*;
+use crate::sc::*;
 
 /// Creates an instance of a zone, we do this in a macro because we
 /// re-use the code in const and non-const functions
@@ -172,7 +173,11 @@ impl ZoneAllocator {
     /// # Arguments
     ///  * `ptr` - Address of the memory location to free.
     ///  * `layout` - Memory layout of the block pointed to by `ptr`.
-    pub fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
+    ///
+    /// # Safety
+    /// The caller must ensure that `ptr` argument is returned from [`Self::allocate()`]
+    /// and `layout` argument is correct.
+    pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
         match ZoneAllocator::get_slab(layout.size()) {
             Slab::Base(idx) => self.small_slabs[idx].deallocate(ptr, layout),
             Slab::Large(_idx) => Err("AllocationError::InvalidLayout"),

--- a/kernel/slabmalloc_unsafe/src/lib.rs
+++ b/kernel/slabmalloc_unsafe/src/lib.rs
@@ -33,7 +33,6 @@ mod sc;
 mod zone;
 
 pub use pages::*;
-pub use sc::*;
 pub use zone::*;
 
 use core::alloc::Layout;

--- a/kernel/slabmalloc_unsafe/src/sc.rs
+++ b/kernel/slabmalloc_unsafe/src/sc.rs
@@ -88,11 +88,6 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
         new_sc_allocator!(size)
     }
 
-    /// Returns the maximum supported object size of this allocator.
-    pub fn size(&self) -> usize {
-        self.size
-    }
-
     /// Add page to partial list.
     fn insert_partial_slab(&mut self, new_head: &'a mut P) {
         self.slabs.insert_front(new_head);

--- a/kernel/slabmalloc_unsafe/src/sc.rs
+++ b/kernel/slabmalloc_unsafe/src/sc.rs
@@ -287,7 +287,11 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
     /// May return an error in case an invalid `layout` is provided.
     /// The function may also move internal slab pages between lists partial -> empty
     /// or full -> partial lists.
-    pub fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
+    ///
+    /// # Safety
+    /// The caller must ensure that `ptr` argument is returned from [`Self::allocate()`]
+    /// and `layout` argument is correct.
+    pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
         assert!(layout.size() <= self.size);
         assert!(self.size <= (P::SIZE - CACHE_LINE_SIZE));
         // trace!(
@@ -302,8 +306,8 @@ impl<'a, P: AllocablePage> SCAllocator<'a, P> {
 
         // Figure out which page we are on and construct a reference to it
         // TODO: The linked list will have another &mut reference
-        let slab_page = unsafe { mem::transmute::<VAddr, &'a mut P>(page) };
-        let new_layout = unsafe { Layout::from_size_align_unchecked(self.size, layout.align()) };
+        let slab_page = mem::transmute::<VAddr, &'a mut P>(page);
+        let new_layout = Layout::from_size_align_unchecked(self.size, layout.align());
 
         let slab_page_was_full = slab_page.is_full();
         let ret = slab_page.deallocate(ptr, new_layout);

--- a/kernel/slabmalloc_unsafe/src/zone.rs
+++ b/kernel/slabmalloc_unsafe/src/zone.rs
@@ -3,6 +3,7 @@
 //! The ZoneAllocator achieves this by having many `SCAllocator`s
 
 use crate::*;
+use crate::sc::*;
 
 /// Creates an instance of a zone, we do this in a macro because we
 /// re-use the code in const and non-const functions
@@ -185,7 +186,11 @@ impl<'a> ZoneAllocator<'a> {
     /// # Arguments
     ///  * `ptr` - Address of the memory location to free.
     ///  * `layout` - Memory layout of the block pointed to by `ptr`.
-    pub fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
+    ///
+    /// # Safety
+    /// The caller must ensure that `ptr` argument is returned from [`Self::allocate()`]
+    /// and `layout` argument is correct.
+    pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Result<(), &'static str> {
         match ZoneAllocator::get_slab(layout.size()) {
             Slab::Base(idx) => self.small_slabs[idx].deallocate(ptr, layout),
             Slab::Large(_idx) => Err("AllocationError::InvalidLayout"),


### PR DESCRIPTION
This PR adjusts the declared safety of `deallocate()` functions. It also made `SCAllocator` private to its corresponding crate since the allocation/deallocation functionality is exposed through `ZoneAllocator` APIs. Fixes #414.