### PR TITLE
Preliminary Intel VT-d IOMMU support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,11 +1415,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "fadt",
  "hpet",
  "ioapic",
+ "iommu",
  "irq_safety",
  "kernel_config",
  "lazy_static",
@@ -194,9 +195,9 @@ checksum = "a165d606cf084741d4ac3a28fb6e9b1eb0bd31f6cd999098cfddb0b2ab381dc0"
 
 [[package]]
 name = "bitflags"
-version = "1.1.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -642,6 +643,7 @@ dependencies = [
  "event_types",
  "fatfs",
  "io",
+ "iommu",
  "ixgbe",
  "keyboard",
  "log",
@@ -1172,6 +1174,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "iommu"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "irq_safety",
+ "log",
+ "memory",
+ "owning_ref",
+ "spin 0.9.0",
+ "static_assertions",
+ "volatile",
+ "zerocopy",
+]
+
+[[package]]
 name = "irq_safety"
 version = "0.1.1"
 source = "git+https://github.com/theseus-os/irq_safety#598d714463fbf07555f3359358662e00a7a8baee"
@@ -1398,11 +1415,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]

--- a/kernel/acpi/Cargo.toml
+++ b/kernel/acpi/Cargo.toml
@@ -68,6 +68,8 @@ path = "hpet"
 [dependencies.dmar]
 path = "dmar"
 
+[dependencies.iommu]
+path = "../iommu"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/acpi/src/lib.rs
+++ b/kernel/acpi/src/lib.rs
@@ -27,6 +27,7 @@ extern crate rsdt;
 extern crate fadt;
 extern crate madt;
 extern crate dmar;
+extern crate iommu;
 
 
 use alloc::vec::Vec;
@@ -109,14 +110,25 @@ pub fn init(page_table: &mut PageTable) -> Result<(), &'static str> {
         let acpi_tables = ACPI_TABLES.lock();
         if let Some(dmar_table) = dmar::Dmar::get(&acpi_tables) {
             debug!("This machine has a DMAR table: flags: {:#b}, host_address_width: {} bits", 
-                dmar_table.flags(), dmar_table.host_address_width(),
+                dmar_table.flags(), dmar_table.host_address_width()
             );
+
             for table in dmar_table.iter() {
                 match table {
                     dmar::DmarEntry::Drhd(drhd) => {
                         debug!("Found DRHD table: INCLUDE_PCI_ALL: {:?}, segment_number: {:#X}, register_base_address: {:#X}", 
                             drhd.include_pci_all(), drhd.segment_number(), drhd.register_base_address(),
                         );
+                        if !drhd.include_pci_all() {
+                            info!("No IOMMU support when INCLUDE_PCI_ALL not set in DRHD");
+                        }
+                        else {
+                            let register_base_address = PhysicalAddress::new(drhd.register_base_address() as usize)
+                                                            .ok_or("IOMMU register_base_address was invalid")?;
+                            iommu::early_init(
+                                dmar_table.host_address_width(), drhd.segment_number(), 
+                                register_base_address, page_table)?;
+                        }
                         debug!("DRHD table has Device Scope entries:");
                         for (_idx, dev_scope) in drhd.iter().enumerate() {
                             debug!("    Device Scope [{}]: type: {}, enumeration_id: {}, start_bus_number: {}", 

--- a/kernel/acpi/src/lib.rs
+++ b/kernel/acpi/src/lib.rs
@@ -125,7 +125,7 @@ pub fn init(page_table: &mut PageTable) -> Result<(), &'static str> {
                         else {
                             let register_base_address = PhysicalAddress::new(drhd.register_base_address() as usize)
                                                             .ok_or("IOMMU register_base_address was invalid")?;
-                            iommu::early_init(
+                            iommu::init(
                                 dmar_table.host_address_width(), drhd.segment_number(), 
                                 register_base_address, page_table)?;
                         }

--- a/kernel/acpi/src/lib.rs
+++ b/kernel/acpi/src/lib.rs
@@ -121,13 +121,15 @@ pub fn init(page_table: &mut PageTable) -> Result<(), &'static str> {
                         );
                         if !drhd.include_pci_all() {
                             info!("No IOMMU support when INCLUDE_PCI_ALL not set in DRHD");
-                        }
-                        else {
+                        } else {
                             let register_base_address = PhysicalAddress::new(drhd.register_base_address() as usize)
-                                                            .ok_or("IOMMU register_base_address was invalid")?;
+                                .ok_or("IOMMU register_base_address was invalid")?;
                             iommu::init(
-                                dmar_table.host_address_width(), drhd.segment_number(), 
-                                register_base_address, page_table)?;
+                                dmar_table.host_address_width(),
+                                drhd.segment_number(), 
+                                register_base_address,
+                                page_table
+                            )?;
                         }
                         debug!("DRHD table has Device Scope entries:");
                         for (_idx, dev_scope) in drhd.iter().enumerate() {

--- a/kernel/device_manager/Cargo.toml
+++ b/kernel/device_manager/Cargo.toml
@@ -69,5 +69,8 @@ path = "../io"
 [dependencies.mlx5]
 path = "../mlx5"
 
+[dependencies.iommu]
+path = "../iommu"
+
 [lib]
 crate-type = ["rlib"]

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -218,11 +218,6 @@ pub fn init(key_producer: Queue<Event>, mouse_producer: Queue<Event>) -> Result<
         }
     }
 
-    // Once devices have been initalized, intialize the IOMMU if it is present
-    if iommu::iommu_present() {
-        iommu::init()?;
-    }
-
     Ok(())
 }
 

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -218,6 +218,11 @@ pub fn init(key_producer: Queue<Event>, mouse_producer: Queue<Event>) -> Result<
         }
     }
 
+    // Once devices have been initalized, intialize the IOMMU if it is present
+    if iommu::iommu_present() {
+        iommu::init()?;
+    }
+
     Ok(())
 }
 

