### PR TITLE
Fix: Overflow in TSC (Timestamp counter)

### DIFF
--- a/kernel/libterm/src/cursor.rs
+++ b/kernel/libterm/src/cursor.rs
@@ -7,7 +7,7 @@ pub struct Cursor {
     /// Whether the cursor is enabled in the terminal.
     enabled: bool,
     /// The blinking frequency.
-    freq: u64,
+    freq: u128,
     /// The last time it blinks.
     time: TscTicks,
     /// The current blinking state show/hidden

--- a/kernel/libterm/src/lib.rs
+++ b/kernel/libterm/src/lib.rs
@@ -45,7 +45,7 @@ pub mod cursor;
 
 pub const FONT_FOREGROUND_COLOR: Color = color::LIGHT_GREEN;
 pub const FONT_BACKGROUND_COLOR: Color = color::BLACK;
-const DEFAULT_CURSOR_FREQ: u64 = 400000000;
+const DEFAULT_CURSOR_FREQ: u128 = 400000000;
 
 /// Error type for tracking different scroll errors that a terminal
 /// application could encounter.

--- a/kernel/tsc/src/lib.rs
+++ b/kernel/tsc/src/lib.rs
@@ -11,13 +11,14 @@ pub struct TscTicks(u128);
 
 impl TscTicks {
     /// Converts ticks to nanoseconds. 
+    ///
     /// Returns `None` if the TSC tick frequency is unavailable 
-    /// or if overflow occured.
+    /// or if overflow occured during the conversion.
     pub fn to_ns(&self) -> Option<u128> {
         get_tsc_frequency()
             .ok()
             .and_then(|freq| self.0.checked_mul(1000000000)
-                    .map(|checked_tsc| checked_tsc / freq)
+                .map(|checked_tsc| checked_tsc / freq)
             )
     }
 


### PR DESCRIPTION
Fixed the panic due to overflow of 64-bit unsigned integer by extending the size to 128 bits. The changes are reflected on `kernel/tsc/src/lib.rs`, also the `kernel/libterm` crate depends on the value from timestamp counter for some internal calculation, so the necessary changes are also made in this crate (updated the size of blinking frequency from 64 to 128 bits).