### PR TITLE
Allow arbitrary extra files to be included in ISO and root FS.

### DIFF
--- a/extra_files/README.md
+++ b/extra_files/README.md
@@ -1,0 +1,23 @@
+# Theseus Extra Files
+This directory contains extra files that are copied directly into the ISO image after Theseus is built.
+
+
+## Usage Examples
+This can be a catch-all space for any random files that aren't necessarily source code or build artifacts, but still need to be present in Theseus's initial filesystem. 
+Examples include:
+* test text files
+* WASM binaries
+* Images
+* Other resources
+
+
+## How it works
+All files and directories here will be copied as-is without modification into the `/extra_files/` directory within Theseus.
+Directory hierarchies are preserved as well, but empty directories are ignored.
+
+Here are some examples of how a hypothetical file in this directory will appear in Theseus at runtime:
+```
+./hello.txt       -->  /extra_files/hello.txt
+./wasm/test.wasm  -->  /extra_files/wasm/test.wasm
+./foo/bar/me.o    -->  /extra_files/foo/bar/me.o
+```

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -50,6 +50,10 @@ pub mod replace_nano_core_crates;
 /// The name of the directory that contains all of the CrateNamespace files.
 pub const NAMESPACES_DIRECTORY_NAME: &'static str = "namespaces";
 
+/// The name of the directory that contains all other "extra_files" contents.
+pub const EXTRA_FILES_DIRECTORY_NAME: &'static str = "extra_files";
+const EXTRA_FILES_DIRECTORY_DELIMITER: char = '?';
+
 /// The initial `CrateNamespace` that all kernel crates are added to by default.
 static INITIAL_KERNEL_NAMESPACE: Once<Arc<CrateNamespace>> = Once::new();
 
@@ -131,6 +135,9 @@ pub fn init(
 /// This function does not create any namespaces, it just populates the files and directories
 /// such that namespaces can be created based on those files.
 /// 
+/// If a file does not have an expected crate prefix according to [`CrateType::from_module_name()`],
+/// then it is treated as part of "extra_files"; see [`parse_extra_file()`] for more.
+/// 
 /// Returns a tuple of: 
 /// * the top-level root "namespaces" directory that contains all other namespace directories,
 /// * the directory of the default kernel crate namespace.
@@ -141,6 +148,8 @@ fn parse_bootloader_modules_into_files(
 
     // create the top-level directory to hold all default namespaces
     let namespaces_dir = VFSDirectory::new(NAMESPACES_DIRECTORY_NAME.to_string(), root::get_root())?;
+    // create the top-level directory to hold all extra files
+    let extra_files_dir = VFSDirectory::new(EXTRA_FILES_DIRECTORY_NAME.to_string(), root::get_root())?;
 
     // a map that associates a prefix string (e.g., "sse" in "ksse#crate.o") to a namespace directory of object files 
     let mut prefix_map: BTreeMap<String, NamespaceDir> = BTreeMap::new();
@@ -151,10 +160,6 @@ fn parse_bootloader_modules_into_files(
     };
 
     for m in bootloader_modules {
-        let (crate_type, prefix, file_name) = CrateType::from_module_name(m.name().as_str())?;
-        let dir_name = format!("{}{}", prefix, crate_type.default_namespace_name());
-        let name = String::from(file_name);
-
         let frames = allocate_frames_by_bytes_at(m.start_address(), m.size_in_bytes())
             .map_err(|_e| "Failed to allocate frames for bootloader module")?;
         let pages = allocate_pages_by_bytes(m.size_in_bytes())
@@ -165,10 +170,18 @@ fn parse_bootloader_modules_into_files(
             EntryFlags::PRESENT, // we never need to write to bootloader-provided modules
         )?;
 
+        let (crate_type, prefix, file_name) = if let Ok((c, p, f)) = CrateType::from_module_name(m.name().as_str()) {
+            (c, p, f)
+        } else {
+            parse_extra_file(&m, mp, Arc::clone(&extra_files_dir))?;
+            continue;
+        };
+
+        let dir_name = format!("{}{}", prefix, crate_type.default_namespace_name());
         // debug!("Module: {:?}, size {}, mp: {:?}", m.name(), m.size_in_bytes(), mp);
 
         let create_file = |dir: &DirRef| {
-            MemFile::from_mapped_pages(mp, name, m.size_in_bytes(), dir)
+            MemFile::from_mapped_pages(mp, file_name.to_string(), m.size_in_bytes(), dir)
         };
 
         // Get the existing (or create a new) namespace directory corresponding to the given directory name.
@@ -183,6 +196,50 @@ fn parse_bootloader_modules_into_files(
         namespaces_dir,
         prefix_map.remove(CrateType::Kernel.default_namespace_name()).ok_or("BUG: no default namespace found")?,
     ))
+}
+
+/// Adds the given extra file to the directory of extra files
+/// 
+/// See the top-level Makefile target "extra_files" for an explanation of how these work.
+/// Basically, they are arbitrary files that are included by the bootloader as modules
+/// (files that exist as areas of pre-loaded memory).
+/// 
+/// Their file paths are encoded by flattening directory hierarchies into a the file name,
+/// using `'?'` (question marks) to replace the directory delimiter `'/'`.
+/// 
+/// Thus, for example, a file named `"foo?bar?me?test.txt"` will be placed at the path
+/// `/extra_files/foo/bar/me/test.txt`.
+fn parse_extra_file(
+    extra_file: &BootloaderModule,
+    extra_file_mp: MappedPages,
+    extra_files_dir: DirRef
+) -> Result<FileRef, &'static str> {
+
+    let mut file_name = extra_file.name().as_str();
+    
+    let mut parent_dir = extra_files_dir;
+    let mut iter = extra_file.name().as_str().split(EXTRA_FILES_DIRECTORY_DELIMITER).peekable();
+    while let Some(path_component) = iter.next() {
+        if iter.peek().is_some() {
+            let existing_dir = parent_dir.lock().get_dir(path_component);
+            parent_dir = existing_dir
+                .or_else(|| VFSDirectory::new(path_component.to_string(), &parent_dir).ok())
+                .ok_or_else(|| {
+                    error!("Failed to get or create directory {:?} for extra file {:?}", path_component, extra_file);
+                    "Failed to get or create directory for extra file"
+                })?;
+        } else {
+            file_name = path_component;
+            break;
+        }
+    }
+
+    MemFile::from_mapped_pages(
+        extra_file_mp,
+        file_name.to_string(),
+        extra_file.size_in_bytes(),
+        &parent_dir
+    )
 }
 
 


### PR DESCRIPTION
You can now place any arbitrary file or directory structure in the `extra_files` directory. They will be packaged up into the Theseus ISO and present in Theseus's root filesystem at runtime.

Needed for @vikrammullick's wasm PR #472 