--- a/kernel/iommu/Cargo.toml
+++ b/kernel/iommu/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "iommu"
+version = "0.1.0"
+authors = ["Nicholas Lindsay <nlindsay747@gmail.com>"]
+description = "Intel VT-d IOMMU support"
+build = "../../build.rs"
+
+[dependencies]
+spin = "0.9.0"
+volatile = "0.2.7"
+zerocopy = "0.5.0"
+static_assertions = "1.1.0"
+owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
+bitflags = "1.3.2"
+
+[dependencies.irq_safety]
+git = "https://github.com/theseus-os/irq_safety"
+
+[dependencies.log]
+version = "0.4.14"
+
+[dependencies.memory]
+path = "../memory"
+
+[lib]
+crate-type = ["rlib"]

--- a/kernel/iommu/Cargo.toml
+++ b/kernel/iommu/Cargo.toml
@@ -6,6 +6,7 @@ description = "Intel VT-d IOMMU support"
 build = "../../build.rs"
 
 [dependencies]
+log = "0.4.8"
 spin = "0.9.0"
 volatile = "0.2.7"
 zerocopy = "0.5.0"
@@ -15,9 +16,6 @@ bitflags = "1.3.2"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"
-
-[dependencies.log]
-version = "0.4.14"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/iommu/src/lib.rs
+++ b/kernel/iommu/src/lib.rs
@@ -1,0 +1,167 @@
+//! Intel VT-d (IOMMU) implementation.
+//!
+//! [Specification](https://software.intel.com/content/dam/develop/external/us/en/documents-tps/vt-directed-io-spec.pdf)
+
+#![allow(dead_code)]
+#![no_std]
+
+extern crate alloc;
+extern crate irq_safety;
+#[macro_use] extern crate log;
+#[macro_use] extern crate static_assertions;
+extern crate memory;
+extern crate spin;
+extern crate volatile;
+extern crate zerocopy;
+extern crate owning_ref;
+#[macro_use] extern crate bitflags;
+
+use spin::Once;
+use irq_safety::MutexIrqSafe;
+use memory::{MappedPages, PageTable, EntryFlags, PhysicalAddress, allocate_frames_at, allocate_pages};
+use owning_ref::BoxRefMut;
+use alloc::boxed::Box;
+
+mod regs;
+use regs::*;
+
+/// Struct representing IOMMU (TODO: rename since this is specific to Intel VT-d)
+pub struct IntelIommu {
+    /// Width of host addresses available for DMA
+    host_address_width: u8,
+    /// PCI segment number associated with this IOMMU
+    pci_segment_number: u16,
+    /// Register set base address
+    register_base_address: PhysicalAddress,
+    /// Memory mapped control registers
+    regs: BoxRefMut<MappedPages,IntelIommuRegisters>,
+}
+
+/// Singleton representing IOMMU (TODO: could there be more than one IOMMU?)
+static IOMMU: Once<MutexIrqSafe<IntelIommu>> = Once::new();
+
+/// Initialization of the IOMMU occurs in two stages. In the first stage, the
+/// relevant ACPI tables are parsed and are used to configure internal data
+/// structures.
+///
+/// # Arguments
+/// * `host_address_width`: number of address bits available for DMA
+/// * `pci_segment_number`: PCI segment associated with this IOMMU
+/// * `register_base_address`: base address of register set
+/// * `page_table`: page table to install mapping
+pub fn early_init(host_address_width: u8, pci_segment_number: u16, register_base_address: PhysicalAddress, 
+                    page_table: &mut PageTable) -> Result<(), &'static str> {
+
+    info!("IOMMU Init stage 1 begin.");
+
+    // map memory-mapped registers into virtual address space
+    let mp = map_iommu_registers(page_table, register_base_address)?;
+
+    // pack into BoxRefMut
+    let regs = 
+        BoxRefMut::new(Box::new(mp)).try_map_mut(|mp| mp.as_type_mut::<IntelIommuRegisters>(0))?;
+
+    // get the version number
+    {
+        let contents = regs.version.read();
+        let major_ver = (contents >> 4) & 0xf;
+        let minor_ver = (contents) & 0xf;
+        info!("IOMMU Major Version = {} Minor Version = {}", major_ver, minor_ver);
+    }
+
+    // check IOMMU capabilities/extended capabilities
+    {
+        let c = Capability(regs.cap.read());
+        let ec = ExtendedCapability(regs.ecap.read());
+
+        // List capabilities and extended capabilities
+        // FIXME: Printing capabilities and extended capabilities produces
+        //        lines without a log prefix (e.g. [I]) which is not desirable.
+        info!("IOMMU Capabilities:");
+        info!("{}", c);
+        info!("IOMMU Extended Capabilities:");
+        info!("{}", ec);
+    }
+
+    // try reading the status register
+    {
+        let status = GlobalStatus::from_bits_truncate(regs.gstatus.read());
+        info!("IOMMU Global Status: {:?}", status);
+    }
+
+    // create the "iommu" object
+    let iommu = IntelIommu {
+        host_address_width,
+        pci_segment_number,
+        register_base_address,
+        regs,
+    };
+
+    // initialize the iommu singleton with this object
+    IOMMU.call_once(|| {MutexIrqSafe::new(iommu)});
+
+    info!("IOMMU Init stage 1 complete.");
+
+    Ok(())
+}
+
+/// Second stage of IOMMU initializion, must be called after early_init()
+pub fn init() -> Result<(), &'static str> {
+    info!("IOMMU Init stage 2 begin.");
+
+    // Ensure translation is disabled.
+    //
+    // TODO: This can be removed, it's only purpose is to test that set_command_bit works
+    set_command_bit(GlobalCommand::TE, false, |x: GlobalStatus| { ! x.intersects(GlobalStatus::TES) })?;
+
+    info!("IOMMU Init stage 2 complete.");
+
+    Ok(())
+}
+
+/// Returns true if IOMMU present in system. Must be called after `iommu::early_init`.
+pub fn iommu_present() -> bool {
+    IOMMU.is_completed()
+}
+
+/// Returns MappedPage(s) to IOMMU memory mapped register region
+///
+/// # Arguments:
+/// * `page_table`: page table to install mapping into
+/// * `phys_addr`: physical address of base of mapping (4kB aligned)
+fn map_iommu_registers(page_table: &mut PageTable, phys_addr: PhysicalAddress) -> Result<MappedPages, &'static str>
+{
+    let frames = allocate_frames_at(phys_addr, 1)?;
+    let pages = allocate_pages(1).ok_or("Unable to find virtual page!")?;
+    let flags = EntryFlags::WRITABLE | EntryFlags::NO_CACHE | EntryFlags::NO_EXECUTE;
+    let mapped_pages = page_table.map_allocated_pages_to(pages, frames, flags)?;
+    Ok(mapped_pages)
+}
+
+/// This function writes a command to the IOMMU Global Command register using
+/// the algorithm described in the Intel documentation:
+/// 1. Read global status register into temporary variable.
+/// 2. Clear all bits in temporary variable that have no effect on command register.
+/// 3. Set or clear the corresponding command bit depending on `x`.
+/// 4. Write the variable to the command register.
+/// 5. Wait until `cond` is met, where `cond` is a function of the status register.
+///
+/// The condition checked is passed into this function so that the command
+/// can be performed as a single atomic operation; there is no need for caller
+/// side locking.
+///
+/// # Arguments:
+/// * `c`: command bit to set/clear
+/// * `x`: value to set command bit to
+/// * `cond`: function which interprets status register and returns true when
+///           command has completed.
+fn set_command_bit(c: GlobalCommand, x: bool, cond: impl Fn(GlobalStatus) -> bool) -> Result<(), &'static str> {
+    let iommu = &mut IOMMU.get().ok_or("IOMMU not initialized!")?.lock();
+    let tmp = iommu.regs.gstatus.read();
+    let tmp = tmp & 0x96ffffff;
+    let bits = c as u32;
+    let cmd = if x { tmp | bits } else { tmp & (!bits) };
+    iommu.regs.gcommand.write(cmd);
+    while !cond(GlobalStatus::from_bits_truncate(iommu.regs.gstatus.read())) {}
+    Ok(())
+}

