### PR TITLE
Add various no_mangle symbols from libm that aren't properly exported in no_std builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,6 +1749,7 @@ dependencies = [
  "exceptions_early",
  "irq_safety",
  "kernel_config",
+ "libm",
  "log",
  "logger",
  "memory",

--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -9,6 +9,7 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 multiboot2 = "0.10.1"
+libm = "0.2.1"
 
 
 # [dependencies.compiler_builtins]

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -249,6 +249,6 @@ extern {
 /// `__truncdfsf2` function in the `compiler_builtins` crate.
 mod truncate;
 
-/// This module is a hack to solve no_std issue with libm by
-/// exposing no_mangle libm functions
+/// This module is a hack to get around the issue of no_mangle symbols
+/// not being exported properly from the `libm` crate in no_std environments.
 mod libm;

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -248,3 +248,7 @@ extern {
 /// This module is a hack to get around the lack of the 
 /// `__truncdfsf2` function in the `compiler_builtins` crate.
 mod truncate;
+
+/// This module is a hack to solve no_std issue with libm by
+/// exposing no_mangle libm functions
+mod libm;

--- a/kernel/nano_core/src/libm.rs
+++ b/kernel/nano_core/src/libm.rs
@@ -1,0 +1,24 @@
+#[no_mangle]
+pub extern "C" fn fmod(a: f64, b: f64) -> f64 {
+    libm::fmod(a, b)
+}
+#[no_mangle]
+pub extern "C" fn fmodf(a: f32, b: f32) -> f32 {
+    libm::fmodf(a, b)
+}
+#[no_mangle]
+pub extern "C" fn fmin(a: f64, b: f64) -> f64 {
+    libm::fmin(a, b)
+}
+#[no_mangle]
+pub extern "C" fn fminf(a: f32, b: f32) -> f32 {
+    libm::fminf(a, b)
+}
+#[no_mangle]
+pub extern "C" fn fmax(a: f64, b: f64) -> f64 {
+    libm::fmax(a, b)
+}
+#[no_mangle]
+pub extern "C" fn fmaxf(a: f32, b: f32) -> f32 {
+    libm::fmaxf(a, b)
+}

--- a/kernel/nano_core/src/libm.rs
+++ b/kernel/nano_core/src/libm.rs
@@ -1,23 +1,31 @@
+//! In no_std compilation environments, the `libm` crate doesn't properly export 
+//! various no_mangle symbols properly, so we do it manually here.
+
 #[no_mangle]
 pub extern "C" fn fmod(a: f64, b: f64) -> f64 {
     libm::fmod(a, b)
 }
+
 #[no_mangle]
 pub extern "C" fn fmodf(a: f32, b: f32) -> f32 {
     libm::fmodf(a, b)
 }
+
 #[no_mangle]
 pub extern "C" fn fmin(a: f64, b: f64) -> f64 {
     libm::fmin(a, b)
 }
+
 #[no_mangle]
 pub extern "C" fn fminf(a: f32, b: f32) -> f32 {
     libm::fminf(a, b)
 }
+
 #[no_mangle]
 pub extern "C" fn fmax(a: f64, b: f64) -> f64 {
     libm::fmax(a, b)
 }
+
 #[no_mangle]
 pub extern "C" fn fmaxf(a: f32, b: f32) -> f32 {
     libm::fmaxf(a, b)


### PR DESCRIPTION
[wasmi](https://github.com/paritytech/wasmi) relies on `libm` which has spotty `no_std` support. Specifically, it seems `wasmi` requires `no_mangle` `libm` functions. This PR implements a similar hack as seen in [redshirt](https://github.com/tomaka/redshirt/blob/main/kernel/standalone/src/arch/x86_64/boot.rs) to resolve this issue. 

Although not included in this PR, a slightly modified `wasmi` example was successfully run on Theseus to verify that this solution works.

Additionally, I believe the `truncate` module (an existing hack) could be replaced by the `libm::trunc` function (as that is what redshirt does), but that change has not been included in this PR.