### PR TITLE
Standardize doc headings to use one top-level header `#`, not two `##`

### DIFF
--- a/applications/loadc/src/lib.rs
+++ b/applications/loadc/src/lib.rs
@@ -172,7 +172,7 @@ impl Offset {
 
 /// Parses an elf executable file from the given slice of bytes and load it into memory.
 ///
-/// ## Important note about memory mappings
+/// # Important note about memory mappings
 /// This function will allocate new memory regions to store each program segment
 /// and copy each segment's data into them.
 /// When this function returns, those segments will be mapped as writable in order to allow them 
@@ -180,7 +180,7 @@ impl Offset {
 /// Before running this executable, each segment's `MappedPages` should be remapped
 /// to the proper `flags` specified in its `LoadedSegment.flags` field. 
 ///
-/// ## Return
+/// # Return
 /// Returns a tuple of:
 /// 1. A list of program segments mapped into memory. 
 /// 2. The virtual address of the executable's entry point, e.g., the `_start` function.

--- a/kernel/acpi/dmar/src/drhd.rs
+++ b/kernel/acpi/dmar/src/drhd.rs
@@ -66,7 +66,7 @@ impl<'t> DmarDrhd<'t> {
     /// Returns the value of the `INCLUDE_PCI_ALL` flag,
     /// the only bit flag in this DRHD table.
     ///
-    /// ## Description from Intel Spec
+    /// # Description from Intel Spec
     /// If `false`, this remapping hardware unit has under its scope only
     /// devices in the specified segment that are explicitly identified through
     /// the Device Scope field. The device can be of any type as described by

--- a/kernel/io/src/lib.rs
+++ b/kernel/io/src/lib.rs
@@ -139,12 +139,12 @@ pub trait BlockReader: BlockIo {
     ///
     /// The number of blocks read is dictated by the length of the given `buffer`.
     ///
-    /// ## Arguments
+    /// # Arguments
     /// * `buffer`: the buffer into which data will be read. 
     ///    The length of this buffer must be a multiple of the block size.
     /// * `block_offset`: the offset in number of blocks from the beginning of this reader.
     ///
-    /// ## Return
+    /// # Return
     /// If successful, returns the number of blocks read into the given `buffer`. 
     /// Otherwise, returns an error.
     fn read_blocks(&mut self, buffer: &mut [u8], block_offset: usize) -> Result<usize, IoError>;
@@ -173,12 +173,12 @@ pub trait BlockWriter: BlockIo {
     ///
     /// The number of blocks written is dictated by the length of the given `buffer`.
     ///
-    /// ## Arguments
+    /// # Arguments
     /// * `buffer`: the buffer from which data will be written. 
     ///    The length of this buffer must be a multiple of the block size.
     /// * `block_offset`: the offset in number of blocks from the beginning of this writer.
     ///
-    /// ## Return
+    /// # Return
     /// If successful, returns the number of blocks written to this writer. 
     /// Otherwise, returns an error.
     fn write_blocks(&mut self, buffer: &[u8], block_offset: usize) -> Result<usize, IoError>;
@@ -205,7 +205,7 @@ impl<W> BlockWriter for &mut W where W: BlockWriter + ?Sized {
 /// A trait that represents an I/O stream that can be read from at the granularity of individual bytes,
 /// but which does not track the current offset into the stream.
 ///
-/// ## `ByteReader` implementation atop `BlockReader`
+/// # `ByteReader` implementation atop `BlockReader`
 /// The [`ByteReader`] trait ideally _should be_ auto-implemented for any type
 /// that implements the [`BlockReader`] trait,
 /// to allow easy byte-wise access to a block-based I/O stream.
@@ -216,12 +216,12 @@ pub trait ByteReader {
     ///
     /// The number of bytes read is dictated by the length of the given `buffer`.
     ///
-    /// ## Arguments
+    /// # Arguments
     /// * `buffer`: the buffer into which data will be copied.
     /// * `offset`: the offset in bytes from the beginning of this reader 
     ///    where the read operation will begin.
     ///
-    /// ## Return
+    /// # Return
     /// If successful, returns the number of bytes read into the given `buffer`. 
     /// Otherwise, returns an error.
     fn read_at(&mut self, buffer: &mut [u8], offset: usize) -> Result<usize, IoError>; 
@@ -242,7 +242,7 @@ impl<R> ByteReader for &mut R where R: ByteReader + ?Sized {
 /// A trait that represents an I/O stream that can be written to,
 /// but which does not track the current offset into the stream.
 ///
-/// ## `ByteWriter` implementation atop `BlockWriter`
+/// # `ByteWriter` implementation atop `BlockWriter`
 /// The [`ByteWriter`] trait ideally _should be_ auto-implemented for any type 
 /// that implements both the [`BlockWriter`] **and** [`BlockReader`] traits
 /// to allow easy byte-wise access to a block-based I/O stream.
@@ -261,12 +261,12 @@ pub trait ByteWriter {
     ///
     /// The number of bytes written is dictated by the length of the given `buffer`.
     ///
-    /// ## Arguments
+    /// # Arguments
     /// * `buffer`: the buffer from which data will be copied. 
     /// * `offset`: the offset in number of bytes from the beginning of this writer
     ///    where the write operation will begin.
     ///
-    /// ## Return
+    /// # Return
     /// If successful, returns the number of bytes written to this writer. 
     /// Otherwise, returns an error.
     fn write_at(&mut self, buffer: &[u8], offset: usize) -> Result<usize, IoError>;
@@ -296,7 +296,7 @@ impl<R> ByteWriter for &mut R where R: ByteWriter + ?Sized {
 /// in which all types that implement `BlockReader` also implement `ByteReader`, 
 /// but we can't do that because Rust currently does not support specialization.
 /// 
-/// ## Example
+/// # Example
 /// Use the `From` implementation around a `BlockReader` instance, such as:
 /// ```ignore
 /// // Assume `storage_dev` implements `BlockReader`
@@ -354,7 +354,7 @@ impl<R> BlockReader for ByteReaderWrapper<R> where R: BlockReader {
 /// also implement `ByteReader + ByteWriter`, 
 /// but we cannot do that because Rust currently does not support specialization.
 /// 
-/// ## Example
+/// # Example
 /// Use the `From` implementation around a `BlockReader + BlockWriter` instance, such as:
 /// ```ignore
 /// // Assume `storage_dev` implements `BlockReader + BlockWriter`
@@ -434,7 +434,7 @@ impl<RW> BlockWriter for ByteReaderWriterWrapper<RW> where RW: BlockReader + Blo
 /// See the [`ByteWriter`] trait docs for an explanation of why both 
 /// `BlockReader + BlockWriter` are required.
 ///
-/// ## Example
+/// # Example
 /// Use the `From` implementation around a `BlockReader + BlockWriter` instance, such as:
 /// ```ignore
 /// // Assume `storage_dev` implements `BlockReader + BlockWriter`
@@ -799,7 +799,7 @@ impl<'io, IO, L, B> core::fmt::Write for LockableIo<'io, IO, L, B>
 /// 3. A partial single-block transfer of some bytes in the last block,
 ///    only if the end of `byte_range` is not aligned to `block_size`.
 /// 
-/// ## Example
+/// # Example
 /// Given a read request for a `byte_range` of `1500..3950` and a `block_size` of `512` bytes,
 /// this function will return the following three transfer operations:
 /// 1. Read 1 block (block `2`) and transfer the last 36 bytes of that block (`476..512`)
@@ -809,12 +809,12 @@ impl<'io, IO, L, B> core::fmt::Write for LockableIo<'io, IO, L, B>
 /// 3. Read 1 block (block `7`) and transfer the first 366 bytes of that block (`0..366`)
 ///    into the byte range `3584..3950`.
 ///
-/// ## Arguments
+/// # Arguments
 /// * `byte_range`: the absolute range of bytes where the I/O transfer starts and ends,
 ///    specified as absolute offsets from the beginning of the block-wise I/O stream.
 /// * `block_size`: the size in bytes of each block in the block-wise I/O stream.
 /// 
-/// ## Return
+/// # Return
 /// Returns a list of the three above transfer operations, 
 /// enclosed in `Option`s to convey that not all operations may be necessary.
 /// 

--- a/kernel/mlx_ethernet/src/command_queue.rs
+++ b/kernel/mlx_ethernet/src/command_queue.rs
@@ -239,7 +239,7 @@ impl CommandQueue {
 
     /// Create a command queue object.
     ///
-    /// ## Arguments
+    /// # Arguments
     /// * `entries`: physically contiguous memory that is mapped as a slice of command queue entries.
     /// * `num_cmdq_entries`: number of entries in the queue.
     pub fn create(entries: BoxRefMut<MappedPages, [CommandQueueEntry]>, num_cmdq_entries: usize) -> Result<CommandQueue, &'static str> {
@@ -273,7 +273,7 @@ impl CommandQueue {
     /// At the end of the function, the command is ready to be posted using the doorbell in the initialization segment. 
     /// Returns an error if no entry is available to use.
     ///
-    /// ## Arguments
+    /// # Arguments
     /// * `opcode`: [`CommandOpcode`] for the command that the driver wants to execute
     /// * `opmod`: opcode modifer, only applicable for certain commands
     /// * `allocated_pages`: physical address of pages that need to be passed to the NIC. Only used in the [`CommandOpcode::ManagePages`] command.
@@ -656,7 +656,7 @@ impl CommandQueueEntry {
     /// Sets the first 16 bytes of input data that are written inline in the command.
     /// The valid values for each field are different for every command, and can be taken from Chapter 23 of the PRM.
     ///
-    /// ## Arguments
+    /// # Arguments
     /// * `opcode`: value identifying which command has to be carried out
     /// * `opmod`: opcode modifier. If None, field will be set to zero.
     /// * `command0`: the first 4 bytes of actual command data. If None, field will be set to zero.

--- a/kernel/mlx_ethernet/src/lib.rs
+++ b/kernel/mlx_ethernet/src/lib.rs
@@ -93,7 +93,7 @@ impl InitializationSegment {
     
     /// Sets the physical address of the command queue within the initialization segment.
     ///
-    /// ## Arguments
+    /// # Arguments
     /// * `cmdq_physical_addr`: the starting physical address of the command queue, the lower 12 bits of which must be zero. 
     pub fn set_physical_address_of_cmdq(&mut self, cmdq_physical_addr: PhysicalAddress) -> Result<(), &'static str> {
         if cmdq_physical_addr.value() & 0xFFF != 0 {
@@ -113,7 +113,7 @@ impl InitializationSegment {
 
     /// Sets a bit in the [`InitializationSegment::command_doorbell_vector`] to inform HW that the command needs to be executed.
     ///
-    /// ## Arguments
+    /// # Arguments
     /// * `command bit`: the command entry that needs to be executed. (e.g. bit 0 corresponds to entry at index 0).
     pub fn post_command(&mut self, command_bit: usize) {
         let val = self.command_doorbell_vector.read().get();

--- a/kernel/simd_personality/src/lib.rs
+++ b/kernel/simd_personality/src/lib.rs
@@ -8,7 +8,7 @@
 //! how to deal with it for context switching, and also for interrupt handling.
 //! Both of these policies are determined per-core as follows:
 //! 
-//! ### Context Switching 
+//! # Context Switching 
 //! * If there is one or zero SIMD-enabled `Task`s running on a given core, 
 //!   then all `Task`s running on that core can use the standard, 
 //!   non-SIMD-enabled context switching routine. 
@@ -26,7 +26,7 @@
 //! However, that static policy misses out on the performance optimization of 
 //! not having to save/restore SIMD registers when only a single SIMD Task is running on a given core.
 //! 
-//! ### Interrupt Handling
+//! # Interrupt Handling
 //! * If interrupt handlers are only ever compiled for the regular world, i.e., 
 //!   no interrupt handlers exist that are compiled to use SIMD instructions,
 //!   then we do not have to save/restore SIMD registers on an interrupt because

--- a/kernel/text_terminal/src/lib.rs
+++ b/kernel/text_terminal/src/lib.rs
@@ -1286,7 +1286,7 @@ impl Default for Character {
 /// but this is different from the concept of a `cell` because it may contain 
 /// more than just a single displayable character, in order to support complex Unicode/emoji.
 ///
-/// ## 1-to-1 Relationship between Units and Columns
+/// # 1-to-1 Relationship between Units and Columns
 /// It is guaranteed that one `Unit` in the scrollback buffer corresponds to exactly one screen column,
 /// which makes it easy to calculate the conversions between screen cursor coordinate points
 /// and scrollback buffer coordinate points.
@@ -1310,7 +1310,7 @@ impl Default for Character {
 /// multiple `Unit`s.
 ///
 ///
-/// ## What Units are Not
+/// # What Units are Not
 /// Displayable control/escape sequences, i.e., those that affect text style,
 /// **do not** exist as individual `Unit`s,
 /// though their effects on text style are represented by a `Unit`'s `FormatFlags`.


### PR DESCRIPTION
No code changes.