--- a/kernel/iommu/src/lib.rs
+++ b/kernel/iommu/src/lib.rs
@@ -73,12 +73,8 @@ pub fn init(host_address_width: u8, pci_segment_number: u16, register_base_addre
         let ec = ExtendedCapability(regs.ecap.read());
 
         // List capabilities and extended capabilities
-        // FIXME: Printing capabilities and extended capabilities produces
-        //        lines without a log prefix (e.g. [I]) which is not desirable.
-        info!("IOMMU Capabilities:");
-        info!("{}", c);
-        info!("IOMMU Extended Capabilities:");
-        info!("{}", ec);
+        info!("IOMMU Capabilities: {:?}", c);
+        info!("IOMMU Extended Capabilities: {:?}", ec);
     }
 
     // try reading the status register

--- a/kernel/iommu/src/regs.rs
+++ b/kernel/iommu/src/regs.rs
@@ -3,6 +3,7 @@
 use zerocopy::FromBytes;
 use volatile::{ReadOnly, WriteOnly};
 use bitflags::bitflags;
+use core::fmt;
 
 /// Struct which allows direct access to memory mapped registers when
 /// overlayed over corresponding page.
@@ -55,33 +56,31 @@ impl Capability {
     fn nd(&self)      -> u64  { self.0 & 0x7 }
 }
 
-impl core::fmt::Display for Capability {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        // TODO: Do we really want multiple lines, since this interferes with 
-        // logging interface?
-        writeln!(f, "ND:      {}", self.nd())?;
-        writeln!(f, "AFL:     {}", self.afl())?;
-        writeln!(f, "RWBF:    {}", self.rwbf())?;
-        writeln!(f, "PLMR:    {}", self.plmr())?;
-        writeln!(f, "PHMR:    {}", self.phmr())?;
-        writeln!(f, "CM:      {}", self.cm())?;
-        writeln!(f, "SAGAW:   {}", self.sagaw())?;
-        writeln!(f, "MGAW:    {}", self.mgaw())?;
-        writeln!(f, "ZLR:     {}", self.zlr())?;
-        writeln!(f, "FRO:     {}", self.fro())?;
-        writeln!(f, "SLLPS:   {}", self.sllps())?;
-        writeln!(f, "PSI:     {}", self.psi())?;
-        writeln!(f, "NFR:     {}", self.nfr())?;
-        writeln!(f, "MAMV:    {}", self.mamv())?;
-        writeln!(f, "DWD:     {}", self.dwd())?;
-        writeln!(f, "DRD:     {}", self.drd())?;
-        writeln!(f, "FL1GP:   {}", self.fl1gp())?;
-        writeln!(f, "PI:      {}", self.pi())?;
-        writeln!(f, "FL5LP:   {}", self.fl5lp())?;
-        writeln!(f, "ESIRTPS: {}", self.esirtps())?;
-        writeln!(f, "ESRTPS:  {}", self.esrtps())?;
-    
-        Ok(())
+impl fmt::Debug for Capability {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Capability")
+            .field("ND",       &self.nd())
+            .field("AFL",      &self.afl())
+            .field("RWBF",     &self.rwbf())
+            .field("PLMR",     &self.plmr())
+            .field("PHMR",     &self.phmr())
+            .field("CM",       &self.cm())
+            .field("SAGAW",    &self.sagaw())
+            .field("MGAW",     &self.mgaw())
+            .field("ZLR",      &self.zlr())
+            .field("FRO",      &self.fro())
+            .field("SLLPS",    &self.sllps())
+            .field("PSI",      &self.psi())
+            .field("NFR",      &self.nfr())
+            .field("MAMV",     &self.mamv())
+            .field("DWD",      &self.dwd())
+            .field("DRD",      &self.drd())
+            .field("FL1GP",    &self.fl1gp())
+            .field("PI",       &self.pi())
+            .field("FL5LP",    &self.fl5lp())
+            .field("ESIRTPS",  &self.esirtps())
+            .field("ESRTPS",   &self.esrtps())
+            .finish()
     }
 }
 
