### PR TITLE
Refactor the `Task` struct to reduce lock contention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,6 +2767,7 @@ dependencies = [
 name = "task"
 version = "0.1.0"
 dependencies = [
+ "atomic",
  "context_switch",
  "environment",
  "irq_safety",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "log",
  "mpmc",
  "spin 0.9.0",
+ "static_assertions",
  "task",
  "wait_queue",
 ]
@@ -1323,7 +1324,6 @@ name = "libtest"
 version = "0.1.0"
 dependencies = [
  "apic",
- "atomic",
  "bit_field 0.10.0",
  "hashbrown",
  "hpet",
@@ -2032,7 +2032,6 @@ name = "pmu_x86"
 version = "0.1.0"
 dependencies = [
  "apic",
- "atomic",
  "bit_field 0.10.0",
  "irq_safety",
  "lazy_static",
@@ -2779,6 +2778,7 @@ dependencies = [
  "root",
  "spin 0.9.0",
  "stack",
+ "static_assertions",
  "tss",
  "x86_64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ dependencies = [
 name = "apic"
 version = "0.1.0"
 dependencies = [
- "atomic",
  "atomic_linked_list",
  "bit_field 0.7.0",
+ "crossbeam-utils",
  "irq_safety",
  "kernel_config",
  "lazy_static",
@@ -137,7 +137,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 name = "async_channel"
 version = "0.1.0"
 dependencies = [
- "atomic",
+ "crossbeam-utils",
  "debugit",
  "hpet",
  "log",
@@ -159,15 +159,6 @@ dependencies = [
  "port_io",
  "spin 0.9.0",
  "storage_device",
-]
-
-[[package]]
-name = "atomic"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -370,6 +361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "channel_app"
 version = "0.1.0"
 dependencies = [
@@ -415,7 +412,7 @@ dependencies = [
 name = "context_switch"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "context_switch_avx",
  "context_switch_regular",
  "context_switch_sse",
@@ -512,6 +509,15 @@ dependencies = [
  "path",
  "qp-trie",
  "spin 0.9.0",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1383,7 +1389,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1433,7 +1439,7 @@ checksum = "fdcec5e97041c7f0f1c5b7d93f12e57293c831c646f4cc7a5db59460c7ea8de6"
 name = "mapper_spillful"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "irq_safety",
  "kernel_config",
  "lazy_static",
@@ -1582,7 +1588,7 @@ name = "mm_eval"
 version = "0.1.0"
 dependencies = [
  "apic",
- "cfg-if",
+ "cfg-if 0.1.10",
  "getopts",
  "hpet",
  "kernel_config",
@@ -1677,7 +1683,7 @@ name = "multiple_heaps"
 version = "0.1.0"
 dependencies = [
  "apic",
- "cfg-if",
+ "cfg-if 0.1.10",
  "hashbrown",
  "heap",
  "intrusive-collections",
@@ -2493,7 +2499,7 @@ name = "simd_personality"
 version = "0.1.0"
 dependencies = [
  "apic",
- "cfg-if",
+ "cfg-if 0.1.10",
  "fs_node",
  "log",
  "memory",
@@ -2507,7 +2513,7 @@ dependencies = [
 name = "simd_test"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "core_simd",
  "log",
  "pit_clock",
@@ -2525,7 +2531,7 @@ dependencies = [
 name = "single_simd_task_optimization"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "log",
  "task",
 ]
@@ -2653,7 +2659,7 @@ dependencies = [
 name = "stack_trace_frame_pointers"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "memory",
 ]
 
@@ -2766,8 +2772,8 @@ dependencies = [
 name = "task"
 version = "0.1.0"
 dependencies = [
- "atomic",
  "context_switch",
+ "crossbeam-utils",
  "environment",
  "irq_safety",
  "kernel_config",
@@ -2980,7 +2986,7 @@ name = "unified_channel"
 version = "0.1.0"
 dependencies = [
  "async_channel",
- "cfg-if",
+ "cfg-if 0.1.10",
  "rendezvous",
 ]
 

--- a/applications/bm/src/lib.rs
+++ b/applications/bm/src/lib.rs
@@ -1555,8 +1555,7 @@ fn get_prog_name() -> String {
         }
     };
 
-    let locked_task = taskref.lock();
-    locked_task.name.clone()
+    taskref.name.clone()
 }
 
 /// Helper function to get the PID of current task
@@ -1569,8 +1568,7 @@ fn getpid() -> usize {
         }
     };
 
-    let locked_task = taskref.lock();
-    locked_task.id
+    taskref.id
 }
 
 
@@ -1589,13 +1587,9 @@ fn hpet_2_time(msg_header: &str, hpet: u64) -> u64 {
 
 /// Helper function to get current working directory
 fn get_cwd() -> Option<DirRef> {
-	if let Some(taskref) = task::get_my_current_task() {
-        let locked_task = &taskref.lock();
-        let curr_env = locked_task.env.lock();
-        return Some(Arc::clone(&curr_env.working_dir));
-    }
-
-    None
+	task::get_my_current_task().map(|t| 
+		Arc::clone(&t.get_env().lock().working_dir)
+	)
 }
 
 /// Helper function to make a temporary file to be used to measure read open latencies

--- a/applications/cat/src/lib.rs
+++ b/applications/cat/src/lib.rs
@@ -53,11 +53,7 @@ pub fn main(args: Vec<String>) -> isize {
     };
 
     // grabs the current working directory pointer; this is scoped so that we drop the lock on the task as soon as we get the working directory pointer
-    let curr_wr = {
-        let locked_task = taskref.lock();
-        let curr_env = locked_task.env.lock();
-        Arc::clone(&curr_env.working_dir)
-    };
+    let curr_wr = Arc::clone(&taskref.get_env().lock().working_dir);
     let path = Path::new(matches.free[0].to_string());
     
     // navigate to the filepath specified by first argument

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -38,18 +38,8 @@ pub fn main(args: Vec<String>) -> isize {
             return -1;
         }
     };
-    // grabs the current environment pointer; this is scoped so that we drop the lock on the "cd" task
-    let curr_env = {
-        let locked_task = taskref.lock();
-        Arc::clone(&locked_task.env)
-    };
-
-    // grabs the current working directory pointer; this is scoped so that we drop the lock on the "cd" task
-    let curr_wr = {
-        let locked_task = taskref.lock();
-        let curr_env = locked_task.env.lock();
-        Arc::clone(&curr_env.working_dir)
-    };
+    let curr_env = taskref.get_env();
+    let curr_wr = Arc::clone(&curr_env.lock().working_dir);
 
     // go to root directory 
     if matches.free.is_empty() {

--- a/applications/cpu/src/lib.rs
+++ b/applications/cpu/src/lib.rs
@@ -39,8 +39,7 @@ pub fn main(args: Vec<String>) -> isize {
         
         if let Some(runqueue) = runqueue::get_runqueue(apic_id).map(|rq| rq.read()) {
             let mut runqueue_contents = String::new();
-            for task_ref in runqueue.iter() {
-                let task = task_ref.lock();
+            for task in runqueue.iter() {
                 runqueue_contents.push_str(&format!("{} ({}) {}\n", 
                     task.name, 
                     task.id,

--- a/applications/deps/src/lib.rs
+++ b/applications/deps/src/lib.rs
@@ -402,7 +402,7 @@ fn find_section(section_name: &str) -> Result<StrongSectionRef, String> {
 
 
 fn get_my_current_namespace() -> Arc<CrateNamespace> {
-    task::get_my_current_task().map(|t| t.get_namespace()).unwrap_or_else(|| 
+    task::get_my_current_task().map(|t| Arc::clone(t.get_namespace())).unwrap_or_else(|| 
         mod_mgmt::get_initial_kernel_namespace().expect("BUG: initial kernel namespace wasn't initialized").clone()
     )
 }

--- a/applications/kill/src/lib.rs
+++ b/applications/kill/src/lib.rs
@@ -60,7 +60,7 @@ fn kill_task(task_id: usize, reap: bool) -> Result<(), String> {
             .and_then(|_| runqueue::remove_task_from_all(&task_ref))
             .is_ok() 
         {
-            println!("Killed task {}", &*task_ref.lock());
+            println!("Killed task {}", &*task_ref);
             if reap {
                 match task_ref.take_exit_value() {
                     Some(exit_val) => { 

--- a/applications/less/src/lib.rs
+++ b/applications/less/src/lib.rs
@@ -49,11 +49,7 @@ fn get_content_string(file_path: String) -> Result<String, String> {
     };
 
     // grabs the current working directory pointer; this is scoped so that we drop the lock on the task as soon as we get the working directory pointer
-    let curr_wr = {
-        let locked_task = taskref.lock();
-        let curr_env = locked_task.env.lock();
-        Arc::clone(&curr_env.working_dir)
-    };
+    let curr_wr = Arc::clone(&taskref.get_env().lock().working_dir);
     let path = Path::new(file_path);
     
     // navigate to the filepath specified by first argument

--- a/applications/loadc/src/lib.rs
+++ b/applications/loadc/src/lib.rs
@@ -64,9 +64,9 @@ pub fn main(args: Vec<String>) -> isize {
 
 fn rmain(matches: Matches) -> Result<c_int, String> {
     let curr_task = task::get_my_current_task().unwrap();
-    let curr_wd   = Arc::clone(&curr_task.lock().env.lock().working_dir);
+    let curr_wd   = Arc::clone(&curr_task.get_env().lock().working_dir);
     let namespace = curr_task.get_namespace();
-    let mmi       = Arc::clone(&curr_task.lock().mmi);
+    let mmi       = &curr_task.mmi;
 
     let path = matches.free.get(0).ok_or_else(|| format!("Missing path to ELF executable"))?;
     let path = Path::new(path.clone());
@@ -84,7 +84,7 @@ fn rmain(matches: Matches) -> Result<c_int, String> {
     // most important of which are static data sections, 
     // as it is logically incorrect to have duplicates of data that are supposed to be global system-wide singletons.
     // We should throw a warning here if there are no relocations in the file, as it was probably built/linked with the wrong arguments.
-    overwrite_relocations(&namespace, &mut segments, &elf_file, &mmi, false)?;
+    overwrite_relocations(&namespace, &mut segments, &elf_file, mmi, false)?;
 
     // Remap each segment's mapped pages using the correct flags; they were previously mapped as always writable.
     {
@@ -272,7 +272,7 @@ fn parse_and_load_elf_executable<'f>(
         // debug!("Adjusted segment vaddr: {:#X}, size: {:#X}, {:?}", start_vaddr, memory_size_in_bytes, this_ap.start_address());
 
         let initial_flags = EntryFlags::from_elf_program_flags(prog_hdr.flags());
-        let mmi = task::get_my_current_task().unwrap().lock().mmi.clone();
+        let mmi = &task::get_my_current_task().unwrap().mmi;
         // Must initially map the memory as writable so we can copy the segment data to it later. 
         let mut mp = mmi.lock().page_table
             .map_allocated_pages(this_ap, initial_flags | EntryFlags::WRITABLE)

--- a/applications/ls/src/lib.rs
+++ b/applications/ls/src/lib.rs
@@ -42,12 +42,7 @@ pub fn main(args: Vec<String>) -> isize {
         }
     };
 
-    // grabs the current working directory pointer; this is scoped so that we drop the lock on the "cd" task
-    let curr_wd = {
-        let locked_task = taskref.lock();
-        let curr_env = locked_task.env.lock();
-        Arc::clone(&curr_env.working_dir)
-    };
+    let curr_wd = Arc::clone(&taskref.get_env().lock().working_dir);
     
     // print children of working directory if no child is specified
     if matches.free.is_empty() {

--- a/applications/mkdir/src/lib.rs
+++ b/applications/mkdir/src/lib.rs
@@ -20,11 +20,7 @@ pub fn main(args: Vec<String>) -> isize {
             // add child dir to current directory
             if let Some(taskref) = task::get_my_current_task() {
                 // grabs a pointer to the current working directory; this is scoped so that we drop the lock on the "mkdir" task as soon as we're finished
-                let curr_dir = {
-                    let locked_task = &taskref.lock();
-                    let curr_env = locked_task.env.lock();
-                    Arc::clone(&curr_env.working_dir)
-                };
+                let curr_dir = Arc::clone(&taskref.get_env().lock().working_dir);
                 let _new_dir = match VFSDirectory::new(dir_name.to_string(), &curr_dir) {
                     Ok(dir) => dir,
                     Err(err) => {println!("{}", err);

--- a/applications/ps/src/lib.rs
+++ b/applications/ps/src/lib.rs
@@ -9,7 +9,7 @@ extern crate scheduler;
 use getopts::Options;
 use alloc::vec::Vec;
 use alloc::string::String;
-use task::{TASKLIST, RunState};
+use task::TASKLIST;
 
 pub fn main(args: Vec<String>) -> isize {
     let mut opts = Options::new();
@@ -55,13 +55,7 @@ pub fn main(args: Vec<String>) -> isize {
         {
             let task = taskref.lock();
             name = task.name.clone();
-            runstate = match &task.runstate {
-                RunState::Initing    => "Initing",
-                RunState::Runnable   => "Runnable",
-                RunState::Blocked    => "Blocked",
-                RunState::Exited(_)  => "Exited",
-                RunState::Reaped     => "Reaped",
-            };
+            runstate = format!("{:?}", task.runstate);
             cpu = task.running_on_cpu.map(|cpu| format!("{}", cpu)).unwrap_or_else(|| String::from("-"));
             pinned = task.pinned_core.map(|pin| format!("{}", pin)).unwrap_or_else(|| String::from("-"));
             task_type = if task.is_an_idle_task {"I"}
@@ -95,16 +89,15 @@ pub fn main(args: Vec<String>) -> isize {
 }
 
 fn print_usage(opts: Options) -> isize {
-    let mut brief = format!("Usage: ps [options] \n \n");
-
-    brief.push_str("TYPE is 'I' if it is an idle task and 'A' if it is an application task. \n");
-    brief.push_str("CPU is the cpu core the task is currently running on. \n");
-    brief.push_str("PIN is the core the task is pinned on, if any. \n");
-    brief.push_str("RUNSATE is runnability status of this task, i.e. whether it's allowed to be scheduled in. \n");
-    brief.push_str("ID is the unique id of task. \n");
-    brief.push_str("NAME is the simple name of the task");
-
-    println!("{} \n", opts.usage(&brief));
-
+    println!("{}", opts.usage(BRIEF));
     0
 }
+
+const BRIEF: &'static str = "Usage: ps [options]\n
+    TYPE:      'I' if an idle task, 'A' if an application task, '-' otherwise.
+    CPU:       the cpu core the task is currently running on.
+    PIN:       the core the task is pinned on, if any.
+    RUNSTATE:  runnability status of this task, e.g., whether it can be scheduled in.
+    ID:        the unique identifier for this task.
+    NAME:      the name of the task.";
+    

--- a/applications/ps/src/lib.rs
+++ b/applications/ps/src/lib.rs
@@ -44,40 +44,37 @@ pub fn main(args: Vec<String>) -> isize {
     // Print all tasks
     let mut num_tasks = 0;
     let mut task_string = String::new();
-    for (id, taskref) in TASKLIST.lock().iter() {
+    for (id, task) in TASKLIST.lock().iter() {
         num_tasks += 1;
-        let name;
         let runstate;
         let cpu;
         let pinned; 
         let task_type;
         // only hold the task's lock for a short time
         {
-            let task = taskref.lock();
-            name = task.name.clone();
-            runstate = format!("{:?}", task.runstate);
-            cpu = task.running_on_cpu.map(|cpu| format!("{}", cpu)).unwrap_or_else(|| String::from("-"));
-            pinned = task.pinned_core.map(|pin| format!("{}", pin)).unwrap_or_else(|| String::from("-"));
+            runstate = task.runstate();
+            cpu = task.running_on_cpu().map(|cpu| format!("{}", cpu)).unwrap_or_else(|| String::from("-"));
+            pinned = task.pinned_core().map(|pin| format!("{}", pin)).unwrap_or_else(|| String::from("-"));
             task_type = if task.is_an_idle_task {"I"}
                 else if task.is_application() {"A"}
                 else {" "} ;
         }    
         if matches.opt_present("b") {
-            task_string.push_str(&format!("{0:<5}  {1}\n", id, name));
+            task_string.push_str(&format!("{0:<5}  {1}\n", id, task.name));
         }
         else {
 
             #[cfg(priority_scheduler)] {
-                let priority = scheduler::get_priority(&taskref).map(|priority| format!("{}", priority)).unwrap_or_else(|| String::from("-"));
+                let priority = scheduler::get_priority(&task).map(|priority| format!("{}", priority)).unwrap_or_else(|| String::from("-"));
                 task_string.push_str(
-                    &format!("{0:<5}  {1:<10}  {2:<4}  {3:<4}  {4:<5}  {5:<10}  {6}\n", 
-                    id, runstate, cpu, pinned, task_type, priority, name)
+                    &format!("{0:<5}  {1:<10?}  {2:<4}  {3:<4}  {4:<5}  {5:<10}  {6}\n", 
+                    id, runstate, cpu, pinned, task_type, priority, task.name)
                 );
             }
             #[cfg(not(priority_scheduler))] {
                 task_string.push_str(
-                    &format!("{0:<5}  {1:<10}  {2:<4}  {3:<4}  {4:<5}  {5}\n", 
-                    id, runstate, cpu, pinned, task_type, name)
+                    &format!("{0:<5}  {1:<10?}  {2:<4}  {3:<4}  {4:<5}  {5}\n", 
+                    id, runstate, cpu, pinned, task_type, task.name)
                 );
             }
         }

--- a/applications/ps/src/lib.rs
+++ b/applications/ps/src/lib.rs
@@ -46,34 +46,28 @@ pub fn main(args: Vec<String>) -> isize {
     let mut task_string = String::new();
     for (id, task) in TASKLIST.lock().iter() {
         num_tasks += 1;
-        let runstate;
-        let cpu;
-        let pinned; 
-        let task_type;
-        // only hold the task's lock for a short time
-        {
-            runstate = task.runstate();
-            cpu = task.running_on_cpu().map(|cpu| format!("{}", cpu)).unwrap_or_else(|| String::from("-"));
-            pinned = task.pinned_core().map(|pin| format!("{}", pin)).unwrap_or_else(|| String::from("-"));
-            task_type = if task.is_an_idle_task {"I"}
-                else if task.is_application() {"A"}
-                else {" "} ;
-        }    
         if matches.opt_present("b") {
             task_string.push_str(&format!("{0:<5}  {1}\n", id, task.name));
         }
         else {
+            // All printed fields below must be strings to ensure the width formatting specifier below works properly.
+            let runstate = format!("{:?}", task.runstate());
+            let cpu = task.running_on_cpu().map(|cpu| format!("{}", cpu)).unwrap_or_else(|| String::from("-"));
+            let pinned = task.pinned_core().map(|pin| format!("{}", pin)).unwrap_or_else(|| String::from("-"));
+            let task_type = if task.is_an_idle_task {"I"}
+                else if task.is_application() {"A"}
+                else {" "} ;
 
             #[cfg(priority_scheduler)] {
                 let priority = scheduler::get_priority(&task).map(|priority| format!("{}", priority)).unwrap_or_else(|| String::from("-"));
                 task_string.push_str(
-                    &format!("{0:<5}  {1:<10?}  {2:<4}  {3:<4}  {4:<5}  {5:<10}  {6}\n", 
+                    &format!("{0:<5}  {1:<10}  {2:<4}  {3:<4}  {4:<5}  {5:<10}  {6}\n", 
                     id, runstate, cpu, pinned, task_type, priority, task.name)
                 );
             }
             #[cfg(not(priority_scheduler))] {
                 task_string.push_str(
-                    &format!("{0:<5}  {1:<10?}  {2:<4}  {3:<4}  {4:<5}  {5}\n", 
+                    &format!("{0:<5}  {1:<10}  {2:<4}  {3:<4}  {4:<5}  {5}\n", 
                     id, runstate, cpu, pinned, task_type, task.name)
                 );
             }

--- a/applications/pwd/src/lib.rs
+++ b/applications/pwd/src/lib.rs
@@ -10,7 +10,7 @@ use alloc::string::String;
 
 pub fn main(_args: Vec<String>) -> isize {
     if let Some(taskref) = task::get_my_current_task() {
-        let curr_env = &taskref.lock().env;
+        let curr_env = taskref.get_env();
         println!("{} \n", curr_env.lock().get_wd_path());
     } else {
         println!("failed to get task ref");    

--- a/applications/rm/src/lib.rs
+++ b/applications/rm/src/lib.rs
@@ -54,11 +54,7 @@ pub fn remove_node(args: Vec<String>) -> Result<(), String> {
         }
     };
 
-    let working_dir = {
-        let locked_task = taskref.lock();
-        let curr_env = locked_task.env.lock();
-        Arc::clone(&curr_env.working_dir)
-    };
+    let working_dir = Arc::clone(&taskref.get_env().lock().working_dir);
 
     if matches.free.is_empty() {
         return Err("rm: missing argument".into());

--- a/applications/rq_eval/src/lib.rs
+++ b/applications/rq_eval/src/lib.rs
@@ -165,11 +165,9 @@ fn run_single(iterations: usize) -> Result<(), &'static str> {
     for _i in 0..iterations {
         runqueue::add_task_to_specific_runqueue(apic::get_my_apic_id(), taskref.clone())?;
 
-        #[cfg(runqueue_spillful)] 
-        {   
-            let task_on_rq = { taskref.lock().on_runqueue.clone() };
+        #[cfg(runqueue_spillful)] {   
             if let Some(remove_from_runqueue) = task::RUNQUEUE_REMOVAL_FUNCTION.get() {
-                if let Some(rq) = task_on_rq {
+                if let Some(rq) = taskref.on_runqueue() {
                     remove_from_runqueue(&taskref, rq)?;
                 }
             }

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -416,7 +416,7 @@ impl Shell {
 
                     // Kill all tasks in the job.
                     for task_ref in &task_refs {
-                        if task_ref.lock().has_exited() { continue; }
+                        if task_ref.has_exited() { continue; }
                         match task_ref.kill(KillReason::Requested) {
                             Ok(_) => {
                                 if let Err(e) = runqueue::remove_task_from_all(&task_ref) {
@@ -433,7 +433,7 @@ impl Shell {
                         // removed from the run queue. We can thereafter release the lock.
                         loop {
                             scheduler::schedule(); // yield the CPU
-                            if !task_ref.lock().is_running() {
+                            if !task_ref.is_running() {
                                 break;
                             }
                         }
@@ -468,7 +468,7 @@ impl Shell {
                     
                     // Stop all tasks in the job.
                     for task_ref in &task_refs {
-                        if task_ref.lock().has_exited() { continue; }
+                        if task_ref.has_exited() { continue; }
                         task_ref.block();
 
                         // Here we must wait for the running application to stop before releasing the lock,
@@ -478,7 +478,7 @@ impl Shell {
                         // truly blocked. We can thereafter release the lock.
                         loop {
                             scheduler::schedule(); // yield the CPU
-                            if !task_ref.lock().is_running() {
+                            if !task_ref.is_running() {
                                 break;
                             }
                         }
@@ -731,7 +731,7 @@ impl Shell {
                 let mut stderr_queues = Vec::new();
 
                 for task_ref in &task_refs {
-                    task_ids.push(task_ref.lock().id);
+                    task_ids.push(task_ref.id);
                 }
 
                 // Set up the chain of queues between applications, and between shell and applications.
@@ -871,11 +871,7 @@ impl Shell {
         };
 
         // Get current working dir.
-        let mut curr_wd = {
-            let locked_task = taskref.lock();
-            let curr_env = locked_task.env.lock();
-            Arc::clone(&curr_env.working_dir)
-        };
+        let mut curr_wd = Arc::clone(&taskref.get_env().lock().working_dir);
 
         // Check if the last character is a slash.
         let slash_ending = match incomplete_cmd.chars().last() {
@@ -1061,8 +1057,8 @@ impl Shell {
 
             let task_refs = job.tasks.clone();
             for task_ref in task_refs {
-                if task_ref.lock().has_exited() { // a task has exited
-                    let exited_task_id = task_ref.lock().id;
+                if task_ref.has_exited() { // a task has exited
+                    let exited_task_id = task_ref.id;
                     if let Some(exit_val) = task_ref.take_exit_value() {
                         match exit_val {
                             ExitValue::Completed(exit_status) => {
@@ -1124,7 +1120,7 @@ impl Shell {
                         }
                     }
 
-                } else if !task_ref.lock().is_runnable() && job.status != JobStatus::Stopped { // task has just stopped
+                } else if !task_ref.is_runnable() && job.status != JobStatus::Stopped { // task has just stopped
 
                     // One task in this job is stopped, but the status of the Job has not been set to
                     // `Stopped`. Let's set it now.
@@ -1433,7 +1429,7 @@ impl Shell {
             if let Ok(job_num) = job_num.parse::<isize>() {
                 if let Some(job) = self.jobs.get_mut(&job_num) {
                     for task_ref in &job.tasks {
-                        if !task_ref.lock().has_exited() {
+                        if !task_ref.has_exited() {
                             task_ref.unblock();
                         }
                         job.status = JobStatus::Running;
@@ -1466,7 +1462,7 @@ impl Shell {
                 if let Some(job) = self.jobs.get_mut(&job_num) {
                     self.fg_job_num = Some(job_num);
                     for task_ref in &job.tasks {
-                        if !task_ref.lock().has_exited() {
+                        if !task_ref.has_exited() {
                             task_ref.unblock();
                         }
                         job.status = JobStatus::Running;

--- a/applications/swap/src/lib.rs
+++ b/applications/swap/src/lib.rs
@@ -72,11 +72,7 @@ fn rmain(matches: Matches) -> Result<(), String> {
     let taskref = task::get_my_current_task()
         .ok_or_else(|| format!("failed to get current task"))?;
 
-    let curr_dir = {
-        let locked_task = taskref.lock();
-        let curr_env = locked_task.env.lock();
-        Arc::clone(&curr_env.working_dir)
-    };
+    let curr_dir = Arc::clone(&taskref.get_env().lock().working_dir);
 
     let override_namespace_crate_dir = if let Some(path) = matches.opt_str("d") {
         let path = Path::new(path);

--- a/applications/upd/src/lib.rs
+++ b/applications/upd/src/lib.rs
@@ -291,9 +291,10 @@ fn apply(base_dir_path: &Path) -> Result<(), String> {
 
 
 fn get_my_current_namespace() -> Arc<CrateNamespace> {
-    task::get_my_current_task().map(|t| t.get_namespace()).unwrap_or_else(|| 
-        mod_mgmt::get_initial_kernel_namespace().expect("BUG: initial kernel namespace wasn't initialized").clone()
-    )
+    task::get_my_current_task()
+        .map(|t| t.get_namespace().clone())
+        .or_else(|| mod_mgmt::get_initial_kernel_namespace().cloned())
+        .expect("BUG: initial kernel namespace wasn't initialized")
 }
 
 

--- a/kernel/apic/Cargo.toml
+++ b/kernel/apic/Cargo.toml
@@ -9,7 +9,7 @@ build = "../../build.rs"
 spin = "0.9.0"
 volatile = "0.2.7"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
-atomic = "0.5.0"
+crossbeam-utils = { version = "0.8.5", default-features = false }
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 bit_field = "0.7.0"
 zerocopy = "0.5.0"

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -17,10 +17,9 @@ extern crate kernel_config;
 extern crate raw_cpuid;
 extern crate x86_64;
 extern crate pit_clock;
-extern crate atomic;
+extern crate crossbeam_utils;
 extern crate bit_field;
 
-use core::sync::atomic::Ordering;
 use volatile::{Volatile, ReadOnly, WriteOnly};
 use zerocopy::FromBytes;
 use alloc::boxed::Box;
@@ -32,7 +31,7 @@ use irq_safety::RwLockIrqSafe;
 use memory::{PageTable, PhysicalAddress, EntryFlags, MappedPages, allocate_pages, allocate_frames_at};
 use kernel_config::time::CONFIG_TIMESLICE_PERIOD_MICROSECONDS;
 use atomic_linked_list::atomic_map::AtomicMap;
-use atomic::Atomic;
+use crossbeam_utils::atomic::AtomicCell;
 use pit_clock::pit_wait;
 use bit_field::BitField;
 
@@ -40,7 +39,7 @@ use bit_field::BitField;
 /// The interrupt chip that is currently configured on this machine. 
 /// The default is `InterruptChip::PIC`, but the typical case is `APIC` or `X2APIC`,
 /// which will be set once those chips have been initialized.
-pub static INTERRUPT_CHIP: Atomic<InterruptChip> = Atomic::new(InterruptChip::PIC);
+pub static INTERRUPT_CHIP: AtomicCell<InterruptChip> = AtomicCell::new(InterruptChip::PIC);
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[repr(u8)]
@@ -50,11 +49,8 @@ pub enum InterruptChip {
     PIC,
 }
 
-pub fn is_lock_free() -> bool {
-    Atomic::<InterruptChip>::is_lock_free()
-}
-// Ensure that `Atomic<InterruptChip>` is actually a lock-free atomic.
-const_assert!(Atomic::<InterruptChip>::is_lock_free());
+// Ensure that `AtomicCell<InterruptChip>` is actually a lock-free atomic.
+const_assert!(AtomicCell::<InterruptChip>::is_lock_free());
 
 
 lazy_static! {
@@ -348,7 +344,7 @@ impl LocalApic {
         unsafe { wrmsr(IA32_APIC_BASE, rdmsr(IA32_APIC_BASE) | IA32_APIC_XAPIC_ENABLE); }
         info!("LAPIC ID {:#x}, version: {:#x}, is_bsp: {}", self.id(), self.version(), is_bsp);
         if is_bsp {
-            INTERRUPT_CHIP.store(InterruptChip::APIC, Ordering::Release);
+            INTERRUPT_CHIP.store(InterruptChip::APIC);
         }
 
         // init APIC to a clean state
@@ -381,7 +377,7 @@ impl LocalApic {
         unsafe { wrmsr(IA32_APIC_BASE, rdmsr(IA32_APIC_BASE) | IA32_APIC_XAPIC_ENABLE | IA32_APIC_X2APIC_ENABLE); }
         info!("LAPIC x2 ID {:#x}, version: {:#x}, is_bsp: {}", self.id(), self.version(), is_bsp);
         if is_bsp {
-            INTERRUPT_CHIP.store(InterruptChip::X2APIC, Ordering::Release);
+            INTERRUPT_CHIP.store(InterruptChip::X2APIC);
         }
 
 

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -43,11 +43,18 @@ use bit_field::BitField;
 pub static INTERRUPT_CHIP: Atomic<InterruptChip> = Atomic::new(InterruptChip::PIC);
 
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[repr(u8)]
 pub enum InterruptChip {
     APIC,
     X2APIC,
     PIC,
 }
+
+pub fn is_lock_free() -> bool {
+    Atomic::<InterruptChip>::is_lock_free()
+}
+// Ensure that `Atomic<InterruptChip>` is actually a lock-free atomic.
+const_assert!(Atomic::<InterruptChip>::is_lock_free());
 
 
 lazy_static! {

--- a/kernel/async_channel/Cargo.toml
+++ b/kernel/async_channel/Cargo.toml
@@ -8,6 +8,7 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 atomic = "0.5.0"
+static_assertions = "1.1.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/async_channel/Cargo.toml
+++ b/kernel/async_channel/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-atomic = "0.5.0"
+crossbeam-utils = { version = "0.8.5", default-features = false }
 static_assertions = "1.1.0"
 
 [dependencies.log]

--- a/kernel/async_channel/src/lib.rs
+++ b/kernel/async_channel/src/lib.rs
@@ -17,18 +17,17 @@ extern crate alloc;
 #[cfg(trace_channel)] #[macro_use] extern crate debugit;
 extern crate wait_queue;
 extern crate mpmc;
-extern crate atomic;
+extern crate crossbeam_utils;
 
 #[cfg(downtime_eval)]
 extern crate hpet;
 #[cfg(downtime_eval)]
 extern crate task;
 
-use core::sync::atomic::Ordering;
 use alloc::sync::Arc;
 use mpmc::Queue as MpmcQueue;
 use wait_queue::WaitQueue;
-use atomic::Atomic;
+use crossbeam_utils::atomic::AtomicCell;
 
 
 /// Create a new channel that allows senders and receivers to 
@@ -50,7 +49,7 @@ pub fn new_channel<T: Send>(minimum_capacity: usize) -> (Sender<T>, Receiver<T>)
         queue: MpmcQueue::with_capacity(minimum_capacity),
         waiting_senders: WaitQueue::new(),
         waiting_receivers: WaitQueue::new(),
-        channel_status: Atomic::new(ChannelStatus::Connected)
+        channel_status: AtomicCell::new(ChannelStatus::Connected)
     });
     (
         Sender   { channel: channel.clone() },
@@ -94,14 +93,11 @@ struct Channel<T: Send> {
     queue: MpmcQueue<T>,
     waiting_senders: WaitQueue,
     waiting_receivers: WaitQueue,
-    channel_status: Atomic<ChannelStatus>
+    channel_status: AtomicCell<ChannelStatus>
 }
 
-pub fn is_lock_free() -> bool {
-    Atomic::<ChannelStatus>::is_lock_free()
-}
-// Ensure that `Atomic<ChannelStatus>` is actually a lock-free atomic.
-const_assert!(Atomic::<ChannelStatus>::is_lock_free());
+// Ensure that `AtomicCell<ChannelStatus>` is actually a lock-free atomic.
+const_assert!(AtomicCell::<ChannelStatus>::is_lock_free());
 
 impl <T: Send> Channel<T> {
     /// Returns true if the channel is disconnected.
@@ -113,7 +109,7 @@ impl <T: Send> Channel<T> {
     /// Returns the channel Status
     #[inline(always)]
     fn get_channel_status(&self) -> ChannelStatus {
-        self.channel_status.load(Ordering::SeqCst)
+        self.channel_status.load()
     }
 }
 
@@ -209,7 +205,7 @@ impl <T: Send> Sender<T> {
         // first we'll check whether the channel is active
         match self.channel.get_channel_status() {
             ChannelStatus::SenderDisconnected => {
-                self.channel.channel_status.store(ChannelStatus::Connected, Ordering::SeqCst);
+                self.channel.channel_status.store(ChannelStatus::Connected);
             },
             ChannelStatus::ReceiverDisconnected  => {
                 return Err((msg, ChannelError::ChannelDisconnected));
@@ -336,7 +332,7 @@ impl <T: Send> Receiver<T> {
             // We check whther the channel is disconnected
             match self.channel.get_channel_status() {
                 ChannelStatus::ReceiverDisconnected => {
-                    self.channel.channel_status.store(ChannelStatus::Connected, Ordering::SeqCst);
+                    self.channel.channel_status.store(ChannelStatus::Connected);
                     Err(ChannelError::ChannelEmpty)
                 },
                 ChannelStatus::SenderDisconnected  => {
@@ -360,7 +356,7 @@ impl <T: Send> Receiver<T> {
 impl<T: Send> Drop for Receiver<T> {
     fn drop(&mut self) {
         // trace!("Dropping the receiver");
-        self.channel.channel_status.store(ChannelStatus::ReceiverDisconnected, Ordering::SeqCst);
+        self.channel.channel_status.store(ChannelStatus::ReceiverDisconnected);
         self.channel.waiting_senders.notify_one();
     }
 }
@@ -369,7 +365,7 @@ impl<T: Send> Drop for Receiver<T> {
 impl<T: Send> Drop for Sender<T> {
     fn drop(&mut self) {
         // trace!("Dropping the sender");
-        self.channel.channel_status.store(ChannelStatus::SenderDisconnected, Ordering::SeqCst);
+        self.channel.channel_status.store(ChannelStatus::SenderDisconnected);
         self.channel.waiting_receivers.notify_one();
     }
 }

--- a/kernel/async_channel/src/lib.rs
+++ b/kernel/async_channel/src/lib.rs
@@ -12,6 +12,7 @@
 #![no_std]
 
 extern crate alloc;
+#[macro_use] extern crate static_assertions;
 #[cfg(trace_channel)] #[macro_use] extern crate log;
 #[cfg(trace_channel)] #[macro_use] extern crate debugit;
 extern crate wait_queue;
@@ -95,6 +96,12 @@ struct Channel<T: Send> {
     waiting_receivers: WaitQueue,
     channel_status: Atomic<ChannelStatus>
 }
+
+pub fn is_lock_free() -> bool {
+    Atomic::<ChannelStatus>::is_lock_free()
+}
+// Ensure that `Atomic<ChannelStatus>` is actually a lock-free atomic.
+const_assert!(Atomic::<ChannelStatus>::is_lock_free());
 
 impl <T: Send> Channel<T> {
     /// Returns true if the channel is disconnected.

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -153,6 +153,8 @@ pub fn init(
             .spawn()?;
     }
 
+    task::is_lock_free();
+
     // Now that initialization is complete, we can spawn various system tasks/daemons
     // and then the first application(s).
     console::start_connection_detection()?;

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -153,8 +153,6 @@ pub fn init(
             .spawn()?;
     }
 
-    task::is_lock_free();
-
     // Now that initialization is complete, we can spawn various system tasks/daemons
     // and then the first application(s).
     console::start_connection_detection()?;

--- a/kernel/exceptions_full/src/lib.rs
+++ b/kernel/exceptions_full/src/lib.rs
@@ -212,7 +212,7 @@ fn kill_and_halt(exception_number: u8, stack_frame: &ExceptionStackFrame, print_
 fn is_stack_overflow(vaddr: VirtualAddress) -> bool {
     let page = Page::containing_address(vaddr);
     task::get_my_current_task()
-        .map(|curr_task| curr_task.lock().kstack.guard_page().contains(&page))
+        .map(|curr_task| curr_task.with_kstack(|kstack| kstack.guard_page().contains(&page)))
         .unwrap_or(false)
 }
 

--- a/kernel/exceptions_full/src/lib.rs
+++ b/kernel/exceptions_full/src/lib.rs
@@ -104,10 +104,7 @@ fn kill_and_halt(exception_number: u8, stack_frame: &ExceptionStackFrame, print_
     // and test out using debug info for recovery
     if false {
         let curr_task = task::get_my_current_task().expect("kill_and_halt: no current task");
-        let app_crate = {
-            let t = curr_task.lock();
-            t.app_crate.as_ref().expect("kill_and_halt: no app_crate").clone_shallow()
-        };
+        let app_crate = curr_task.app_crate.as_ref().expect("kill_and_halt: no app_crate").clone_shallow();
         let debug_symbols_file = {
             let krate = app_crate.lock_as_ref();
             trace!("============== Crate {} =================", krate.crate_name);

--- a/kernel/fault_crate_swap/src/lib.rs
+++ b/kernel/fault_crate_swap/src/lib.rs
@@ -58,7 +58,7 @@ pub fn do_self_swap(
     curr_dir: &DirRef, 
     override_namespace_crate_dir: Option<NamespaceDir>, 
     state_transfer_functions: Vec<String>,
-    namespace: Arc<CrateNamespace>,
+    namespace: &Arc<CrateNamespace>,
     verbose_log: bool
 ) -> Result<SwapRanges, String> {
 
@@ -83,7 +83,7 @@ pub fn do_self_swap(
 
         let swap_req = SwapRequest::new(
             Some(crate_name),
-            Arc::clone(&namespace),
+            Arc::clone(namespace),
             into_new_crate_file,
             new_namespace,
             false, //reexport
@@ -98,7 +98,7 @@ pub fn do_self_swap(
     };
 
 
-    let mut matching_crates = CrateNamespace::get_crates_starting_with(&namespace, crate_name);
+    let mut matching_crates = CrateNamespace::get_crates_starting_with(namespace, crate_name);
 
     // There can be only one matching crate for a given crate name
     if matching_crates.len() == 0 {
@@ -127,7 +127,7 @@ pub fn do_self_swap(
 
     // Swap crates
     let swap_result = swap_crates(
-        &namespace,
+        namespace,
         swap_requests, 
         override_namespace_crate_dir,
         state_transfer_functions,
@@ -139,7 +139,7 @@ pub fn do_self_swap(
     let ocn = crate_name;
 
     // Find the new crate loaded. It should have the exact same name as the old crate
-    let mut matching_crates = CrateNamespace::get_crates_starting_with(&namespace, ocn);
+    let mut matching_crates = CrateNamespace::get_crates_starting_with(namespace, ocn);
 
     // There can be only one matching crate for a given crate name
     if matching_crates.len() == 0 {
@@ -311,11 +311,7 @@ pub fn self_swap_handler(crate_name: &str) -> Result<SwapRanges, String> {
     #[cfg(not(downtime_eval))]
     debug!("The taskref is {:?}",taskref);
 
-    let curr_dir = {
-        let locked_task = taskref.lock();
-        let curr_env = locked_task.env.lock();
-        Arc::clone(&curr_env.working_dir)
-    };
+    let curr_dir = Arc::clone(&taskref.get_env().lock().working_dir);
 
     let override_namespace_crate_dir = Option::<NamespaceDir>::None;
 
@@ -329,16 +325,13 @@ pub fn self_swap_handler(crate_name: &str) -> Result<SwapRanges, String> {
     #[cfg(not(downtime_eval))]
     debug!("tuples: {:?}", tuples);
 
-
-    let namespace = task::get_my_current_task().ok_or("Couldn't get current task")?.get_namespace();    
-
     // 1) Call generic crate swapping routine
     let swap_result = do_self_swap(
         crate_name, 
         &curr_dir, 
         override_namespace_crate_dir,
         state_transfer_functions,
-        namespace,
+        &taskref.namespace,
         verbose
     );
 
@@ -356,14 +349,14 @@ pub fn self_swap_handler(crate_name: &str) -> Result<SwapRanges, String> {
     };
 
     for (_id, taskref) in task::TASKLIST.lock().iter() {
-        let locked_task = taskref.lock();
-        let bottom = locked_task.kstack.bottom().value();
-        let top = locked_task.kstack.top_usable().value();
-        // debug!("Bottom and top of stack of task {} are {:X} {:X}", locked_task.name, bottom, top);
+        let (bottom, top) = taskref.with_kstack(|kstack| 
+            (kstack.bottom().value(), kstack.top_usable().value())
+        ); 
+        // debug!("Bottom and top of stack of task {} are {:X} {:X}", taskref.name, bottom, top);
 
         match constant_offset_fix(&swap_ranges, bottom, top) {
             Err (e) => {
-                debug! {"Failed to perform constant offset fix for the stack for task {} due to {}",locked_task.name, e.to_string()};
+                debug! {"Failed to perform constant offset fix for the stack for task {} due to {}", taskref.name, e.to_string()};
             },
             _ => {},
         }

--- a/kernel/fault_log/src/lib.rs
+++ b/kernel/fault_log/src/lib.rs
@@ -161,13 +161,12 @@ fn update_and_insert_fault_entry_internal(
 
     // Add name of current task
     fe.running_task = {
-        Some(curr_task.lock().name.clone())
+        Some(curr_task.name.clone())
     };
 
     // If task is from an application add application crate name. `None` if not 
     fe.running_app_crate = {
-        let t = curr_task.lock();
-        t.app_crate.as_ref().map(|x| x.lock_as_ref().crate_name.clone())
+        curr_task.app_crate.as_ref().map(|x| x.lock_as_ref().crate_name.clone())
     };
 
     if let Some(instruction_pointer) = instruction_pointer {

--- a/kernel/interrupts/src/lib.rs
+++ b/kernel/interrupts/src/lib.rs
@@ -233,7 +233,7 @@ pub fn deregister_interrupt(interrupt_num: u8, func: HandlerFunc) -> Result<(), 
 /// Send an end of interrupt signal, which works for all types of interrupt chips (APIC, x2apic, PIC)
 /// irq arg is only used for PIC
 pub fn eoi(irq: Option<u8>) {
-    match INTERRUPT_CHIP.load(Ordering::Acquire) {
+    match INTERRUPT_CHIP.load() {
         InterruptChip::APIC |
         InterruptChip::X2APIC => {
             apic::get_my_apic().expect("eoi(): couldn't get my apic to send EOI!").write().eoi();
@@ -364,7 +364,7 @@ extern "x86-interrupt" fn apic_spurious_interrupt_handler(_stack_frame: &mut Exc
 
 extern "x86-interrupt" fn unimplemented_interrupt_handler(_stack_frame: &mut ExceptionStackFrame) {
     println_raw!("\nUnimplemented interrupt handler: {:#?}", _stack_frame);
-	match apic::INTERRUPT_CHIP.load(Ordering::Acquire) {
+	match apic::INTERRUPT_CHIP.load() {
         apic::InterruptChip::PIC => {
             let irq_regs = PIC.get().map(|pic| pic.read_isr_irr());  
             println_raw!("PIC IRQ Registers: {:?}", irq_regs);

--- a/kernel/libtest/Cargo.toml
+++ b/kernel/libtest/Cargo.toml
@@ -9,7 +9,6 @@ build = "../../build.rs"
 spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 bit_field = "0.10.0"
-atomic = "0.5.0"
 libm = "0.2.1"
 
 [dependencies.apic]

--- a/kernel/pmu_x86/Cargo.toml
+++ b/kernel/pmu_x86/Cargo.toml
@@ -9,7 +9,6 @@ build = "../../build.rs"
 spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 bit_field = "0.10.0"
-atomic = "0.5.0"
 
 [dependencies.apic]
 path = "../apic"

--- a/kernel/pmu_x86/src/lib.rs
+++ b/kernel/pmu_x86/src/lib.rs
@@ -849,7 +849,7 @@ pub fn handle_sample(stack_frame: &mut ExceptionStackFrame) -> Result<bool, &'st
     if let Some(taskref) = task::get_my_current_task() {
         let requested_task_id = samples.task_id;
         
-        let task_id = taskref.lock().id;
+        let task_id = taskref.id;
         if (requested_task_id == 0) | (requested_task_id == task_id) {
             samples.ip_list.push(stack_frame.instruction_pointer);
             samples.task_id_list.push(task_id);

--- a/kernel/pmu_x86/src/lib.rs
+++ b/kernel/pmu_x86/src/lib.rs
@@ -72,7 +72,6 @@ extern crate apic;
 #[macro_use] extern crate log;
 extern crate mod_mgmt;
 extern crate bit_field;
-extern crate atomic;
 
 use x86_64::registers::msr::*;
 use x86_64::VirtualAddress;

--- a/kernel/runqueue_priority/src/lib.rs
+++ b/kernel/runqueue_priority/src/lib.rs
@@ -75,11 +75,6 @@ impl PriorityTaskRef {
         priority_taskref
     }
 
-    /// Obtains the lock on the underlying `Task` in a read-only, blocking fashion.
-    pub fn lock(&self) -> MutexIrqSafeGuardRef<Task> {
-       self.taskref.lock()
-    }
-
     /// Increment the number of times the task is picked
     pub fn increment_context_switches(&mut self) -> (){
         self.context_switches = self.context_switches.saturating_add(1);

--- a/kernel/runqueue_priority/src/lib.rs
+++ b/kernel/runqueue_priority/src/lib.rs
@@ -16,9 +16,9 @@ extern crate task;
 extern crate single_simd_task_optimization;
 
 use alloc::collections::VecDeque;
-use irq_safety::{RwLockIrqSafe, MutexIrqSafeGuardRef};
+use irq_safety::RwLockIrqSafe;
 use atomic_linked_list::atomic_map::AtomicMap;
-use task::{TaskRef, Task};
+use task::TaskRef;
 use core::ops::{Deref, DerefMut};
 
 pub const MAX_PRIORITY: u8 = 40;

--- a/kernel/runqueue_priority/src/lib.rs
+++ b/kernel/runqueue_priority/src/lib.rs
@@ -208,12 +208,8 @@ impl RunQueue {
 
     /// Adds a `TaskRef` to this RunQueue.
     fn add_task(&mut self, task: TaskRef) -> Result<(), &'static str> {        
-        #[cfg(single_simd_task_optimization)]
-        let is_simd = task.lock().simd;
-        
-        #[cfg(runqueue_spillful)]
-        {
-            task.lock_mut().on_runqueue = Some(self.core);
+        #[cfg(runqueue_spillful)] {
+            task.set_on_runqueue(Some(self.core));
         }
 
         #[cfg(not(loscd_eval))]
@@ -225,7 +221,7 @@ impl RunQueue {
         {   
             warn!("USING SINGLE_SIMD_TASK_OPTIMIZATION VERSION OF RUNQUEUE::ADD_TASK");
             // notify simd_personality crate about runqueue change, but only for SIMD tasks
-            if is_simd {
+            if task.simd {
                 single_simd_task_optimization::simd_tasks_added_to_core(self.iter(), self.core);
             }
         }
@@ -238,12 +234,10 @@ impl RunQueue {
         debug!("Removing task from runqueue_priority {}, {:?}", self.core, task);
         self.retain(|x| &x.taskref != task);
 
-        #[cfg(single_simd_task_optimization)]
-        {   
-            let is_simd = { task.lock().simd };
+        #[cfg(single_simd_task_optimization)] {   
             warn!("USING SINGLE_SIMD_TASK_OPTIMIZATION VERSION OF RUNQUEUE::REMOVE_TASK");
             // notify simd_personality crate about runqueue change, but only for SIMD tasks
-            if is_simd {
+            if task.simd {
                 single_simd_task_optimization::simd_tasks_removed_from_core(self.iter(), self.core);
             }
         }
@@ -253,16 +247,16 @@ impl RunQueue {
 
 
     /// Removes a `TaskRef` from this RunQueue.
-    pub fn remove_task(&mut self, task: &TaskRef) -> Result<(), &'static str> {
-        #[cfg(runqueue_spillful)]
-        {
+    pub fn remove_task(&mut self, _task: &TaskRef) -> Result<(), &'static str> {
+        #[cfg(runqueue_spillful)] {
             // For the runqueue state spill evaluation, we disable this method because we 
             // only want to allow removing a task from a runqueue from within the TaskRef::internal_exit() method.
-            // trace!("skipping remove_task() on core {}, task {:?}", self.core, task);
+            // trace!("skipping remove_task() on core {}, task {:?}", self.core, _task);
             return Ok(());
         }
-
-        self.remove_internal(task)
+        #[cfg(not(runqueue_spillful))] {
+            self.remove_internal(_task)
+        }
     }
 
 
@@ -282,7 +276,7 @@ impl RunQueue {
     /// Note: This method is only used by the state spillful runqueue implementation.
     pub fn remove_task_from_within_task(task: &TaskRef, core: u8) -> Result<(), &'static str> {
         // warn!("remove_task_from_within_task(): core {}, task: {:?}", core, task);
-        task.lock_mut().on_runqueue = None;
+        task.set_on_runqueue(None);
         RUNQUEUES.get(&core)
             .ok_or("Couldn't get runqueue for specified core")
             .and_then(|rq| {

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -43,11 +43,11 @@ pub fn schedule() -> bool {
         return false;
     }
 
-    trace!("BEFORE TASK_SWITCH CALL (AP {}), current: {:?}, next: {:?}, interrupts are {}", apic_id, curr_task, next_task, irq_safety::interrupts_enabled());
+    // trace!("BEFORE TASK_SWITCH CALL (AP {}), current: {:?}, next: {:?}, interrupts are {}", apic_id, curr_task, next_task, irq_safety::interrupts_enabled());
 
     curr_task.task_switch(next_task.deref(), apic_id); 
 
-    trace!("AFTER TASK_SWITCH CALL (AP {}) new current: {:?}, interrupts are {}", apic_id, get_my_current_task(), irq_safety::interrupts_enabled());
+    // trace!("AFTER TASK_SWITCH CALL (AP {}) new current: {:?}, interrupts are {}", apic_id, get_my_current_task(), irq_safety::interrupts_enabled());
  
     true
 }
@@ -71,7 +71,6 @@ pub fn get_priority(_task: &TaskRef) -> Option<u8> {
         scheduler_priority::get_priority(_task)
     }
     #[cfg(not(priority_scheduler))] {
-        //Err("no scheduler that uses task priority is currently loaded")
         None
     }
 }

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -13,7 +13,7 @@ extern crate runqueue;
 use core::ops::Deref;
 use irq_safety::hold_interrupts;
 use apic::get_my_apic_id;
-use task::{Task, get_my_current_task, TaskRef};
+use task::{get_my_current_task, TaskRef};
 #[cfg(priority_scheduler)] use scheduler_priority::select_next_task;
 #[cfg(not(priority_scheduler))] use scheduler_round_robin::select_next_task;
 
@@ -39,15 +39,15 @@ pub fn schedule() -> bool {
     };
 
     // No need to task switch if the chosen task is the same as the current task.
-    if current_task == next_task {
+    if curr_task == &next_task {
         return false;
     }
 
-    trace!("BEFORE TASK_SWITCH CALL (AP {}), current: {}, next: {}, interrupts are {}", apic_id, curr_task, next_task, irq_safety::interrupts_enabled());
+    trace!("BEFORE TASK_SWITCH CALL (AP {}), current: {:?}, next: {:?}, interrupts are {}", apic_id, curr_task, next_task, irq_safety::interrupts_enabled());
 
     curr_task.task_switch(next_task.deref(), apic_id); 
 
-    trace!("AFTER TASK_SWITCH CALL (AP {}) new current: {}, interrupts are {}", apic_id, get_my_current_task(), irq_safety::interrupts_enabled());
+    trace!("AFTER TASK_SWITCH CALL (AP {}) new current: {:?}, interrupts are {}", apic_id, get_my_current_task(), irq_safety::interrupts_enabled());
  
     true
 }

--- a/kernel/scheduler_priority/src/lib.rs
+++ b/kernel/scheduler_priority/src/lib.rs
@@ -82,9 +82,7 @@ fn select_next_task_priority(apic_id: u8) -> Option<NextTaskResult>  {
     let mut chosen_task_index: Option<usize> = None;
     let mut idle_task = true;
 
-    for (i, priority_taskref) in runqueue_locked.iter().enumerate() {
-        let t = priority_taskref.lock();
-
+    for (i, t) in runqueue_locked.iter().enumerate() {
         // we skip the idle task, and only choose it if no other tasks are runnable
         if t.is_an_idle_task {
             idle_task_index = Some(i);
@@ -97,23 +95,23 @@ fn select_next_task_priority(apic_id: u8) -> Option<NextTaskResult>  {
         }
 
         // if this task is pinned, it must not be pinned to a different core
-        if let Some(pinned) = t.pinned_core {
+        if let Some(pinned) = t.pinned_core() {
             if pinned != apic_id {
                 // with per-core runqueues, this should never happen!
-                error!("select_next_task() (AP {}) found a task pinned to a different core: {:?}", apic_id, *t);
+                error!("select_next_task() (AP {}) found a task pinned to a different core: {:?}", apic_id, &*t);
                 return None;
             }
         }
 
         // if the task has no remaining tokens we ignore the task
-        if priority_taskref.tokens_remaining == 0{
+        if t.tokens_remaining == 0 {
             continue;
         }
             
         // found a runnable task!
         chosen_task_index = Some(i);
         idle_task = false;
-        // debug!("select_next_task(): AP {} chose Task {:?}", apic_id, *t);
+        // debug!("select_next_task(): AP {} chose Task {:?}", apic_id, &*t);
         break; 
     }
 
@@ -155,9 +153,7 @@ fn assign_tokens(apic_id: u8) -> bool  {
     let mut total_priorities :usize = 1;
 
     // This loop calculates the total priorities of the runqueue
-    for (_i, priority_taskref) in runqueue_locked.iter().enumerate() {
-        let t = priority_taskref.lock();
-
+    for (_i, t) in runqueue_locked.iter().enumerate() {
         // we skip the idle task, it contains zero tokens as it is picked last
         if t.is_an_idle_task {
             continue;
@@ -169,22 +165,22 @@ fn assign_tokens(apic_id: u8) -> bool  {
         }
 
         // if this task is pinned, it must not be pinned to a different core
-        if let Some(pinned) = t.pinned_core {
+        if let Some(pinned) = t.pinned_core() {
             if pinned != apic_id {
                 // with per-core runqueues, this should never happen!
-                error!("select_next_task() (AP {}) found a task pinned to a different core: {:?}", apic_id, *t);
+                error!("select_next_task() (AP {}) found a task pinned to a different core: {:?}", apic_id, &*t);
                 return false;
             }
         }
             
         // found a runnable task!
         // We add its priority
-        // debug!("assign_tokens(): AP {} Task {:?} priority {}", apic_id, *t, priority_taskref.priority);
-        total_priorities = total_priorities.saturating_add(1).saturating_add(priority_taskref.priority as usize);
+        // debug!("assign_tokens(): AP {} Task {:?} priority {}", apic_id, &*t, t.priority);
+        total_priorities = total_priorities.saturating_add(1).saturating_add(t.priority as usize);
         
         
         
-        // debug!("assign_tokens(): AP {} chose Task {:?}", apic_id, *t);
+        // debug!("assign_tokens(): AP {} chose Task {:?}", apic_id, &*t);
         // break; 
     }
 
@@ -196,40 +192,32 @@ fn assign_tokens(apic_id: u8) -> bool  {
 
     // We iterate through each task in runqueue
     // We dont use iterator as items are modified in the process
-    for (_i, priority_taskref) in runqueue_locked.iter_mut().enumerate() { 
+    for (_i, t) in runqueue_locked.iter_mut().enumerate() { 
         let task_tokens;
-        {
 
-            //let priority_taskref = match runqueue_locked.get_priority_task_ref(_i){ Some(x) => x, None => { continue;},};
-
-            let t = priority_taskref.lock();
-
-            // we give zero tokens to the idle tasks
-            if t.is_an_idle_task {
-                continue;
-            }
-
-            // we give zero tokens to none runnable tasks
-            if !t.is_runnable() {
-                continue;
-            }
-
-            // if this task is pinned, it must not be pinned to a different core
-            if let Some(pinned) = t.pinned_core {
-                if pinned != apic_id {
-                    // with per-core runqueues, this should never happen!
-                    error!("select_next_task() (AP {}) found a task pinned to a different core: {:?}", apic_id, *t);
-                    return false;
-                }
-            }
-            // task_tokens = epoch * (taskref + 1) / total_priorities;
-            task_tokens = epoch.saturating_mul((priority_taskref.priority as usize).saturating_add(1)).wrapping_div(total_priorities);
+        // we give zero tokens to the idle tasks
+        if t.is_an_idle_task {
+            continue;
         }
-        
-        {
-            priority_taskref.tokens_remaining = task_tokens;
+
+        // we give zero tokens to none runnable tasks
+        if !t.is_runnable() {
+            continue;
         }
-        // debug!("assign_tokens(): AP {} chose Task {:?}", apic_id, *t);
+
+        // if this task is pinned, it must not be pinned to a different core
+        if let Some(pinned) = t.pinned_core() {
+            if pinned != apic_id {
+                // with per-core runqueues, this should never happen!
+                error!("select_next_task() (AP {}) found a task pinned to a different core: {:?}", apic_id, &*t);
+                return false;
+            }
+        }
+        // task_tokens = epoch * (taskref + 1) / total_priorities;
+        task_tokens = epoch.saturating_mul((t.priority as usize).saturating_add(1)).wrapping_div(total_priorities);
+
+        t.tokens_remaining = task_tokens;
+        // debug!("assign_tokens(): AP {} chose Task {:?}", apic_id, &*t);
         // break; 
     }
 

--- a/kernel/scheduler_round_robin/src/lib.rs
+++ b/kernel/scheduler_round_robin/src/lib.rs
@@ -29,9 +29,7 @@ pub fn select_next_task(apic_id: u8) -> Option<TaskRef> {
     let mut idle_task_index: Option<usize> = None;
     let mut chosen_task_index: Option<usize> = None;
 
-    for (i, taskref) in runqueue_locked.iter().enumerate() {
-        let t = taskref.lock();
-
+    for (i, t) in runqueue_locked.iter().enumerate() {
         // we skip the idle task, and only choose it if no other tasks are runnable
         if t.is_an_idle_task {
             idle_task_index = Some(i);
@@ -45,7 +43,7 @@ pub fn select_next_task(apic_id: u8) -> Option<TaskRef> {
             
         // found a runnable task!
         chosen_task_index = Some(i);
-        // debug!("select_next_task(): AP {} chose Task {:?}", apic_id, *t);
+        // debug!("select_next_task(): AP {} chose Task {:?}", apic_id, &*t);
         break;
     }
 

--- a/kernel/single_simd_task_optimization/src/lib.rs
+++ b/kernel/single_simd_task_optimization/src/lib.rs
@@ -31,7 +31,7 @@ pub fn simd_tasks_added_to_core<'t, I>(tasks_on_core: I, _which_core: u8)
 	where I: Iterator<Item = &'t TaskRef>
 {
 	let num_simd_tasks = &tasks_on_core
-		.filter(|taskref| taskref.lock().simd)
+		.filter(|taskref| taskref.simd)
 		.count();
 	warn!("simd_tasks_added_to_core(): core {} now has {} SIMD tasks total.", 
 		_which_core, num_simd_tasks);
@@ -68,7 +68,7 @@ pub fn simd_tasks_removed_from_core<'t, I>(tasks_on_core: I, _which_core: u8)
 	where I: Iterator<Item = &'t TaskRef>
 {
 	let num_simd_tasks = &tasks_on_core
-		.filter(|taskref| taskref.lock().simd)
+		.filter(|taskref| taskref.simd)
 		.count();
 	warn!("simd_tasks_removed_from_core(): core {} now has {} SIMD tasks total.", 
 		_which_core, num_simd_tasks);

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -136,8 +136,7 @@ pub fn new_application_task_builder(
     new_namespace: Option<Arc<CrateNamespace>>,
 ) -> Result<TaskBuilder<MainFunc, MainFuncArg, MainFuncRet>, &'static str> {
     
-    let namespace = new_namespace.clone()
-        .or_else(|| task::get_my_current_task().map(|taskref| taskref.get_namespace()))
+    let namespace = new_namespace.or_else(|| task::get_my_current_task().map(|t| t.get_namespace().clone()))
         .ok_or("spawn::new_application_task_builder(): couldn't get current task to use its CrateNamespace")?;
     
     let crate_object_file = match crate_object_file.get(namespace.dir())
@@ -288,21 +287,22 @@ impl<F, A, R> TaskBuilder<F, A, R>
         // Currently we're using the very bottom of the kstack for kthread arguments. 
         // This is probably stupid (it'd be best to put them directly where they need to go towards the top of the stack),
         // but it simplifies type safety in the `task_wrapper` entry point and removes uncertainty from assumed calling conventions.
-        {
-            let bottom_of_stack: &mut usize = new_task.kstack.as_type_mut(0)?;
+        new_task.with_inner_mut(|inner_mut| -> Result<(), &'static str> {
+            let bottom_of_stack: &mut usize = inner_mut.kstack.as_type_mut(0)?;
             let box_ptr = Box::into_raw(Box::new(TaskFuncArg::<F, A, R> {
                 arg:  self.argument,
                 func: self.func,
                 _rettype: PhantomData,
             }));
             *bottom_of_stack = box_ptr as usize;
-        }
+            Ok(())
+        })?;
 
         // The new task is ready to be scheduled in, now that its stack trampoline has been set up.
         if self.blocked {
-            new_task.runstate = RunState::Blocked;
+            new_task.block();
         } else {
-            new_task.runstate = RunState::Runnable;
+            new_task.unblock();
         }
 
         // The new task is marked as idle
@@ -374,7 +374,7 @@ impl<F, A, R> TaskBuilder<F, A, R>
         // and tell it to use the restartable version of the final task cleanup function.
         self.post_build_function = Some(Box::new(
             move |new_task| {
-                new_task.restart_info = Some(restart_info);
+                new_task.with_inner_mut(|inner_mut| inner_mut.restart_info = Some(restart_info));
                 new_task.failure_cleanup_function = task_restartable_cleanup_failure::<F, A, R>;
                 setup_context_trampoline(new_task, task_wrapper_restartable::<F, A, R>)?;
                 Ok(())
@@ -428,10 +428,13 @@ fn setup_context_trampoline(new_task: &mut Task, entry_point_function: fn() -> !
         ($ContextType:ty) => (
             // We write the new Context struct at the top of the stack, which is at the end of the stack's MappedPages. 
             // We subtract "size of usize" (8) bytes to ensure the new Context struct doesn't spill over past the top of the stack.
-            let mp_offset = new_task.kstack.size_in_bytes() - mem::size_of::<usize>() - mem::size_of::<$ContextType>();
-            let new_context_destination: &mut $ContextType = new_task.kstack.as_type_mut(mp_offset)?;
-            *new_context_destination = <$ContextType>::new(entry_point_function as usize);
-            new_task.saved_sp = new_context_destination as *const _ as usize; 
+            new_task.with_inner_mut(|inner_mut| -> Result<(), &'static str> {
+                let mp_offset = inner_mut.kstack.size_in_bytes() - mem::size_of::<usize>() - mem::size_of::<$ContextType>();
+                let new_context_destination: &mut $ContextType = inner_mut.kstack.as_type_mut(mp_offset)?;
+                *new_context_destination = <$ContextType>::new(entry_point_function as usize);
+                inner_mut.saved_sp = new_context_destination as *const _ as usize;
+                Ok(())
+            })?;
         );
     }
 
@@ -474,22 +477,21 @@ fn task_wrapper_internal<F, A, R>() -> Result<R, task::KillReason>
     // when invoking the task's entry function, in order to simplify cleanup when unwinding.
     // That is, only non-droppable values on the stack are allowed, nothing can be allocated/locked.
     let (func, arg) = {
-        let curr_task_ref = get_my_current_task().expect("BUG: task_wrapper: couldn't get current task (before task func).");
+        let curr_task = get_my_current_task().expect("BUG: task_wrapper: couldn't get current task (before task func).");
 
         // This task's function and argument were placed at the bottom of the stack when this task was spawned.
-        let task_func_arg = {
-            let t = curr_task_ref.lock();
-            let tfa_box_raw_ptr: &usize = t.kstack.as_type(0)
-                .expect("BUG: task_wrapper: couldn't access task's function/argument at bottom of stack");
-            // SAFE: we placed this Box in this task's stack in the `spawn()` function when creating the TaskFuncArg struct.
-            let tfa_boxed = unsafe { Box::from_raw((*tfa_box_raw_ptr) as *mut TaskFuncArg<F, A, R>) };
-            *tfa_boxed // un-box it
-        };
+        let task_func_arg = curr_task.with_kstack(|kstack| {
+            kstack.as_type(0).map(|tfa_box_raw_ptr: &usize| {
+                // SAFE: we placed this Box in this task's stack in the `spawn()` function when creating the TaskFuncArg struct.
+                let tfa_boxed = unsafe { Box::from_raw((*tfa_box_raw_ptr) as *mut TaskFuncArg<F, A, R>) };
+                *tfa_boxed // un-box it
+            })
+        }).expect("BUG: task_wrapper: couldn't access task's function/argument at bottom of stack");
         let (func, arg) = (task_func_arg.func, task_func_arg.arg);
 
         #[cfg(not(any(rq_eval, downtime_eval)))]
         debug!("task_wrapper [1]: \"{}\" about to call task entry func {:?} {{{}}} with arg {:?}",
-            curr_task_ref.lock().name.clone(), debugit!(func), core::any::type_name::<F>(), debugit!(arg)
+            curr_task.name.clone(), debugit!(func), core::any::type_name::<F>(), debugit!(arg)
         );
 
         (func, arg)
@@ -558,9 +560,9 @@ fn task_cleanup_success_internal<R>(current_task: TaskRef, exit_value: R) -> (ir
     let held_interrupts = hold_interrupts();
 
     #[cfg(not(rq_eval))]
-    debug!("task_cleanup_success: {:?} successfully exited with return value {:?}", current_task.lock().name, debugit!(exit_value));
+    debug!("task_cleanup_success: {:?} successfully exited with return value {:?}", current_task.name, debugit!(exit_value));
     if current_task.mark_as_exited(Box::new(exit_value)).is_err() {
-        error!("task_cleanup_success: {:?} task could not set exit value, because task had already exited. Is this correct?", current_task.lock().name);
+        error!("task_cleanup_success: {:?} task could not set exit value, because task had already exited. Is this correct?", current_task.name);
     }
 
     (held_interrupts, current_task)
@@ -595,10 +597,10 @@ fn task_cleanup_failure_internal(current_task: TaskRef, kill_reason: task::KillR
     let held_interrupts = hold_interrupts();
 
     #[cfg(not(downtime_eval))]
-    debug!("task_cleanup_failure: {:?} panicked with {:?}", current_task.lock().name, kill_reason);
+    debug!("task_cleanup_failure: {:?} panicked with {:?}", current_task.name, kill_reason);
 
     if current_task.mark_as_killed(kill_reason).is_err() {
-        error!("task_cleanup_failure: {:?} task could not set kill reason, because task had already exited. Is this correct?", current_task.lock().name);
+        error!("task_cleanup_failure: {:?} task could not set kill reason, because task had already exited. Is this correct?", current_task.name);
     }
 
     (held_interrupts, current_task)
@@ -684,17 +686,15 @@ fn task_restartable_cleanup_final<F, A, R>(held_interrupts: irq_safety::HeldInte
 
         // Re-spawn a new instance of the task if it was spawned as a restartable task. 
         // We must not hold the current task's lock when calling spawn().
-        let restartable_info = {
-            let t = current_task.lock();
-            if let Some(restart_info) = t.restart_info.as_ref() {
+        let restartable_info = current_task.with_restart_info(|restart_info_opt| {
+            restart_info_opt.map(|restart_info| {
                 #[cfg(use_crate_replacement)] {
                     let func_ptr = &(restart_info.func) as *const _ as usize;
                     let arg_ptr = &(restart_info.argument) as *const _ as usize;
 
-                    let arg_size = mem::size_of::<A>();
                     #[cfg(not(downtime_eval))] {
                         debug!("func_ptr {:#X}", func_ptr);
-                        debug!("arg_ptr {:#X} , {}", arg_ptr, arg_size);
+                        debug!("arg_ptr {:#X} , {}", arg_ptr, mem::size_of::<A>());
                     }
 
                     // func_ptr is of size 16. Argument is of the argument_size + 8.
@@ -705,30 +705,23 @@ fn task_restartable_cleanup_final<F, A, R>(held_interrupts: irq_safety::HeldInte
                         debug!("Function and argument addresses corrected");
                     }
                 }
-                
 
                 let func: &F = restart_info.func.downcast_ref().expect("BUG: failed to downcast restartable task's function");
                 let arg : &A = restart_info.argument.downcast_ref().expect("BUG: failed to downcast restartable task's argument");
-                Some((t.name.clone(), func.clone(), arg.clone(), t.pinned_core.clone()))
-            } else {
-                None
-            }
-        };
+                (func.clone(), arg.clone())
+            })
+        });
 
-        if let Some((name, func, arg, pinned_core)) = restartable_info {
-            let new_task = new_task_builder(func, arg)
-                    .name(name);
-
-            if let Some(core) = pinned_core {
-                new_task.pin_on_core(core)
-                .spawn_restartable()
-                .expect("Could not restart the task");
-            } else {
-                new_task.spawn_restartable()
-                .expect("Could not restart the task");
+        if let Some((func, arg)) = restartable_info {
+            let mut new_task = new_task_builder(func, arg)
+                .name(current_task.name.clone());
+            if let Some(core) = current_task.pinned_core() {
+                new_task = new_task.pin_on_core(core);
             }
+            new_task.spawn_restartable()
+                .expect("Failed to respawn the restartable task");
         } else {
-            error!("BUG : Restartable task has no restart information available");
+            error!("BUG: Restartable task has no restart information available");
         }
     }
 

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -45,7 +45,7 @@ use alloc::{
 use irq_safety::{MutexIrqSafe, hold_interrupts, enable_interrupts};
 use memory::{get_kernel_mmi_ref, MemoryManagementInfo};
 use stack::Stack;
-use task::{Task, TaskRef, get_my_current_task, RunState, RestartInfo, TASKLIST};
+use task::{Task, TaskRef, get_my_current_task, RestartInfo, TASKLIST};
 use mod_mgmt::{CrateNamespace, SectionType, SECTION_HASH_DELIMITER};
 use path::Path;
 use apic::get_my_apic_id;
@@ -287,16 +287,13 @@ impl<F, A, R> TaskBuilder<F, A, R>
         // Currently we're using the very bottom of the kstack for kthread arguments. 
         // This is probably stupid (it'd be best to put them directly where they need to go towards the top of the stack),
         // but it simplifies type safety in the `task_wrapper` entry point and removes uncertainty from assumed calling conventions.
-        new_task.with_inner_mut(|inner_mut| -> Result<(), &'static str> {
-            let bottom_of_stack: &mut usize = inner_mut.kstack.as_type_mut(0)?;
-            let box_ptr = Box::into_raw(Box::new(TaskFuncArg::<F, A, R> {
-                arg:  self.argument,
-                func: self.func,
-                _rettype: PhantomData,
-            }));
-            *bottom_of_stack = box_ptr as usize;
-            Ok(())
-        })?;
+        let bottom_of_stack: &mut usize = new_task.inner_mut().kstack.as_type_mut(0)?;
+        let box_ptr = Box::into_raw(Box::new(TaskFuncArg::<F, A, R> {
+            arg:  self.argument,
+            func: self.func,
+            _rettype: PhantomData,
+        }));
+        *bottom_of_stack = box_ptr as usize;
 
         // The new task is ready to be scheduled in, now that its stack trampoline has been set up.
         if self.blocked {
@@ -374,7 +371,7 @@ impl<F, A, R> TaskBuilder<F, A, R>
         // and tell it to use the restartable version of the final task cleanup function.
         self.post_build_function = Some(Box::new(
             move |new_task| {
-                new_task.with_inner_mut(|inner_mut| inner_mut.restart_info = Some(restart_info));
+                new_task.inner_mut().restart_info = Some(restart_info);
                 new_task.failure_cleanup_function = task_restartable_cleanup_failure::<F, A, R>;
                 setup_context_trampoline(new_task, task_wrapper_restartable::<F, A, R>)?;
                 Ok(())
@@ -428,13 +425,10 @@ fn setup_context_trampoline(new_task: &mut Task, entry_point_function: fn() -> !
         ($ContextType:ty) => (
             // We write the new Context struct at the top of the stack, which is at the end of the stack's MappedPages. 
             // We subtract "size of usize" (8) bytes to ensure the new Context struct doesn't spill over past the top of the stack.
-            new_task.with_inner_mut(|inner_mut| -> Result<(), &'static str> {
-                let mp_offset = inner_mut.kstack.size_in_bytes() - mem::size_of::<usize>() - mem::size_of::<$ContextType>();
-                let new_context_destination: &mut $ContextType = inner_mut.kstack.as_type_mut(mp_offset)?;
-                *new_context_destination = <$ContextType>::new(entry_point_function as usize);
-                inner_mut.saved_sp = new_context_destination as *const _ as usize;
-                Ok(())
-            })?;
+            let mp_offset = new_task.inner_mut().kstack.size_in_bytes() - mem::size_of::<usize>() - mem::size_of::<$ContextType>();
+            let new_context_destination: &mut $ContextType = new_task.inner_mut().kstack.as_type_mut(mp_offset)?;
+            *new_context_destination = <$ContextType>::new(entry_point_function as usize);
+            new_task.inner_mut().saved_sp = new_context_destination as *const _ as usize;
         );
     }
 

--- a/kernel/stack_trace/src/lib.rs
+++ b/kernel/stack_trace/src/lib.rs
@@ -63,9 +63,9 @@ pub fn stack_trace(
     unwind::invoke_with_current_registers(|registers| {
         let namespace = task::get_my_current_task()
             .map(|t| t.get_namespace())
-            .or_else(|| mod_mgmt::get_initial_kernel_namespace().cloned())
+            .or_else(|| mod_mgmt::get_initial_kernel_namespace())
             .ok_or("couldn't get current task's or default namespace")?;
-        let mut stack_frame_iter = StackFrameIter::new(namespace, registers);
+        let mut stack_frame_iter = StackFrameIter::new(namespace.clone(), registers);
 
         // iterate over each frame in the call stack
         let mut i = 0;

--- a/kernel/task/Cargo.toml
+++ b/kernel/task/Cargo.toml
@@ -8,6 +8,7 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+atomic = "0.5.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/task/Cargo.toml
+++ b/kernel/task/Cargo.toml
@@ -8,8 +8,8 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
-atomic = "0.5.0"
 static_assertions = "1.1.0"
+crossbeam-utils = { version = "0.8.5", default-features = false }
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/task/Cargo.toml
+++ b/kernel/task/Cargo.toml
@@ -9,6 +9,7 @@ build = "../../build.rs"
 spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
 atomic = "0.5.0"
+static_assertions = "1.1.0"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -337,11 +337,17 @@ const_assert!(AtomicCell::<RunState>::is_lock_free());
 
 impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Task")
+        let mut ds = f.debug_struct("Task");
+        ds.field("name", &self.name)
+            .field("id", &self.id)
             .field("running_on", &self.running_on_cpu)
-            .field("runstate", &self.runstate)
-            .field("pinned", &self.inner.try_lock().map(|l| l.pinned_core).unwrap_or(None))
-            .finish()
+            .field("runstate", &self.runstate);
+        if let Some(inner) = self.inner.try_lock() {
+            ds.field("pinned", &inner.pinned_core);
+        } else {
+            ds.field("pinned", &"<Locked>");
+        }
+        ds.finish()
     }
 }
 

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -214,7 +214,8 @@ pub type FailureCleanupFunction = fn(TaskRef, KillReason) -> !;
 
 
 /// A wrapper around `Option<u8>` with a forced type alignment of 2 bytes,
-/// to ensure lock freedom when using it inside of [`AtomicCell`].
+/// which guarantees that it compiles down to lock-free native atomic instructions
+/// when using it inside of an atomic type like [`AtomicCell`].
 #[derive(Copy, Clone)]
 #[repr(align(2))]
 struct OptionU8(Option<u8>);

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -28,8 +28,6 @@
 #![no_std]
 #![feature(panic_info_message)]
 
-#[cfg(test)] #[macro_use] extern crate std;
-
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;

--- a/kernel/task_fs/src/lib.rs
+++ b/kernel/task_fs/src/lib.rs
@@ -41,7 +41,7 @@ use spin::Mutex;
 use alloc::sync::Arc;
 use fs_node::{DirRef, WeakDirRef, Directory, FileOrDir, File, FileRef, FsNode};
 use memory::MappedPages;
-use task::{TaskRef, TASKLIST, RunState};
+use task::{TaskRef, TASKLIST};
 use path::Path;
 
 
@@ -239,13 +239,7 @@ impl TaskFile {
     fn generate(&self) -> String {
         // Print all tasks
         let name = &self.taskref.lock().name.clone();
-        let runstate = match &self.taskref.lock().runstate {
-            RunState::Initing    => "Initing",
-            RunState::Runnable   => "Runnable",
-            RunState::Blocked    => "Blocked",
-            RunState::Exited(_)  => "Exited",
-            RunState::Reaped     => "Reaped",
-        };
+        let runstate = format!("{:?}", self.taskref.lock().runstate);
         let cpu = self.taskref.lock().running_on_cpu.map(|cpu| format!("{}", cpu)).unwrap_or(String::from("-"));
         let pinned = &self.taskref.lock().pinned_core.map(|pin| format!("{}", pin)).unwrap_or(String::from("-"));
         let task_type = if self.taskref.lock().is_an_idle_task {

--- a/old_crates/spawn_userspace/Cargo.toml
+++ b/old_crates/spawn_userspace/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-atomic = "0.5.0"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 
 


### PR DESCRIPTION
* Move immutable states into `Task` and mutable states into `TaskInner`
* Use properly-aligned and -sized atomic types such that native atomic instructions are actually used. For this, we switch from `atomic::Atomic` to `crossbeam_utils::atomic::AtomicCell` since it actually works. For a custom-target build like Theseus, the [`atomic` crate](https://github.com/Amanieu/atomic-rs) does not get configured properly (due to https://github.com/cuviper/autocfg/issues/34) and thus doesn't actually use native atomic instructions! 
    - Use `const_assert!()` to ensure that all types wrapped in `AtomicCell` actually use native atomic instructions.
* The `runstate` and `running_on_cpu` fields of `Task` are wrapped in `AtomicCell`, enabling them to be accessed in a lock-free manner.
    - This is beneficial for blocking/unblocking tasks in a lock-free context, e.g., within an interrupt handler.
* Removes now-unnecessary unsafe statements from `schedule()`
* Move `ExitValue` out of the `RunState` enum such that `RunState` can be placed within an atomic type.