### PR TITLE
Upgrade to new `mpmc` version from `crates.io`.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 	url = https://github.com/theseus-os/x86_64
 	branch = master
 	ignore = dirty
-[submodule "libs/mpmc"]
-	path = libs/mpmc
-	url = https://github.com/theseus-os/mpmc
 [submodule "libs/object"]
 	path = libs/object
 	url = https://github.com/theseus-os/object.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,7 +1690,9 @@ version = "0.1.0"
 
 [[package]]
 name = "mpmc"
-version = "0.1.6-pre"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf78b1242a953be96e01b5f8ed8ffdfc8055c0a2b779899b3835e5d27a69dced"
 
 [[package]]
 name = "multiboot2"

--- a/kernel/async_channel/Cargo.toml
+++ b/kernel/async_channel/Cargo.toml
@@ -9,15 +9,13 @@ build = "../../build.rs"
 spin = "0.9.0"
 crossbeam-utils = { version = "0.8.5", default-features = false }
 static_assertions = "1.1.0"
+mpmc = "0.1.6"
 
 [dependencies.log]
 version = "0.4.8"
 
 [dependencies.debugit]
 path = "../../libs/debugit"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 [dependencies.wait_queue]
 path = "../wait_queue"

--- a/kernel/console/Cargo.toml
+++ b/kernel/console/Cargo.toml
@@ -9,6 +9,7 @@ build = "../../build.rs"
 spin = "0.9.0"
 core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 log = "0.4.8"
+mpmc = "0.1.6"
 
 [dependencies.async_channel]
 path = "../async_channel"
@@ -30,9 +31,6 @@ path = "../spawn"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/device_manager/Cargo.toml
+++ b/kernel/device_manager/Cargo.toml
@@ -9,6 +9,7 @@ build = "../../build.rs"
 spin = "0.9.0"
 core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
 derive_more = "0.99.0"
+mpmc = "0.1.6"
 
 [dependencies.fatfs]
 git = "https://github.com/rafalh/rust-fatfs"
@@ -17,9 +18,6 @@ features = [ "alloc", "lfn", "unicode", "log_level_warn" ]
 
 [dependencies.log]
 version = "0.4.8"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 [dependencies.event_types]
 path = "../event_types"

--- a/kernel/e1000/Cargo.toml
+++ b/kernel/e1000/Cargo.toml
@@ -12,6 +12,7 @@ x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.5.0"
 static_assertions = "1.1.0"
+mpmc = "0.1.6"
 
 
 [dependencies.log]
@@ -35,9 +36,6 @@ path = "../pci"
 
 [dependencies.interrupts]
 path = "../interrupts"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 [dependencies.network_interface_card]
 path = "../network_interface_card"

--- a/kernel/ixgbe/Cargo.toml
+++ b/kernel/ixgbe/Cargo.toml
@@ -12,6 +12,7 @@ bit_field = "0.7.0"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.5.0"
 static_assertions = "1.1.0"
+mpmc = "0.1.6"
 
 [dependencies.hashbrown]
 version = "0.9.1"
@@ -51,9 +52,6 @@ path = "../pit_clock"
 
 [dependencies.interrupts]
 path = "../interrupts"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 [dependencies.rand]
 version = "0.6"

--- a/kernel/keyboard/Cargo.toml
+++ b/kernel/keyboard/Cargo.toml
@@ -7,16 +7,13 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-
+mpmc = "0.1.6"
 
 [dependencies.log]
 version = "0.4.8"
 
 [dependencies.keycodes_ascii]
 path = "../../libs/keycodes_ascii"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 [dependencies.event_types]
 path = "../event_types"

--- a/kernel/mouse/Cargo.toml
+++ b/kernel/mouse/Cargo.toml
@@ -6,7 +6,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-
+mpmc = "0.1.6"
 
 [dependencies.log]
 version = "0.4.8"
@@ -19,9 +19,6 @@ path = "../ps2"
 
 [dependencies.event_types]
 path = "../event_types"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/nic_buffers/Cargo.toml
+++ b/kernel/nic_buffers/Cargo.toml
@@ -7,16 +7,13 @@ build = "../../build.rs"
 
 [dependencies]
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
-
+mpmc = "0.1.6"
 
 [dependencies.memory]
 path = "../memory"
 
 [dependencies.log]
 version = "0.4.8"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 
 [lib]

--- a/kernel/nic_initialization/Cargo.toml
+++ b/kernel/nic_initialization/Cargo.toml
@@ -8,15 +8,13 @@ build = "../../build.rs"
 [dependencies]
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 volatile = "0.2.7"
+mpmc = "0.1.6"
 
 [dependencies.log]
 version = "0.4.8"
 
 [dependencies.memory]
 path = "../memory"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 [dependencies.pci]
 path = "../pci"

--- a/kernel/nic_queues/Cargo.toml
+++ b/kernel/nic_queues/Cargo.toml
@@ -7,6 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
+mpmc = "0.1.6"
 
 [dependencies.memory]
 path = "../memory"
@@ -19,9 +20,6 @@ path = "../intel_ethernet"
 
 [dependencies.nic_buffers]
 path = "../nic_buffers"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/window/Cargo.toml
+++ b/kernel/window/Cargo.toml
@@ -8,12 +8,10 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
+mpmc = "0.1.6"
 
 [dependencies.log]
 version = "0.4.8"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 [dependencies.shapes]
 path = "../shapes"

--- a/kernel/window_inner/Cargo.toml
+++ b/kernel/window_inner/Cargo.toml
@@ -5,9 +5,8 @@ authors = ["Yue Wu <wuyue16@pku.edu.cn>", "Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "allocate new windows and manage a list of existing windows"
 build = "../../build.rs"
 
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
+[dependencies]
+mpmc = "0.1.6"
 
 [dependencies.framebuffer]
 path = "../framebuffer"

--- a/kernel/window_manager/Cargo.toml
+++ b/kernel/window_manager/Cargo.toml
@@ -7,12 +7,10 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
+mpmc = "0.1.6"
 
 [dependencies.log]
 version = "0.4.8"
-
-[dependencies.mpmc]
-path = "../../libs/mpmc"
 
 [dependencies.framebuffer_drawer]
 path = "../framebuffer_drawer"


### PR DESCRIPTION
Remove our outdated fork in `libs/mpmc` as a git submodule. 

Closes #412 