@@ -120,41 +119,39 @@ impl ExtendedCapability {
     fn c(&self)       -> bool { (self.0) & (1 << 0) != 0 }
 }
 
-impl core::fmt::Display for ExtendedCapability {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // TODO: Do we really want multiple lines, since this interferes with 
-        // logging interface?
-        writeln!(f, "C:       {}", self.c())?;
-        writeln!(f, "QI:      {}", self.qi())?;
-        writeln!(f, "DT:      {}", self.dt())?;
-        writeln!(f, "IR:      {}", self.ir())?;
-        writeln!(f, "EIM:     {}", self.eim())?;
-        writeln!(f, "PT:      {}", self.pt())?;
-        writeln!(f, "SC:      {}", self.sc())?;
-        writeln!(f, "IRO:     {}", self.iro())?;
-        writeln!(f, "MHMV:    {}", self.mhmv())?;
-        writeln!(f, "MTS:     {}", self.mts())?;
-        writeln!(f, "NEST:    {}", self.nest())?;
-        writeln!(f, "PRS:     {}", self.prs())?;
-        writeln!(f, "ERS:     {}", self.ers())?;
-        writeln!(f, "SRS:     {}", self.srs())?;
-        writeln!(f, "NWFS:    {}", self.nwfs())?;
-        writeln!(f, "EAFS:    {}", self.eafs())?;
-        writeln!(f, "PSS:     {}", self.pss())?;
-        writeln!(f, "PASID:   {}", self.pasid())?;
-        writeln!(f, "DIT:     {}", self.dit())?;
-        writeln!(f, "PDS:     {}", self.pds())?;
-        writeln!(f, "SMTS:    {}", self.smts())?;
-        writeln!(f, "VCS:     {}", self.vcs())?;
-        writeln!(f, "SLADS:   {}", self.slads())?;
-        writeln!(f, "SLTS:    {}", self.slts())?;
-        writeln!(f, "FLTS:    {}", self.flts())?;
-        writeln!(f, "SMPWCS:  {}", self.smpwcs())?;
-        writeln!(f, "RPS:     {}", self.rps())?;
-        writeln!(f, "ADMS:    {}", self.adms())?;
-        writeln!(f, "RPRIVS:  {}", self.rprivs())?;
-
-        Ok(())
+impl fmt::Debug for ExtendedCapability {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ExtendedCapability")
+            .field("C",       &self.c())
+            .field("QI",      &self.qi())
+            .field("DT",      &self.dt())
+            .field("IR",      &self.ir())
+            .field("EIM",     &self.eim())
+            .field("PT",      &self.pt())
+            .field("SC",      &self.sc())
+            .field("IRO",     &self.iro())
+            .field("MHMV",    &self.mhmv())
+            .field("MTS",     &self.mts())
+            .field("NEST",    &self.nest())
+            .field("PRS",     &self.prs())
+            .field("ERS",     &self.ers())
+            .field("SRS",     &self.srs())
+            .field("NWFS",    &self.nwfs())
+            .field("EAFS",    &self.eafs())
+            .field("PSS",     &self.pss())
+            .field("PASID",   &self.pasid())
+            .field("DIT",     &self.dit())
+            .field("PDS",     &self.pds())
+            .field("SMTS",    &self.smts())
+            .field("VCS",     &self.vcs())
+            .field("SLADS",   &self.slads())
+            .field("SLTS",    &self.slts())
+            .field("FLTS",    &self.flts())
+            .field("SMPWCS",  &self.smpwcs())
+            .field("RPS",     &self.rps())
+            .field("ADMS",    &self.adms())
+            .field("RPRIVS",  &self.rprivs())
+            .finish()
     }
 }
 

