### PR TITLE
Remove the dependency from `heap` -> `memory_initialization`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bootloader_modules"
+version = "0.1.0"
+dependencies = [
+ "memory_structs",
+]
+
+[[package]]
 name = "by_address"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1539,7 @@ dependencies = [
 name = "memory_initialization"
 version = "0.1.0"
 dependencies = [
+ "bootloader_modules",
  "heap",
  "irq_safety",
  "kernel_config",
@@ -1635,6 +1643,7 @@ dependencies = [
 name = "mod_mgmt"
 version = "0.1.0"
 dependencies = [
+ "bootloader_modules",
  "cow_arc",
  "crate_metadata",
  "crate_name_utils",
@@ -1646,7 +1655,6 @@ dependencies = [
  "log",
  "memfs",
  "memory",
- "memory_initialization",
  "path",
  "qp-trie",
  "rangemap",

--- a/kernel/bootloader_modules/Cargo.toml
+++ b/kernel/bootloader_modules/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "bootloader_modules"
+description = "A type abstration for modules provided by a bootloader, e.g., multiboot"
+version = "0.1.0"
+build = "../../build.rs"
+
+[dependencies.memory_structs]
+path = "../memory_structs"
+
+[lib]
+crate-type = ["rlib"]

--- a/kernel/bootloader_modules/src/lib.rs
+++ b/kernel/bootloader_modules/src/lib.rs
@@ -1,0 +1,46 @@
+//! An abstraction for bootloader-provided "modules".
+
+#![no_std]
+
+extern crate alloc;
+extern crate memory_structs;
+
+use alloc::string::String;
+use memory_structs::PhysicalAddress;
+
+/// A record of a bootloader module's name and location in physical memory.
+#[derive(Debug)]
+pub struct BootloaderModule {
+    /// The starting address of this module, inclusive.
+    start_paddr: PhysicalAddress,
+    /// The ending address of this module, exclusive.
+    end_paddr: PhysicalAddress,
+    /// The name of this module, i.e.,
+    /// the filename it was given in the bootloader's cfg file.
+    name: String,
+}
+impl BootloaderModule {
+    pub fn new(
+        start_paddr: PhysicalAddress,
+        end_paddr: PhysicalAddress,
+        name: String
+    ) -> BootloaderModule {
+        BootloaderModule { start_paddr, end_paddr, name }
+    } 
+
+    pub fn start_address(&self) -> PhysicalAddress {
+        self.start_paddr
+    }
+
+    pub fn end_address(&self) -> PhysicalAddress {
+        self.end_paddr
+    }
+
+    pub fn name(&self) -> &String {
+        &self.name
+    }
+
+    pub fn size_in_bytes(&self) -> usize {
+        self.end_paddr.value() - self.start_paddr.value()
+    }
+}

--- a/kernel/memory_initialization/Cargo.toml
+++ b/kernel/memory_initialization/Cargo.toml
@@ -16,6 +16,9 @@ path = "../stack"
 [dependencies.kernel_config]
 path = "../kernel_config"
 
+[dependencies.bootloader_modules]
+path = "../bootloader_modules"
+
 [dependencies.log]
 version = "0.4.8"
 

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -38,8 +38,8 @@ path = "../crate_metadata"
 [dependencies.memory]
 path = "../memory"
 
-[dependencies.memory_initialization]
-path = "../memory_initialization"
+[dependencies.bootloader_modules]
+path = "../bootloader_modules"
 
 [dependencies.root]
 path = "../root"


### PR DESCRIPTION
* Adds a new `bootloader_modules` crate to break the unnecessary dependency chain from `mod_mgmt` -> `memory_initialization`.

This allows, for example, to use a bunch of memory-related or memory-dependent crates from most foreign crates. For one, the `heap` crate can now depend on `task` as @NamiLiy requested.