### PR TITLE
Better mode and CRLF handling for headless ANSI terminal

### DIFF
--- a/kernel/text_terminal/src/ansi_style.rs
+++ b/kernel/text_terminal/src/ansi_style.rs
@@ -498,32 +498,41 @@ pub struct AsciiControlCodes;
 #[allow(non_upper_case_globals)]
 impl AsciiControlCodes {
     /// (BEL) Plays a terminal bell or beep.
+    ///
     /// `Ctrl + G`, or `'\a'`.
     pub const Bell: u8 = 0x07;
     /// (BS) Moves the cursor backwards by one unit/character, but does not remove it.
     /// Note that this is different than the typical behavior of the "Backspace" key on a keyboard.
+    ///
     /// `Ctrl + H`, or `'\b'`.
     pub const Backspace: u8 = 0x08;
     /// (HT) Inserts a horizontal tab.
+    ///
     /// `Ctrl + I`, or `'\t'`.
     pub const Tab: u8 = 0x09;
-    /// (LF) Moves the cursor to the next line, i.e., Line feed.
+    /// (LF) Moves the cursor to the next line, i.e., Line feed, or new line / newline.
+    ///
     /// `Ctrl + J`, or `'\n'`.
-    pub const NewLine: u8 = 0x0A;
+    pub const LineFeed: u8 = 0x0A;
     /// (VT) Inserts a vertical tab.
+    ///
     /// `Ctrl + K`, or `'\v'`.
     pub const VerticalTab: u8 = 0x0B;
     /// (FF) Inserts a page break (form feed) to move the cursor/prompt to the beginning of a new page (screen).
+    ///
     /// `Ctrl + L`, or `'\f'`.
     pub const PageBreak: u8 = 0x0C;
     /// (CR) Moves the cursor to the beginning of the line, i.e., carriage return.
+    ///
     /// `Ctrl + M`, or `'\r'`.
     pub const CarriageReturn: u8 = 0x0D;
     /// (ESC) The escape character.
+    ///
     /// `ESC`, or `'\e'`.
     pub const Escape: u8 = 0x1B;
     /// (DEL) Backwards-deletes the character before (to the left of) the cursor.
     /// This is equivalent to what the Backspace key on a keyboard typically does.
+    ///
     /// `DEL`.
     pub const BackwardsDelete: u8 = 0x7F;
 }