--- a/kernel/iommu/src/regs.rs
+++ b/kernel/iommu/src/regs.rs
@@ -32,26 +32,26 @@ const_assert_eq!(core::mem::size_of::<IntelIommuRegisters>(), 4096);
 pub struct Capability(pub u64);
 
 impl Capability {
-    fn esrtps(&self)  -> bool { (self.0 >> 63) & 0x1 == 0x1 }
-    fn esirtps(&self) -> bool { (self.0 >> 62) & 0x1 == 0x1 }
-    fn fl5lp(&self)   -> bool { (self.0 >> 60) & 0x1 == 0x1 }
-    fn pi(&self)      -> bool { (self.0 >> 59) & 0x1 == 0x1 }
-    fn fl1gp(&self)   -> bool { (self.0 >> 56) & 0x1 == 0x1 }
-    fn drd(&self)     -> bool { (self.0 >> 55) & 0x1 == 0x1 }
-    fn dwd(&self)     -> bool { (self.0 >> 54) & 0x1 == 0x1 }
+    fn esrtps(&self)  -> bool { (self.0) & (1 << 63) != 0 }
+    fn esirtps(&self) -> bool { (self.0) & (1 << 62) != 0 }
+    fn fl5lp(&self)   -> bool { (self.0) & (1 << 60) != 0 }
+    fn pi(&self)      -> bool { (self.0) & (1 << 59) != 0 }
+    fn fl1gp(&self)   -> bool { (self.0) & (1 << 56) != 0 }
+    fn drd(&self)     -> bool { (self.0) & (1 << 55) != 0 }
+    fn dwd(&self)     -> bool { (self.0) & (1 << 54) != 0 }
     fn mamv(&self)    -> u64  { (self.0 >> 48) & 0x3f }
     fn nfr(&self)     -> u64  { ((self.0 >> 40) & 0xff) + 1 }
-    fn psi(&self)     -> bool { (self.0 >> 39) & 0x1 == 0x1 }
+    fn psi(&self)     -> bool { (self.0) & (1 << 39) != 0 }
     fn sllps(&self)   -> u64  { (self.0 >> 34) & 0xf }
     fn fro(&self)     -> u64  { (self.0 >> 24) & 0x3ff }
-    fn zlr(&self)     -> bool { (self.0 >> 22) & 0x1 == 0x1 }
+    fn zlr(&self)     -> bool { (self.0) & (1 << 22) != 0 }
     fn mgaw(&self)    -> u64  { ((self.0 >> 16) & 0x3f) + 1 }
     fn sagaw(&self)   -> u64  { (self.0 >> 8) & 0x1f }
-    fn cm(&self)      -> bool { (self.0 >> 7) & 0x1 == 0x1 }
-    fn phmr(&self)    -> bool { (self.0 >> 6) & 0x1 == 0x1 }
-    fn plmr(&self)    -> bool { (self.0 >> 5) & 0x1 == 0x1 }
-    fn rwbf(&self)    -> bool { (self.0 >> 4) & 0x1 == 0x1 }
-    fn afl(&self)     -> bool { (self.0 >> 3) & 0x1 == 0x1 }
+    fn cm(&self)      -> bool { (self.0) & (1 << 7) != 0 }
+    fn phmr(&self)    -> bool { (self.0) & (1 << 6) != 0 }
+    fn plmr(&self)    -> bool { (self.0) & (1 << 5) != 0 }
+    fn rwbf(&self)    -> bool { (self.0) & (1 << 4) != 0 }
+    fn afl(&self)     -> bool { (self.0) & (1 << 3) != 0 }
     fn nd(&self)      -> u64  { self.0 & 0x7 }
 }
 
