### PR TITLE
Generalize the `logger` to use any backend that implements `fmt::Write`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,7 +1398,6 @@ version = "0.1.0"
 dependencies = [
  "irq_safety",
  "log",
- "serial_port",
  "spin 0.9.0",
 ]
 

--- a/kernel/io/src/lib.rs
+++ b/kernel/io/src/lib.rs
@@ -643,6 +643,7 @@ impl<IO> Seek for Writer<IO> where IO: KnownLength {
 /// * [`BlockReader`] and [`BlockWriter`]
 /// * [`ByteReader`] and [`ByteWriter`]
 /// * [`bare_io::Read`], [`bare_io::Write`], and [`bare_io::Seek`]
+/// * [`core::fmt::Write`]
 ///
 /// # Usage and Examples
 /// The Rust compiler has difficulty inferring all of the types needed in this struct; 
@@ -769,6 +770,13 @@ impl<'io, IO, L, B> bare_io::Seek for LockableIo<'io, IO, L, B>
     where IO: bare_io::Seek + 'io + ?Sized, L: for <'a> Lockable<'a, IO> + ?Sized, B: Borrow<L>,
 {
     delegate!{ to self.lock_mut() { fn seek(&mut self, position: bare_io::SeekFrom) -> bare_io::Result<u64>; } }
+}
+impl<'io, IO, L, B> core::fmt::Write for LockableIo<'io, IO, L, B>
+    where IO: core::fmt::Write + 'io + ?Sized, L: for <'a> Lockable<'a, IO> + ?Sized, B: Borrow<L>,
+{
+    delegate!{ to self.lock_mut() {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result;
+    } }
 }
 
 

--- a/kernel/logger/Cargo.toml
+++ b/kernel/logger/Cargo.toml
@@ -8,9 +8,6 @@ build = "../../build.rs"
 spin = "0.9.0"
 log = "0.4.8"
 
-[dependencies.serial_port]
-path = "../serial_port"
-
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"
 

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -101,8 +101,8 @@ pub extern "C" fn nano_core_start(
     println_raw!("Entered nano_core_start(). Interrupts disabled.");
 
     // Initialize the logger up front so we can see early log messages for debugging.
-    let logger_serial_ports = [serial_port::SerialPortAddress::COM1];  // some servers use COM2 instead. 
-    try_exit!(logger::init(None, &logger_serial_ports).map_err(|_a| "couldn't init logger!"));
+    let logger_writers = [serial_port::get_serial_port(serial_port::SerialPortAddress::COM1)]; // some servers use COM2 instead. 
+    try_exit!(logger::init(None, &logger_writers).map_err(|_a| "couldn't init logger!"));
     info!("Logger initialized.");
     println_raw!("nano_core_start(): initialized logger."); 
 


### PR DESCRIPTION
* Removes the hard dependency on `serial_port` from `logger`, which causes some problematic dependency chains.