--- a/kernel/text_terminal/src/lib.rs
+++ b/kernel/text_terminal/src/lib.rs
@@ -410,9 +410,8 @@ impl<Backend: TerminalBackend> TextTerminal<Backend> {
         terminal.backend.clear_screen();
         terminal.backend.move_cursor_to(ScreenPoint::default());
 
-        // By default, the terminal backend should not be in insert mode (aka replace mode),
-        // as that may prevent proper operation of the backwards delete functionality.
-        terminal.backend.set_insert_mode(false);
+        // By default, terminal backends typically operate in Overwrite mode, not Insert mode.
+        terminal.backend.set_insert_mode(InsertMode::Overwrite);
         
         let welcome = "Welcome to Theseus's text terminal!";
         terminal.handle_input(&mut welcome.as_bytes()).expect("failed to write terminal welcome message");
@@ -676,30 +675,22 @@ impl<'term, Backend: TerminalBackend> Perform for TerminalParserHandler<'term, B
     }
 
     fn execute(&mut self, byte: u8) {
-        debug!("[EXECUTE]: byte: {:#X} ({})", byte, byte as char);
+        debug!("[EXECUTE]: byte: {:#X} ({:?})", byte, byte as char);
 
         let screen_size = self.backend.screen_size();
 
         match byte {
-            AsciiControlCodes::NewLine | AsciiControlCodes::CarriageReturn => {
-                // Insert a new line into the scrollback buffer
-                let new_line_idx = self.scrollback_cursor.line_idx + LineIndex(1); 
-                self.scrollback_cursor.line_idx = new_line_idx;
-                self.scrollback_cursor.unit_idx = UnitIndex(0); 
-                self.scrollback_buffer.insert(new_line_idx.0, Line::new());
-                self.cursor.underneath = Unit::default(); // TODO: use style from the previous unit
-                
-                // Adjust the screen cursor to the next row
-                let needs_scroll_down = {
-                    self.cursor.position.column = Column(0);
-                    self.cursor.position.row.0 += 1;
-                    if self.cursor.position.row >= screen_size.num_rows {
-                        self.cursor.position.row.0 = screen_size.num_rows.0 - 1;
-                        true
-                    } else {
-                        false
-                    }
-                };
+            AsciiControlCodes::CarriageReturn => {
+                self.carriage_return();
+                if self.mode.cr_sends_lf == CarriageReturnSendsLineFeed::Yes {
+                    self.line_feed();
+                }
+            }
+            AsciiControlCodes::LineFeed | AsciiControlCodes::VerticalTab => {
+                self.line_feed();
+                if self.mode.lf_sends_cr == LineFeedSendsCarriageReturn::Yes {
+                    self.carriage_return();
+                }
             }
             AsciiControlCodes::Tab => self.print('\t'),
             AsciiControlCodes::Backspace => {
@@ -849,6 +840,149 @@ impl<'term, Backend: TerminalBackend> Perform for TerminalParserHandler<'term, B
     }
 }
 
+impl<'term, Backend: TerminalBackend> TerminalParserHandler<'term, Backend> {
+    /// Moves the screen cursor to the next row and adjusts the scrollback cursor position
+    /// to the `Unit` in the scrollback buffer at the corresponding position.
+    ///
+    /// The screen cursor's column position is not changed.
+    ///
+    /// If in Insert mode, a new `Line` will be inserted into the scrollback buffer,
+    /// with the remainder of the `Line` being reflowed onto the next new `Line`.
+    ///
+    /// In either Insert or Overwrite mode, a new `Line` will be added if the screen cursor
+    /// is already at the last displayable line of the scrollback buffer.
+    fn line_feed(&mut self) {
+        let screen_size = self.backend.screen_size();
+        let original_screen_cursor = self.cursor.position;
+
+        // Adjust the scrollback cursor position to the unit displayed one row beneath it
+        if self.mode.insert == InsertMode::Overwrite {
+            let unit_idx = self.scrollback_cursor.unit_idx;
+            let line = &self.scrollback_buffer[self.scrollback_cursor.line_idx];
+            let unit_idx_of_current_line_break = line.soft_line_breaks.iter()
+                .skip_while(|&&soft_break| unit_idx < soft_break)
+                .next();
+
+            // If there is a soft line break after the current unit, then use that to calculate 
+            // what the next unit is.
+            if let Some(next_soft_lb) = unit_idx_of_current_line_break {
+                // Iterate over all the units in this Line, starting from the next soft line break
+                // until we reach the displayed width specified by the current screen cursor's column position.
+                let mut width_so_far = 0;
+                let mut units_iterated = 0;
+                let mut previous_style = Style::default();
+                let mut target_unit = None;
+                for (i, unit) in (&line.units[next_soft_lb.0 ..]).iter().enumerate() {
+                    previous_style = unit.style;
+                    width_so_far += match unit.displayable_width() {
+                        0 => *self.tab_width,
+                        w => w,
+                    };
+                    if width_so_far >= original_screen_cursor.column.0 {
+                        // Found the proper unit
+                        target_unit = Some(unit);
+                        break;
+                    }
+                    units_iterated += 1;
+                }
+
+                if let Some(t) = target_unit {
+                    // We found a Unit that corresponds to the screen cursor's column.
+                    self.scrollback_cursor.unit_idx = UnitIndex(units_iterated);
+                    self.cursor.underneath = t.clone();
+                } else {
+                    // We didn't find a Unit that corresponds to the screen cursor's column.
+                    // Thus, the line was too short to reach that column, so we set the unit index of
+                    // the scrollback buffer such that it will be padded to that column point upon next print.
+                    self.scrollback_cursor.unit_idx = *next_soft_lb + UnitIndex(units_iterated) + 
+                        UnitIndex((original_screen_cursor.column.0 - width_so_far) as usize);
+                    self.cursor.underneath = Unit {
+                        character: Character::default(),
+                        style: previous_style,
+                    };
+                }
+            }
+            // If there are no future soft line breaks, then we're at the end of a displayed line,
+            // so we need to insert a new line into the scrollback_buffer.
+            else {
+                let next_line_idx = self.scrollback_cursor.line_idx + LineIndex(1);
+                let previous_style = line.last().cloned().unwrap_or_default().style;
+                self.scrollback_buffer.insert(next_line_idx.0, Line::new());
+                // This is not a carriage return, we don't move the cursor to column 0.
+                *self.scrollback_cursor = ScrollbackBufferPoint {
+                    line_idx: next_line_idx,
+                    unit_idx: UnitIndex(self.cursor.position.column.0 as usize),
+                };
+                self.cursor.underneath = Unit {
+                    character: Character::default(),
+                    style: previous_style,
+                };
+            }
+        }
+        else {
+            // If in Insert mode, we need to split the line at the current unit,
+            // insert a new line, and move the remainder of that Line's content into the new line.
+            let curr_line = &mut self.scrollback_buffer[self.scrollback_cursor.line_idx];
+            let new_line_units = curr_line.units.split_off(self.scrollback_cursor.unit_idx.0);
+            let mut new_line = Line {
+                units: new_line_units,
+                soft_line_breaks: Vec::new(),
+            };
+            // TODO: we can recalculate curr_line soft breaks faster by deleting all of the ones greater than the current unit_idx.
+            curr_line.recalculate_soft_line_breaks(screen_size.num_columns, *self.tab_width);
+            new_line.recalculate_soft_line_breaks(screen_size.num_columns, *self.tab_width);
+
+            // Insert the split-off new line into the scrollback buffer
+            let next_line_idx = self.scrollback_cursor.line_idx + LineIndex(1);
+            *self.scrollback_cursor = ScrollbackBufferPoint {
+                line_idx: next_line_idx,
+                unit_idx: UnitIndex(0),
+            };
+            self.scrollback_buffer.insert(next_line_idx.0, new_line);
+            
+            self.cursor.underneath = self.scrollback_buffer[*self.scrollback_cursor].clone();
+            self.cursor.position.column.0 = 0;
+        }
+
+        // Actually move the screen cursor down to the next row.
+        // The screen cursor's column has already been adjusted above.
+        let scroll_action = {
+            self.cursor.position.row.0 += 1;
+            if self.cursor.position.row >= screen_size.num_rows {
+                self.cursor.position.row = screen_size.num_rows - Row(1);
+                ScrollAction::Down(1)
+            } else {
+                ScrollAction::None
+            }
+        };
+        // TODO: process the `scroll_action`
+        self.backend.move_cursor_to(self.cursor.position);
+    }
+
+    /// Moves the screen cursor back to the beginning of the current row
+    /// and adjusts the scrollback cursor position to point to that corresponding Unit.
+    ///
+    /// Note that a carriage return alone does not move the screen cursor down to the next row,
+    /// only a line feed (new line) can do that.
+    fn carriage_return(&mut self) {
+        let unit_idx = self.scrollback_cursor.unit_idx;
+        let line = &self.scrollback_buffer[self.scrollback_cursor.line_idx];
+        let idx_of_preceding_line_break = line.soft_line_breaks.iter()
+            .rfind(|&&soft_break| unit_idx >= soft_break)
+            .cloned()
+            .unwrap_or_default(); // No soft line breaks --> cursor goes to the beginning of the line.
+        
+        debug!("carriage_return: setting scrollback buffer at {:?} from {:?} to {:?}",
+            self.scrollback_cursor.line_idx, self.scrollback_cursor.unit_idx, idx_of_preceding_line_break
+        );
+        self.scrollback_cursor.unit_idx = idx_of_preceding_line_break;
+
+        // Move the screen cursor to the beginning of the current row.
+        self.cursor.position.column = Column(0);
+        self.backend.move_cursor_to(self.cursor.position);
+    }
+}
+
 
 
 /// The character stored in each [`Unit`] of the terminal screen. 
@@ -859,7 +993,7 @@ impl<'term, Backend: TerminalBackend> Perform for TerminalParserHandler<'term, B
 /// In the rare case of a character that consist of multiple UTF-8 sequences, e.g., complex emoji,
 /// we store the entire character here as a dynamically-allocated `String`. 
 /// This saves space in the typical case of a character being 4 bytes or less (`char`-sized).
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Character {
     Single(char),
     Multi(String),
@@ -906,7 +1040,7 @@ impl Default for Character {
 /// Non-displayable control/escape sequences, i.e., bells, backspace, delete, etc,
 /// are **NOT** saved as `Unit`s in the terminal's scrollback buffer,
 /// as they cannot be displayed and are simply transient actions.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Unit {
     /// The displayable character(s) held in this `Unit`.
     character: Character,
@@ -1204,7 +1338,7 @@ pub trait TerminalBackend {
     fn move_cursor_by(&mut self, num_columns: i32, num_rows: i32) -> ScreenPoint;
 
     /// TODO: change this to support any arbitrary terminal mode
-    fn set_insert_mode(&mut self, enable: bool);
+    fn set_insert_mode(&mut self, mode: InsertMode);
 
     /// Fully reset the terminal screen to its initial default state.
     fn reset_screen(&mut self);
@@ -1235,7 +1369,7 @@ pub struct TtyBackend<Output: bare_io::Write> {
     /// which will be read by a TTY.terminal emulator on the other side of the stream.
     output: Output,
 
-    insert_mode: bool,
+    insert_mode: InsertMode,
 }
 impl<Output: bare_io::Write> TtyBackend<Output> {
     // const FORWARDS_DELETE: &'static [u8] = &[
@@ -1266,7 +1400,7 @@ impl<Output: bare_io::Write> TtyBackend<Output> {
             screen_size: screen_size.unwrap_or_default(),
             real_screen_cursor: ScreenPoint::default(),
             output: output_stream,
-            insert_mode: false,
+            insert_mode: InsertMode::Overwrite,
         }
         // TODO: here, query the backend for the real cursor location,
         //       which could be anywhere, e.g., if we connected to an existing terminal.
@@ -1317,7 +1451,7 @@ impl<Output: bare_io::Write> TtyBackend<Output> {
         self.real_screen_cursor
     }
 
-    /// Sets the cursor position directly using a `(1,1)` based coordinate system.
+    /// Sets the cursor position directly using a `(1,1)`-based coordinate system.
     ///
     /// This is needed because terminal backends use a different coordinate system than we do,
     /// in which the origin point at the upper-left corner is `(1,1)`,
@@ -1474,15 +1608,18 @@ impl<Output: bare_io::Write> TerminalBackend for TtyBackend<Output> {
         self.real_screen_cursor
     }
 
-    fn set_insert_mode(&mut self, enable: bool) {
-        if self.insert_mode != enable {
+    fn set_insert_mode(&mut self, mode: InsertMode) {
+        if self.insert_mode != mode {
             self.output.write(&[
                 AsciiControlCodes::Escape,
                 b'[',
                 ModeSwitch::InsertMode,
-                if enable { ModeSwitch::SET_SUFFIX } else { ModeSwitch::RESET_SUFFIX },
+                match mode {
+                    InsertMode::Insert => ModeSwitch::SET_SUFFIX,
+                    InsertMode::Overwrite => ModeSwitch::RESET_SUFFIX,
+                },
             ]).expect("failed to write bytes for insert mode");
-            self.insert_mode = enable;
+            self.insert_mode = mode;
         }
     }
 
@@ -1620,17 +1757,35 @@ pub enum ShowCursor {
     Hidden,
 }
 
+/// Whether a Carriage Return subsequently issues a Line Feed (newline / new line).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum CarriageReturnSendsLineFeed {
+    Yes,
+    No,
+}
+
+/// Whether a Line Feed (newline / new line) subsequently issues a Carriage Return.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum LineFeedSendsCarriageReturn {
+    Yes,
+    No,
+}
+
 /// The set of options that determine terminal behavior.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct TerminalMode {
-    insert: InsertMode,
+    insert:      InsertMode,
     show_cursor: ShowCursor,
+    cr_sends_lf: CarriageReturnSendsLineFeed,
+    lf_sends_cr: LineFeedSendsCarriageReturn,
 }
 impl Default for TerminalMode {
     fn default() -> Self {
         TerminalMode {
             insert: InsertMode::Overwrite,
             show_cursor: ShowCursor::Visible,
+            cr_sends_lf: CarriageReturnSendsLineFeed::Yes,
+            lf_sends_cr: LineFeedSendsCarriageReturn::Yes,
         }
     }
 }


### PR DESCRIPTION
* Add more terminal modes and more clear handling of line feed & carriage return 

* This PR is more of a temporary merge to preserve changes, since we plan to completely refactor how units in the scrollback buffer are stored in memory. 