@@ -89,35 +89,35 @@ impl core::fmt::Display for Capability {
 pub struct ExtendedCapability(pub u64);
 
 impl ExtendedCapability {
-    fn rprivs(&self)  -> bool { (self.0 >> 53) & 0x1 == 0x1 }
-    fn adms(&self)    -> bool { (self.0 >> 52) & 0x1 == 0x1 }
-    fn rps(&self)     -> bool { (self.0 >> 49) & 0x1 == 0x1 }
-    fn smpwcs(&self)  -> bool { (self.0 >> 48) & 0x1 == 0x1 }
-    fn flts(&self)    -> bool { (self.0 >> 47) & 0x1 == 0x1 }
-    fn slts(&self)    -> bool { (self.0 >> 46) & 0x1 == 0x1 }
-    fn slads(&self)   -> bool { (self.0 >> 45) & 0x1 == 0x1 }
-    fn vcs(&self)     -> bool { (self.0 >> 44) & 0x1 == 0x1 }
-    fn smts(&self)    -> bool { (self.0 >> 43) & 0x1 == 0x1 }
-    fn pds(&self)     -> bool { (self.0 >> 42) & 0x1 == 0x1 }
-    fn dit(&self)     -> bool { (self.0 >> 41) & 0x1 == 0x1 }
-    fn pasid(&self)   -> bool { (self.0 >> 40) & 0x1 == 0x1 }
+    fn rprivs(&self)  -> bool { (self.0) & (1 << 53) != 0 }
+    fn adms(&self)    -> bool { (self.0) & (1 << 52) != 0 }
+    fn rps(&self)     -> bool { (self.0) & (1 << 49) != 0 }
+    fn smpwcs(&self)  -> bool { (self.0) & (1 << 48) != 0 }
+    fn flts(&self)    -> bool { (self.0) & (1 << 47) != 0 }
+    fn slts(&self)    -> bool { (self.0) & (1 << 46) != 0 }
+    fn slads(&self)   -> bool { (self.0) & (1 << 45) != 0 }
+    fn vcs(&self)     -> bool { (self.0) & (1 << 44) != 0 }
+    fn smts(&self)    -> bool { (self.0) & (1 << 43) != 0 }
+    fn pds(&self)     -> bool { (self.0) & (1 << 42) != 0 }
+    fn dit(&self)     -> bool { (self.0) & (1 << 41) != 0 }
+    fn pasid(&self)   -> bool { (self.0) & (1 << 40) != 0 }
     fn pss(&self)     -> u64  { ((self.0 >> 35) & 0x1f) + 1 }
-    fn eafs(&self)    -> bool { (self.0 >> 34) & 0x1 == 0x1 }
-    fn nwfs(&self)    -> bool { (self.0 >> 33) & 0x1 == 0x1 }
-    fn srs(&self)     -> bool { (self.0 >> 31) & 0x1 == 0x1 }
-    fn ers(&self)     -> bool { (self.0 >> 30) & 0x1 == 0x1 }
-    fn prs(&self)     -> bool { (self.0 >> 29) & 0x1 == 0x1 }
-    fn nest(&self)    -> bool { (self.0 >> 26) & 0x1 == 0x1 }
-    fn mts(&self)     -> bool { (self.0 >> 25) & 0x1 == 0x1 }
+    fn eafs(&self)    -> bool { (self.0) & (1 << 34) != 0 }
+    fn nwfs(&self)    -> bool { (self.0) & (1 << 33) != 0 }
+    fn srs(&self)     -> bool { (self.0) & (1 << 31) != 0 }
+    fn ers(&self)     -> bool { (self.0) & (1 << 30) != 0 }
+    fn prs(&self)     -> bool { (self.0) & (1 << 29) != 0 }
+    fn nest(&self)    -> bool { (self.0) & (1 << 26) != 0 }
+    fn mts(&self)     -> bool { (self.0) & (1 << 25) != 0 }
     fn mhmv(&self)    -> u64  { (self.0 >> 20) & 0xf }
     fn iro(&self)     -> u64  { (self.0 >> 8) & 0x3ff }
-    fn sc(&self)      -> bool { (self.0 >> 7) & 0x1 == 0x1 }
-    fn pt(&self)      -> bool { (self.0 >> 6) & 0x1 == 0x1 }
-    fn eim(&self)     -> bool { (self.0 >> 4) & 0x1 == 0x1 }
-    fn ir(&self)      -> bool { (self.0 >> 3) & 0x1 == 0x1 }
-    fn dt(&self)      -> bool { (self.0 >> 2) & 0x1 == 0x1 }
-    fn qi(&self)      -> bool { (self.0 >> 1) & 0x1 == 0x1 }
-    fn c(&self)       -> bool { self.0 & 0x1 == 0x1 }
+    fn sc(&self)      -> bool { (self.0) & (1 << 7) != 0 }
+    fn pt(&self)      -> bool { (self.0) & (1 << 6) != 0 }
+    fn eim(&self)     -> bool { (self.0) & (1 << 4) != 0 }
+    fn ir(&self)      -> bool { (self.0) & (1 << 3) != 0 }
+    fn dt(&self)      -> bool { (self.0) & (1 << 2) != 0 }
+    fn qi(&self)      -> bool { (self.0) & (1 << 1) != 0 }
+    fn c(&self)       -> bool { (self.0) & (1 << 0) != 0 }
 }
 
 impl core::fmt::Display for ExtendedCapability {

--- a/kernel/iommu/src/regs.rs
+++ b/kernel/iommu/src/regs.rs
@@ -1,0 +1,212 @@
+//! This file contains structs that simplify programming the IOMMU.
+
+use zerocopy::FromBytes;
+use volatile::{ReadOnly, WriteOnly};
+use bitflags::bitflags;
+
+/// Struct which allows direct access to memory mapped registers when
+/// overlayed over corresponding page.
+#[derive(FromBytes)]
+#[repr(C)]
+pub struct IntelIommuRegisters {
+    /// Version register
+    pub version:            ReadOnly<u32>,     // 0x00
+    /// Reserved
+    _reserved0:             [u8; 4],           // 0x04 - 0x07
+    /// Capability register
+    pub cap:                ReadOnly<u64>,     // 0x08
+    /// Extended Capability register
+    pub ecap:               ReadOnly<u64>,     // 0x10
+    /// Global command register
+    pub gcommand:           WriteOnly<u32>,    // 0x18
+    /// Global status register
+    pub gstatus:            ReadOnly<u32>,     // 0x1c
+    /// Unimplemented (may be architecturally defined)
+    _unimplemented:         [u8; 4096-0x20],   // 0x20-0xFFF
+}
+// TODO: Hardware may use more than 4kB, which means the registers may occupy
+// more than one contiguous page.
+const_assert_eq!(core::mem::size_of::<IntelIommuRegisters>(), 4096);
+
+/// Helper struct for decoding and printing capability register
+pub struct Capability(pub u64);
+
+impl Capability {
+    fn esrtps(&self)  -> bool { (self.0 >> 63) & 0x1 == 0x1 }
+    fn esirtps(&self) -> bool { (self.0 >> 62) & 0x1 == 0x1 }
+    fn fl5lp(&self)   -> bool { (self.0 >> 60) & 0x1 == 0x1 }
+    fn pi(&self)      -> bool { (self.0 >> 59) & 0x1 == 0x1 }
+    fn fl1gp(&self)   -> bool { (self.0 >> 56) & 0x1 == 0x1 }
+    fn drd(&self)     -> bool { (self.0 >> 55) & 0x1 == 0x1 }
+    fn dwd(&self)     -> bool { (self.0 >> 54) & 0x1 == 0x1 }
+    fn mamv(&self)    -> u64  { (self.0 >> 48) & 0x3f }
+    fn nfr(&self)     -> u64  { ((self.0 >> 40) & 0xff) + 1 }
+    fn psi(&self)     -> bool { (self.0 >> 39) & 0x1 == 0x1 }
+    fn sllps(&self)   -> u64  { (self.0 >> 34) & 0xf }
+    fn fro(&self)     -> u64  { (self.0 >> 24) & 0x3ff }
+    fn zlr(&self)     -> bool { (self.0 >> 22) & 0x1 == 0x1 }
+    fn mgaw(&self)    -> u64  { ((self.0 >> 16) & 0x3f) + 1 }
+    fn sagaw(&self)   -> u64  { (self.0 >> 8) & 0x1f }
+    fn cm(&self)      -> bool { (self.0 >> 7) & 0x1 == 0x1 }
+    fn phmr(&self)    -> bool { (self.0 >> 6) & 0x1 == 0x1 }
+    fn plmr(&self)    -> bool { (self.0 >> 5) & 0x1 == 0x1 }
+    fn rwbf(&self)    -> bool { (self.0 >> 4) & 0x1 == 0x1 }
+    fn afl(&self)     -> bool { (self.0 >> 3) & 0x1 == 0x1 }
+    fn nd(&self)      -> u64  { self.0 & 0x7 }
+}
+
+impl core::fmt::Display for Capability {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        // TODO: Do we really want multiple lines, since this interferes with 
+        // logging interface?
+        writeln!(f, "ND:      {}", self.nd())?;
+        writeln!(f, "AFL:     {}", self.afl())?;
+        writeln!(f, "RWBF:    {}", self.rwbf())?;
+        writeln!(f, "PLMR:    {}", self.plmr())?;
+        writeln!(f, "PHMR:    {}", self.phmr())?;
+        writeln!(f, "CM:      {}", self.cm())?;
+        writeln!(f, "SAGAW:   {}", self.sagaw())?;
+        writeln!(f, "MGAW:    {}", self.mgaw())?;
+        writeln!(f, "ZLR:     {}", self.zlr())?;
+        writeln!(f, "FRO:     {}", self.fro())?;
+        writeln!(f, "SLLPS:   {}", self.sllps())?;
+        writeln!(f, "PSI:     {}", self.psi())?;
+        writeln!(f, "NFR:     {}", self.nfr())?;
+        writeln!(f, "MAMV:    {}", self.mamv())?;
+        writeln!(f, "DWD:     {}", self.dwd())?;
+        writeln!(f, "DRD:     {}", self.drd())?;
+        writeln!(f, "FL1GP:   {}", self.fl1gp())?;
+        writeln!(f, "PI:      {}", self.pi())?;
+        writeln!(f, "FL5LP:   {}", self.fl5lp())?;
+        writeln!(f, "ESIRTPS: {}", self.esirtps())?;
+        writeln!(f, "ESRTPS:  {}", self.esrtps())?;
+    
+        Ok(())
+    }
+}
+
+/// Helper struct for decoding and printing extended capability register
+pub struct ExtendedCapability(pub u64);
+
+impl ExtendedCapability {
+    fn rprivs(&self)  -> bool { (self.0 >> 53) & 0x1 == 0x1 }
+    fn adms(&self)    -> bool { (self.0 >> 52) & 0x1 == 0x1 }
+    fn rps(&self)     -> bool { (self.0 >> 49) & 0x1 == 0x1 }
+    fn smpwcs(&self)  -> bool { (self.0 >> 48) & 0x1 == 0x1 }
+    fn flts(&self)    -> bool { (self.0 >> 47) & 0x1 == 0x1 }
+    fn slts(&self)    -> bool { (self.0 >> 46) & 0x1 == 0x1 }
+    fn slads(&self)   -> bool { (self.0 >> 45) & 0x1 == 0x1 }
+    fn vcs(&self)     -> bool { (self.0 >> 44) & 0x1 == 0x1 }
+    fn smts(&self)    -> bool { (self.0 >> 43) & 0x1 == 0x1 }
+    fn pds(&self)     -> bool { (self.0 >> 42) & 0x1 == 0x1 }
+    fn dit(&self)     -> bool { (self.0 >> 41) & 0x1 == 0x1 }
+    fn pasid(&self)   -> bool { (self.0 >> 40) & 0x1 == 0x1 }
+    fn pss(&self)     -> u64  { ((self.0 >> 35) & 0x1f) + 1 }
+    fn eafs(&self)    -> bool { (self.0 >> 34) & 0x1 == 0x1 }
+    fn nwfs(&self)    -> bool { (self.0 >> 33) & 0x1 == 0x1 }
+    fn srs(&self)     -> bool { (self.0 >> 31) & 0x1 == 0x1 }
+    fn ers(&self)     -> bool { (self.0 >> 30) & 0x1 == 0x1 }
+    fn prs(&self)     -> bool { (self.0 >> 29) & 0x1 == 0x1 }
+    fn nest(&self)    -> bool { (self.0 >> 26) & 0x1 == 0x1 }
+    fn mts(&self)     -> bool { (self.0 >> 25) & 0x1 == 0x1 }
+    fn mhmv(&self)    -> u64  { (self.0 >> 20) & 0xf }
+    fn iro(&self)     -> u64  { (self.0 >> 8) & 0x3ff }
+    fn sc(&self)      -> bool { (self.0 >> 7) & 0x1 == 0x1 }
+    fn pt(&self)      -> bool { (self.0 >> 6) & 0x1 == 0x1 }
+    fn eim(&self)     -> bool { (self.0 >> 4) & 0x1 == 0x1 }
+    fn ir(&self)      -> bool { (self.0 >> 3) & 0x1 == 0x1 }
+    fn dt(&self)      -> bool { (self.0 >> 2) & 0x1 == 0x1 }
+    fn qi(&self)      -> bool { (self.0 >> 1) & 0x1 == 0x1 }
+    fn c(&self)       -> bool { self.0 & 0x1 == 0x1 }
+}
+
+impl core::fmt::Display for ExtendedCapability {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // TODO: Do we really want multiple lines, since this interferes with 
+        // logging interface?
+        writeln!(f, "C:       {}", self.c())?;
+        writeln!(f, "QI:      {}", self.qi())?;
+        writeln!(f, "DT:      {}", self.dt())?;
+        writeln!(f, "IR:      {}", self.ir())?;
+        writeln!(f, "EIM:     {}", self.eim())?;
+        writeln!(f, "PT:      {}", self.pt())?;
+        writeln!(f, "SC:      {}", self.sc())?;
+        writeln!(f, "IRO:     {}", self.iro())?;
+        writeln!(f, "MHMV:    {}", self.mhmv())?;
+        writeln!(f, "MTS:     {}", self.mts())?;
+        writeln!(f, "NEST:    {}", self.nest())?;
+        writeln!(f, "PRS:     {}", self.prs())?;
+        writeln!(f, "ERS:     {}", self.ers())?;
+        writeln!(f, "SRS:     {}", self.srs())?;
+        writeln!(f, "NWFS:    {}", self.nwfs())?;
+        writeln!(f, "EAFS:    {}", self.eafs())?;
+        writeln!(f, "PSS:     {}", self.pss())?;
+        writeln!(f, "PASID:   {}", self.pasid())?;
+        writeln!(f, "DIT:     {}", self.dit())?;
+        writeln!(f, "PDS:     {}", self.pds())?;
+        writeln!(f, "SMTS:    {}", self.smts())?;
+        writeln!(f, "VCS:     {}", self.vcs())?;
+        writeln!(f, "SLADS:   {}", self.slads())?;
+        writeln!(f, "SLTS:    {}", self.slts())?;
+        writeln!(f, "FLTS:    {}", self.flts())?;
+        writeln!(f, "SMPWCS:  {}", self.smpwcs())?;
+        writeln!(f, "RPS:     {}", self.rps())?;
+        writeln!(f, "ADMS:    {}", self.adms())?;
+        writeln!(f, "RPRIVS:  {}", self.rprivs())?;
+
+        Ok(())
+    }
+}
+
+/// Bits corresponding to commands in the Global Command register.
+pub enum GlobalCommand {
+    /// Compatibility Format Interrupt
+    CFI   = 1 << 23,
+    /// Set Interrupt Remap Table Pointer
+    SIRTP = 1 << 24,
+    /// Interrupt Remapping Enable
+    IRE   = 1 << 25,
+    /// Queued Invalidation Enable
+    QIE   = 1 << 26,
+    /// Write Buffer Flush
+    WBF   = 1 << 27,
+    /// Enable Advanced Fault Logging
+    EAFL  = 1 << 28,
+    /// Set Fault Log
+    SFL   = 1 << 29,
+    /// Set Root Table Pointer
+    SRTP  = 1 << 30,
+    /// Translation Enable
+    TE    = 1 << 31,
+}
+
+bitflags! {
+    /// Global status register flags.
+    ///
+    /// The lowest 22 bits are `RsvdZ`. This is Intel parleance meaning that
+    /// they may be used in the future, but for now, all writes to these
+    /// bits must have the value 0. Since these bits may have values in the
+    /// future, the `from_bits_truncate()` method should be used to construct
+    /// this object from the underlying bit representation. Note of course
+    /// that this conversion is not invertible.
+    pub struct GlobalStatus: u32 {
+        /// Compatibility Format Interrupt Status
+        const CFIS  = 1 << 23;
+        /// Interrupt Remapping Table Pointer Status
+        const IRTPS = 1 << 24;
+        /// Interrupt Remapping Enable Status
+        const IRES  = 1 << 25;
+        /// Queued Invalidation Enable Status
+        const QIES  = 1 << 26;
+        /// Write Buffer Flush Status
+        const WBFS  = 1 << 27;
+        /// Advanced Fault Logging Status
+        const AFLS  = 1 << 28;
+        /// Fault Log Status
+        const FLS   = 1 << 29;
+        /// Root Table Pointer Status
+        const RTPS  = 1 << 30;
+        /// Translation Enable Status
+        const TES   = 1 << 31;
+    }
+}


