### PR TITLE
Replace the yanked `bare-io` crate with `core2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
 name = "app_io"
 version = "0.1.0"
 dependencies = [
- "bare-io",
+ "core2",
  "event_types",
  "keycodes_ascii",
  "lazy_static",
@@ -171,15 +171,6 @@ name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-
-[[package]]
-name = "bare-io"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec6ec4815d7aacd0be4ec053ef9e2883b22f79b29f9bd2ef3f79003e3ee7c9d"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "bit_field"
@@ -319,7 +310,7 @@ name = "cat"
 version = "0.1.0"
 dependencies = [
  "app_io",
- "bare-io",
+ "core2",
  "fs_node",
  "getopts",
  "log",
@@ -397,7 +388,7 @@ name = "console"
 version = "0.1.0"
 dependencies = [
  "async_channel",
- "bare-io",
+ "core2",
  "io",
  "irq_safety",
  "log",
@@ -447,6 +438,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "core2"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf12d2dad3ed124aa116f59561428478993d69ab81ae4d30e5349c9c5b5a5f6"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "core_simd"
@@ -636,7 +636,7 @@ version = "0.1.0"
 dependencies = [
  "acpi",
  "apic",
- "bare-io",
+ "core2",
  "derive_more",
  "e1000",
  "ethernet_smoltcp_device",
@@ -1086,7 +1086,7 @@ name = "immediate_input_echo"
 version = "0.1.0"
 dependencies = [
  "app_io",
- "bare-io",
+ "core2",
  "log",
  "stdio",
 ]
@@ -1096,7 +1096,7 @@ name = "input_echo"
 version = "0.1.0"
 dependencies = [
  "app_io",
- "bare-io",
+ "core2",
  "log",
 ]
 
@@ -1151,7 +1151,7 @@ dependencies = [
 name = "io"
 version = "0.1.0"
 dependencies = [
- "bare-io",
+ "core2",
  "delegate",
  "lazy_static",
  "lockable",
@@ -1270,7 +1270,7 @@ name = "keyboard_echo"
 version = "0.1.0"
 dependencies = [
  "app_io",
- "bare-io",
+ "core2",
  "keycodes_ascii",
  "log",
  "scheduler",
@@ -1308,7 +1308,7 @@ name = "less"
 version = "0.1.0"
 dependencies = [
  "app_io",
- "bare-io",
+ "core2",
  "fs_node",
  "getopts",
  "keycodes_ascii",
@@ -2479,7 +2479,7 @@ name = "serial_port"
 version = "0.1.0"
 dependencies = [
  "async_channel",
- "bare-io",
+ "core2",
  "deferred_interrupt_tasks",
  "interrupts",
  "irq_safety",
@@ -2521,7 +2521,7 @@ name = "shell"
 version = "0.1.0"
 dependencies = [
  "app_io",
- "bare-io",
+ "core2",
  "dfqueue",
  "environment",
  "event_types",
@@ -2750,7 +2750,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stdio"
 version = "0.1.0"
 dependencies = [
- "bare-io",
+ "core2",
  "keycodes_ascii",
  "spin 0.9.0",
 ]
@@ -2872,7 +2872,7 @@ name = "test_block_io"
 version = "0.1.0"
 dependencies = [
  "ata",
- "bare-io",
+ "core2",
  "io",
  "log",
  "storage_manager",
@@ -2946,7 +2946,7 @@ dependencies = [
 name = "test_serial_echo"
 version = "0.1.0"
 dependencies = [
- "bare-io",
+ "core2",
  "io",
  "irq_safety",
  "log",
@@ -2981,8 +2981,8 @@ dependencies = [
 name = "text_terminal"
 version = "0.1.0"
 dependencies = [
- "bare-io",
  "bitflags",
+ "core2",
  "derive_more",
  "event_types",
  "log",

--- a/applications/app_io/Cargo.toml
+++ b/applications/app_io/Cargo.toml
@@ -9,7 +9,7 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" }
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.log]
 version = "0.4.8"

--- a/applications/app_io/src/lib.rs
+++ b/applications/app_io/src/lib.rs
@@ -23,7 +23,7 @@ extern crate spin;
 extern crate keycodes_ascii;
 extern crate libterm;
 extern crate logger;
-extern crate bare_io;
+extern crate core2;
 extern crate window_manager;
 
 use stdio::{StdioReader, StdioWriter, KeyEventReadGuard,
@@ -318,7 +318,7 @@ macro_rules! print {
 }
 
 use core::fmt;
-use bare_io::Write;
+use core2::io::Write;
 /// Converts the given `core::fmt::Arguments` to a `String` and enqueues the string into the correct
 /// terminal print-producer
 pub fn print_to_stdout_args(fmt_args: fmt::Arguments) {

--- a/applications/cat/Cargo.toml
+++ b/applications/cat/Cargo.toml
@@ -6,7 +6,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 
 
 [dependencies.log]

--- a/applications/cat/src/lib.rs
+++ b/applications/cat/src/lib.rs
@@ -7,7 +7,7 @@ extern crate task;
 extern crate getopts;
 extern crate path;
 extern crate fs_node;
-extern crate bare_io;
+extern crate core2;
 
 use core::str;
 use alloc::{
@@ -18,7 +18,7 @@ use alloc::{
 use getopts::Options;
 use path::Path;
 use fs_node::FileOrDir;
-use bare_io::{Read, Write};
+use core2::io::{Read, Write};
 
 
 pub fn main(args: Vec<String>) -> isize {

--- a/applications/immediate_input_echo/Cargo.toml
+++ b/applications/immediate_input_echo/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
 
 [dependencies]
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.stdio]
 path = "../../libs/stdio"

--- a/applications/immediate_input_echo/src/lib.rs
+++ b/applications/immediate_input_echo/src/lib.rs
@@ -2,14 +2,14 @@
 #![no_std]
 
 #[macro_use] extern crate alloc;
-extern crate bare_io;
+extern crate core2;
 extern crate stdio;
 extern crate app_io;
 #[macro_use] extern crate log;
 
 use alloc::vec::Vec;
 use alloc::string::String;
-use bare_io::{Read, Write};
+use core2::io::{Read, Write};
 
 pub fn main(_args: Vec<String>) -> isize {
     if let Err(e) = run() {

--- a/applications/input_echo/Cargo.toml
+++ b/applications/input_echo/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
 
 [dependencies]
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.app_io]
 path = "../app_io"

--- a/applications/input_echo/src/lib.rs
+++ b/applications/input_echo/src/lib.rs
@@ -2,13 +2,13 @@
 #![no_std]
 
 #[macro_use] extern crate alloc;
-extern crate bare_io;
+extern crate core2;
 extern crate app_io;
 #[macro_use] extern crate log;
 
 use alloc::vec::Vec;
 use alloc::string::String;
-use bare_io::Write;
+use core2::io::Write;
 
 pub fn main(_args: Vec<String>) -> isize {
     if let Err(e) = run() {

--- a/applications/keyboard_echo/Cargo.toml
+++ b/applications/keyboard_echo/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
 
 [dependencies]
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.scheduler]
 path = "../../kernel/scheduler"

--- a/applications/keyboard_echo/src/lib.rs
+++ b/applications/keyboard_echo/src/lib.rs
@@ -3,13 +3,13 @@
 #![no_std]
 
 #[macro_use] extern crate alloc;
-extern crate bare_io;
+extern crate core2;
 extern crate scheduler;
 extern crate app_io;
 extern crate keycodes_ascii;
 #[macro_use] extern crate log;
 
-use bare_io::Write;
+use core2::io::Write;
 use alloc::vec::Vec;
 use alloc::string::String;
 use keycodes_ascii::Keycode;

--- a/applications/less/Cargo.toml
+++ b/applications/less/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 [dependencies]
 getopts = "0.2.21"
 spin = "0.9.0"
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.task]
 path = "../../kernel/task"

--- a/applications/less/src/lib.rs
+++ b/applications/less/src/lib.rs
@@ -12,7 +12,7 @@ extern crate libterm;
 extern crate spin;
 extern crate app_io;
 extern crate stdio;
-extern crate bare_io;
+extern crate core2;
 #[macro_use] extern crate log;
 
 use keycodes_ascii::{Keycode, KeyAction};
@@ -29,7 +29,7 @@ use alloc::collections::BTreeMap;
 use libterm::Terminal;
 use spin::Mutex;
 use stdio::{StdioWriter, KeyEventQueueReader};
-use bare_io::Write;
+use core2::io::Write;
 
 /// The metadata for each line in the file.
 struct LineSlice {

--- a/applications/shell/Cargo.toml
+++ b/applications/shell/Cargo.toml
@@ -9,7 +9,7 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" }
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.log]
 version = "0.4.8"

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -17,7 +17,7 @@ extern crate path;
 extern crate root;
 extern crate scheduler;
 extern crate stdio;
-extern crate bare_io;
+extern crate core2;
 extern crate app_io;
 extern crate fs_node;
 extern crate terminal_print;
@@ -43,7 +43,7 @@ use core::mem;
 use alloc::collections::BTreeMap;
 use stdio::{Stdio, KeyEventQueue, KeyEventQueueReader, KeyEventQueueWriter,
             StdioReader, StdioWriter};
-use bare_io::Write;
+use core2::io::Write;
 use core::ops::Deref;
 use app_io::{IoStreams, IoControlFlags};
 use fs_node::FileOrDir;

--- a/applications/test_block_io/Cargo.toml
+++ b/applications/test_block_io/Cargo.toml
@@ -6,7 +6,7 @@ description = "a simple app for testing IO transfers for block devices"
 build = "../../build.rs"
 
 [dependencies]
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.log]
 version = "0.4.8"

--- a/applications/test_block_io/src/lib.rs
+++ b/applications/test_block_io/src/lib.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 // #[macro_use] extern crate terminal_print;
 extern crate task;
 extern crate io;
-extern crate bare_io;
+extern crate core2;
 extern crate storage_manager;
 extern crate ata;
 
@@ -78,7 +78,7 @@ pub fn main(_args: Vec<String>) -> isize {
 
 
     // Test the Reader, Writer, ReaderWriter stuff (with offsets)
-    use bare_io::{Read, Write, Seek, SeekFrom};
+    use core2::io::{Read, Write, Seek, SeekFrom};
     let mut locked_sd = dev.lock();
     // let dev_mut = locked_sd.deref_mut();
     {

--- a/applications/test_serial_echo/Cargo.toml
+++ b/applications/test_serial_echo/Cargo.toml
@@ -6,7 +6,7 @@ description = "a simple app for testing serial port I/O using higher-level I/O t
 build = "../../build.rs"
 
 [dependencies]
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 log = "0.4.8"
 
 [dependencies.irq_safety]

--- a/applications/test_serial_echo/src/lib.rs
+++ b/applications/test_serial_echo/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 // #[macro_use] extern crate log;
 #[macro_use] extern crate terminal_print;
 extern crate task;
-extern crate bare_io;
+extern crate core2;
 extern crate io;
 extern crate irq_safety;
 extern crate serial_port;
@@ -18,7 +18,7 @@ use alloc::{
     string::String,
     vec::Vec,
 };
-use bare_io::Read;
+use core2::io::Read;
 use io::LockableIo;
 use irq_safety::MutexIrqSafe;
 use serial_port::{SerialPort, SerialPortAddress, get_serial_port};
@@ -45,7 +45,7 @@ pub fn main(args: Vec<String>) -> isize {
             let res = serial_port_io2.read(&mut buf);
             if let Ok(bytes_read) = res {
                 if let Ok(s) = core::str::from_utf8(&buf[..bytes_read]) {
-                    use bare_io::Write;
+                    use core2::io::Write;
                     serial_port_io.write(s.as_bytes()).expect("serial port write failed");
                 }
             }

--- a/kernel/console/Cargo.toml
+++ b/kernel/console/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 log = "0.4.8"
 
 [dependencies.async_channel]

--- a/kernel/console/src/lib.rs
+++ b/kernel/console/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 #[macro_use] extern crate log;
 extern crate spin;
 extern crate irq_safety;
-extern crate bare_io;
+extern crate core2;
 extern crate mpmc;
 
 extern crate task;
@@ -41,8 +41,8 @@ pub fn start_connection_detection() -> Result<TaskRef, &'static str> {
 }
 
 pub struct Console<I, O, Backend> 
-	where I: bare_io::Read,
-	      O: bare_io::Write,
+	where I: core2::io::Read,
+	      O: core2::io::Write,
 		  Backend: TerminalBackend,
 {
 	name: String,
@@ -64,8 +64,8 @@ pub fn new_serial_console<S, I, O>(
 	output_stream: O,
 ) -> Console<I, O, TtyBackend<O>> 
 	where S: Into<String>,
-		  I: bare_io::Read,
-	      O: bare_io::Write + Send + 'static,
+		  I: core2::io::Read,
+	      O: core2::io::Write + Send + 'static,
 {
 	Console {
 		name: name.into(),
@@ -114,8 +114,8 @@ fn console_connection_detector(connection_listener: Receiver<SerialPortAddress>)
 fn console_entry<I, O, Backend>(
 	(mut console, input_receiver): (Console<I, O, Backend>, Receiver<DataChunk>),
 ) -> Result<(), &'static str> 
-	where I: bare_io::Read,
-	      O: bare_io::Write,
+	where I: core2::io::Read,
+	      O: core2::io::Write,
 		  Backend: TerminalBackend,
 {
 	loop {

--- a/kernel/device_manager/Cargo.toml
+++ b/kernel/device_manager/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 derive_more = "0.99.0"
 
 [dependencies.fatfs]

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -21,7 +21,7 @@ extern crate ixgbe;
 extern crate alloc;
 extern crate fatfs;
 extern crate io;
-extern crate bare_io;
+extern crate core2;
 #[macro_use] extern crate derive_more;
 extern crate mlx5;
 
@@ -233,8 +233,8 @@ pub fn init(key_producer: Queue<Event>, mouse_producer: Queue<Event>) -> Result<
 ///
 /// To meet [`fatfs`]'s requirements, the underlying I/O stream must be able to 
 /// read, write, and seek while tracking its current offset. 
-/// We use traits from the [`bare_io`] crate to meet these requirements, 
-/// thus, the given `IO` parameter must implement those [`bare_io`] traits.
+/// We use traits from the [`core2`] crate to meet these requirements, 
+/// thus, the given `IO` parameter must implement those [`core2`] traits.
 ///
 /// For example, this allows one to access a FAT filesystem 
 /// by reading from or writing to a storage device.
@@ -244,16 +244,16 @@ impl<IO> FatFsAdapter<IO> {
 }
 /// This tells the `fatfs` crate that our read/write/seek functions
 /// may return errors of the type [`FatFsIoErrorAdapter`],
-/// which is a simple wrapper around [`bare_io::Error`].
+/// which is a simple wrapper around [`core2::io::Error`].
 impl<IO> fatfs::IoBase for FatFsAdapter<IO> {
     type Error = FatFsIoErrorAdapter;
 }
-impl<IO> fatfs::Read for FatFsAdapter<IO> where IO: bare_io::Read {
+impl<IO> fatfs::Read for FatFsAdapter<IO> where IO: core2::io::Read {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         self.0.read(buf).map_err(Into::into)
     }
 }
-impl<IO> fatfs::Write for FatFsAdapter<IO> where IO: bare_io::Write {
+impl<IO> fatfs::Write for FatFsAdapter<IO> where IO: core2::io::Write {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.0.write(buf).map_err(Into::into)
     }
@@ -261,31 +261,31 @@ impl<IO> fatfs::Write for FatFsAdapter<IO> where IO: bare_io::Write {
         self.0.flush().map_err(Into::into)
     }
 }
-impl<IO> fatfs::Seek for FatFsAdapter<IO> where IO: bare_io::Seek {
+impl<IO> fatfs::Seek for FatFsAdapter<IO> where IO: core2::io::Seek {
     fn seek(&mut self, pos: fatfs::SeekFrom) -> Result<u64, Self::Error> {
-        let bare_io_pos = match pos {
-            fatfs::SeekFrom::Start(s)   => bare_io::SeekFrom::Start(s),
-            fatfs::SeekFrom::Current(c) => bare_io::SeekFrom::Current(c),
-            fatfs::SeekFrom::End(e)     => bare_io::SeekFrom::End(e),
+        let core2_pos = match pos {
+            fatfs::SeekFrom::Start(s)   => core2::io::SeekFrom::Start(s),
+            fatfs::SeekFrom::Current(c) => core2::io::SeekFrom::Current(c),
+            fatfs::SeekFrom::End(e)     => core2::io::SeekFrom::End(e),
         };
-        self.0.seek(bare_io_pos).map_err(Into::into)
+        self.0.seek(core2_pos).map_err(Into::into)
     }
 }
 
 /// This struct exists to enable us to implement the [`fatfs::IoError`] trait
-/// for the [`bare_io::Error`] trait.
+/// for the [`core2::io::Error`] trait.
 /// 
 /// This is required because Rust prevents implementing foreign traits for foreign types.
 #[derive(Debug, From, Into)]
-pub struct FatFsIoErrorAdapter(bare_io::Error);
+pub struct FatFsIoErrorAdapter(core2::io::Error);
 impl fatfs::IoError for FatFsIoErrorAdapter {
     fn is_interrupted(&self) -> bool {
-        self.0.kind() == bare_io::ErrorKind::Interrupted
+        self.0.kind() == core2::io::ErrorKind::Interrupted
     }
     fn new_unexpected_eof_error() -> Self {
-        FatFsIoErrorAdapter(bare_io::ErrorKind::UnexpectedEof.into())
+        FatFsIoErrorAdapter(core2::io::ErrorKind::UnexpectedEof.into())
     }
     fn new_write_zero_error() -> Self {
-        FatFsIoErrorAdapter(bare_io::ErrorKind::WriteZero.into())
+        FatFsIoErrorAdapter(core2::io::ErrorKind::WriteZero.into())
     }
 }

--- a/kernel/io/Cargo.toml
+++ b/kernel/io/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 delegate = "0.6.0"
 spin = "0.9.0"
 

--- a/kernel/serial_port/Cargo.toml
+++ b/kernel/serial_port/Cargo.toml
@@ -8,7 +8,7 @@ build = "../../build.rs"
 [dependencies]
 log = "0.4.8"
 spin = "0.9.0"
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 x86_64 = { path = "../../libs/x86_64" }
 static_assertions = "1.1.0"
 

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -5,7 +5,7 @@
 //! This crate extends that functionality to provide interrupt handlers for receiving data
 //! and handling data access in a deferred, asynchronous manner.
 //! It also implements additional higher-level I/O traits for serial ports,
-//! namely [`bare_io::Read`] and [`bare_io::Write`].
+//! namely [`core2::io::Read`] and [`core2::io::Write`].
 //!
 //! # Notes
 //! Typically, drivers do not need to be designed in this split manner. 
@@ -22,7 +22,7 @@ extern crate spin;
 extern crate irq_safety;
 extern crate interrupts;
 extern crate deferred_interrupt_tasks;
-extern crate bare_io;
+extern crate core2;
 extern crate x86_64;
 extern crate serial_port_basic;
 
@@ -226,33 +226,33 @@ impl SerialPort {
 }
 
 
-/// A non-blocking implementation of [`bare_io::Read`] that will read bytes into the given `buf`
+/// A non-blocking implementation of [`core2::io::Read`] that will read bytes into the given `buf`
 /// so long as more bytes are available.
 /// The read operation will be completed when there are no more bytes to be read,
 /// or when the `buf` is filled, whichever comes first.
 ///
-/// Because it's non-blocking, a [`bare_io::ErrorKind::WouldBlock`] error is returned
+/// Because it's non-blocking, a [`core2::io::ErrorKind::WouldBlock`] error is returned
 /// if there are no bytes available to be read, indicating that the read would block.
-impl bare_io::Read for SerialPort {
-    fn read(&mut self, buf: &mut [u8]) -> bare_io::Result<usize> {
+impl core2::io::Read for SerialPort {
+    fn read(&mut self, buf: &mut [u8]) -> core2::io::Result<usize> {
         if !self.data_available() {
-            return Err(bare_io::ErrorKind::WouldBlock.into());
+            return Err(core2::io::ErrorKind::WouldBlock.into());
         }
         Ok(self.in_bytes(buf))
     }
 }
 
-/// A blocking implementation of [`bare_io::Write`] that will write bytes from the given `buf`
+/// A blocking implementation of [`core2::io::Write`] that will write bytes from the given `buf`
 /// to the `SerialPort`, waiting until it is ready to transfer all bytes. 
 ///
 /// The `flush()` function is a no-op, since the `SerialPort` does not have buffering. 
-impl bare_io::Write for SerialPort {
-    fn write(&mut self, buf: &[u8]) -> bare_io::Result<usize> {
+impl core2::io::Write for SerialPort {
+    fn write(&mut self, buf: &[u8]) -> core2::io::Result<usize> {
         self.out_bytes(buf);
         Ok(buf.len())
     }
 
-    fn flush(&mut self) -> bare_io::Result<()> {
+    fn flush(&mut self) -> core2::io::Result<()> {
         Ok(())
     }    
 }

--- a/kernel/text_terminal/Cargo.toml
+++ b/kernel/text_terminal/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 bitflags = "1.1.0"
-bare-io = { version = "0.2.1", features = [ "alloc", "nightly" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 unicode-width = "0.1.8"
 vte = "0.10.1"
 derive_more = "0.99.0"

--- a/kernel/text_terminal/src/lib.rs
+++ b/kernel/text_terminal/src/lib.rs
@@ -33,7 +33,7 @@
 #[macro_use] extern crate bitflags;
 extern crate event_types;
 extern crate unicode_width;
-extern crate bare_io;
+extern crate core2;
 extern crate vte;
 extern crate util;
 #[macro_use] extern crate derive_more;
@@ -55,7 +55,7 @@ use core::num::NonZeroUsize;
 use core::ops::{Bound, Deref, DerefMut, Index, IndexMut};
 use alloc::string::String;
 use alloc::vec::Vec;
-use bare_io::{Read, Write};
+use core2::io::{Read, Write};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use vte::{Parser, Perform};
 
@@ -500,7 +500,7 @@ impl<Backend: TerminalBackend> TextTerminal<Backend> {
     /// and handles that stream of bytes as input into this terminal.
     ///
     /// Returns the number of bytes read from the given reader.
-    pub fn handle_input<R: Read>(&mut self, reader: &mut R) -> bare_io::Result<usize> {
+    pub fn handle_input<R: Read>(&mut self, reader: &mut R) -> core2::io::Result<usize> {
         const READ_BATCH_SIZE: usize = 128;
         let mut total_bytes_read = 0;
         let mut buf = [0; READ_BATCH_SIZE];
@@ -533,7 +533,7 @@ impl<Backend: TerminalBackend> TextTerminal<Backend> {
     /// to the backend output stream.
     ///
     /// No caching or performance optimizations are used. 
-    pub fn flush(&mut self) -> bare_io::Result<usize> {
+    pub fn flush(&mut self) -> core2::io::Result<usize> {
         unimplemented!()
     }
 
@@ -1820,7 +1820,7 @@ pub trait TerminalBackend {
 ///
 /// A TTY backend doesn't support any form of random access or direct text rendering, 
 /// so we can only issue regular ANSI/xterm control and escape sequences to it.
-pub struct TtyBackend<Output: bare_io::Write> {
+pub struct TtyBackend<Output: core2::io::Write> {
     /// The width and height of this terminal's screen.
     screen_size: ScreenSize,
 
@@ -1833,7 +1833,7 @@ pub struct TtyBackend<Output: bare_io::Write> {
 
     insert_mode: InsertMode,
 }
-impl<Output: bare_io::Write> TtyBackend<Output> {
+impl<Output: core2::io::Write> TtyBackend<Output> {
     // const FORWARDS_DELETE: &'static [u8] = &[
     //     AsciiControlCodes::Escape,
     //     b'[',
@@ -1921,8 +1921,8 @@ impl<Output: bare_io::Write> TtyBackend<Output> {
         self.real_screen_cursor = cursor;
     }
 }
-impl<Output: bare_io::Write> TerminalBackend for TtyBackend<Output> {
-    type DisplayError = bare_io::Error;
+impl<Output: core2::io::Write> TerminalBackend for TtyBackend<Output> {
+    type DisplayError = core2::io::Error;
 
     #[inline(always)]
     fn screen_size(&self) -> ScreenSize {

--- a/libs/stdio/Cargo.toml
+++ b/libs/stdio/Cargo.toml
@@ -6,7 +6,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.keycodes_ascii]
 path = "../keycodes_ascii"

--- a/libs/stdio/src/lib.rs
+++ b/libs/stdio/src/lib.rs
@@ -5,7 +5,7 @@
 
 extern crate alloc;
 extern crate spin;
-extern crate bare_io;
+extern crate core2;
 extern crate keycodes_ascii;
 
 use alloc::collections::VecDeque;
@@ -14,7 +14,7 @@ use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
 use spin::{Mutex, MutexGuard};
-use bare_io::{Read, Write};
+use core2::io::{Read, Write};
 use keycodes_ascii::KeyEvent;
 use core::ops::Deref;
 
@@ -138,7 +138,7 @@ impl StdioReader {
     /// buffer. Do NOT use this function alternatively with `read()` method defined in
     /// `StdioReadGuard`. This function returns the number of bytes read. It will return
     /// zero only upon EOF.
-    pub fn read_line(&mut self, buf: &mut String) -> Result<usize, bare_io::Error> {
+    pub fn read_line(&mut self, buf: &mut String) -> Result<usize, core2::io::Error> {
         let mut total_cnt = 0usize;    // total number of bytes read this time
         let mut new_cnt;               // number of bytes returned from a `read()` invocation
         let mut tmp_buf = Vec::new();  // temporary buffer
@@ -204,7 +204,7 @@ impl<'a> Read for StdioReadGuard<'a> {
     /// It will only return zero under one of two scenarios:
     /// 1. The EOF flag has been set.
     /// 2. The buffer specified was 0 bytes in length.
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize, bare_io::Error> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, core2::io::Error> {
 
         // Deal with the edge case that the buffer specified was 0 bytes in length.
         if buf.len() == 0 { return Ok(0); }
@@ -241,7 +241,7 @@ impl<'a> StdioReadGuard<'a> {
     /// Same as `read()`, but is non-blocking.
     /// 
     /// Returns `Ok(0)` when the underlying buffer is empty.
-    pub fn try_read(&mut self, buf: &mut [u8]) -> Result<usize, bare_io::Error> {
+    pub fn try_read(&mut self, buf: &mut [u8]) -> Result<usize, core2::io::Error> {
 
         // Deal with the edge case that the buffer specified was 0 bytes in length.
         if buf.len() == 0 { return Ok(0); }
@@ -275,9 +275,9 @@ impl<'a> Write for StdioWriteGuard<'a> {
     /// Also note that this method does *not* guarantee to write all given bytes, although it currently
     /// does so. Always check the return value when using this method. Otherwise, use `write_all` to
     /// ensure that all given bytes are written.
-    fn write(&mut self, buf: &[u8]) -> Result<usize, bare_io::Error> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, core2::io::Error> {
         if self.guard.lock().end {
-            return Err(bare_io::Error::new(bare_io::ErrorKind::UnexpectedEof,
+            return Err(core2::io::Error::new(core2::io::ErrorKind::UnexpectedEof,
                                            "cannot write to a stream with EOF set"));
         }
         let mut locked_ring_buf = self.guard.lock();
@@ -288,7 +288,7 @@ impl<'a> Write for StdioWriteGuard<'a> {
     }
     /// The function required by `Write` trait. Currently it performs nothing,
     /// since everything is write directly to the ring buffer in `write` method.
-    fn flush(&mut self) -> Result<(), bare_io::Error> {
+    fn flush(&mut self) -> Result<(), core2::io::Error> {
         Ok(())
     }
 }

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -50,7 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "bare-io"
+name = "core2"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec6ec4815d7aacd0be4ec053ef9e2883b22f79b29f9bd2ef3f79003e3ee7c9d"
@@ -776,7 +776,7 @@ dependencies = [
 name = "tlibc"
 version = "0.1.0"
 dependencies = [
- "bare-io",
+ "core2",
  "cbitset",
  "cstr_core",
  "lazy_static",

--- a/tlibc/Cargo.toml
+++ b/tlibc/Cargo.toml
@@ -10,7 +10,7 @@ spin = "0.9.0"
 log = "0.4.8"
 libc = { version = "0.2.107", default-features = false }
 cstr_core = "0.2.3"
-bare-io = { version = "0.2.1", features = [ "alloc" ] }
+core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 memchr = { version = "2.2.0", default-features = false }
 cbitset = "0.2.0"
 

--- a/tlibc/src/io.rs
+++ b/tlibc/src/io.rs
@@ -1,9 +1,9 @@
-pub use bare_io::*;
+pub use core2::io::*;
 use core::fmt;
 
-pub fn last_os_error() -> bare_io::Error {
+pub fn last_os_error() -> core2::io::Error {
     // If we switch back to core_io, this should invoke `Error::from_raw_os_error()`
-    bare_io::Error::new(ErrorKind::Other, crate::errno_str())
+    core2::io::Error::new(ErrorKind::Other, crate::errno_str())
 }
 
 
@@ -32,23 +32,23 @@ impl<T: WriteByte> WriteByte for CountingWriter<T> {
     }
 }
 impl<T: Write> Write for CountingWriter<T> {
-    fn write(&mut self, buf: &[u8]) -> bare_io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> core2::io::Result<usize> {
         let res = self.inner.write(buf);
         if let Ok(written) = res {
             self.written += written;
         }
         res
     }
-    fn write_all(&mut self, buf: &[u8]) -> bare_io::Result<()> {
+    fn write_all(&mut self, buf: &[u8]) -> core2::io::Result<()> {
         match self.inner.write_all(&buf) {
             Ok(()) => (),
-            Err(ref err) if err.kind() == bare_io::ErrorKind::WriteZero => (),
+            Err(ref err) if err.kind() == core2::io::ErrorKind::WriteZero => (),
             Err(err) => return Err(err),
         }
         self.written += buf.len();
         Ok(())
     }
-    fn flush(&mut self) -> bare_io::Result<()> {
+    fn flush(&mut self) -> core2::io::Result<()> {
         self.inner.flush()
     }
 }
@@ -57,7 +57,7 @@ impl<T: Write> Write for CountingWriter<T> {
 
 pub struct StringWriter(pub *mut u8, pub usize);
 impl Write for StringWriter {
-    fn write(&mut self, buf: &[u8]) -> bare_io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> core2::io::Result<usize> {
         if self.1 > 1 {
             let copy_size = buf.len().min(self.1 - 1);
             unsafe {
@@ -76,7 +76,7 @@ impl Write for StringWriter {
         // `cmp::min(written, maxlen)`.
         Ok(buf.len())
     }
-    fn flush(&mut self) -> bare_io::Result<()> {
+    fn flush(&mut self) -> core2::io::Result<()> {
         Ok(())
     }
 }

--- a/tlibc/src/lib.rs
+++ b/tlibc/src/lib.rs
@@ -22,7 +22,7 @@ extern crate cbitset;
 extern crate memory;
 extern crate task;
 extern crate cstr_core;
-extern crate bare_io;
+extern crate core2;
 
 
 mod errno;


### PR DESCRIPTION
Closes #466 and solves the CI doc build errors.