### PR DESCRIPTION
# Overview

Adds preliminary driver support for an Intel IOMMU implementing Intel VT-d (Intel Virtualization for Directed I/O). Currently all we do is detect the IOMMU, and if detected, print out some useful information. This sets the groundwork for the rest of the IOMMU implementation.

This preliminary driver performs the following:
* Initialize the kernel IOMMU object if it is detected in the ACPI DMAR table (see `acpi::init()` and `iommu::early_init()`)
   * Map the IOMMU's memory-mapped registers into virtual memory
* Output the interpreted contents of the following IOMMU registers to the log:
  * `Version Register`
  * `Capability Register`
  * `Extended Capability Register`
  * `Global Status Register`
* Further initialization will be performed by calling `iommu::init()` from  `device_manager::init()` - although currently `iommu::init()` doesn't do anything useful.

Additionally, the driver provides a mechanism for sending commands to the IOMMU `Global Command Register` (and waiting until the command is complete).

# Testing

To test IOMMU support, pass `IOMMU=yes` when invoking the Makefile QEMU target (`orun` etc). Details about the IOMMU will be printed to the log.

Please test with and without `IOMMU=yes`.

# Outstanding issues:
* Printing to the log the interpreted contents of the `Capability Register` and `Extended Capability Register` produces multiple lines, of which only the first line has the log prefix (e.g. `[I] ...`)
* Only a single IOMMU is supported. Support for multiple IOMMUs can be added in the future.
* Further initialization in `device_manager::init()` currently doesn't do anything useful but is there because I anticipate it will be needed in the future.