### PR TITLE
Upgrade hashbrown to 0.11.2 everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "ap_start"
@@ -992,6 +997,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "gimli"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
 ]
@@ -1914,6 +1930,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
@@ -3195,6 +3217,12 @@ name = "util"
 version = "0.1.0"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "vfs_node"
 version = "0.1.0"
 dependencies = [
@@ -3286,6 +3314,12 @@ version = "0.10.0+wasi-snapshot-preview1"
 source = "git+https://github.com/bytecodealliance/wasi?rev=45536ac956a6211e3cff047f36cf19d6da82fd95#45536ac956a6211e3cff047f36cf19d6da82fd95"
 
 [[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
 name = "wasi_interpreter"
 version = "0.1.0"
 dependencies = [
@@ -3297,7 +3331,7 @@ dependencies = [
  "path",
  "root",
  "task",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "wasmi",
 ]
 

--- a/applications/heap_eval/Cargo.toml
+++ b/applications/heap_eval/Cargo.toml
@@ -25,7 +25,7 @@ path = "../../kernel/apic"
 path = "../../kernel/runqueue"
 
 [dependencies.hashbrown]
-version = "0.1.8"
+version = "0.11.2"
 features = ["nightly"]
 
 [dependencies.libtest]

--- a/applications/ping/Cargo.toml
+++ b/applications/ping/Cargo.toml
@@ -23,7 +23,7 @@ path = "../upd"
 path = "../../kernel/acpi/hpet"
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 features = ["nightly"]
 
 [dependencies.network_manager]

--- a/kernel/block_cache/Cargo.toml
+++ b/kernel/block_cache/Cargo.toml
@@ -15,7 +15,7 @@ features = ["spin_no_std"]
 version = "1.4.0"
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 features = ["nightly"]
 
 [dependencies.storage_device]

--- a/kernel/crate_metadata/Cargo.toml
+++ b/kernel/crate_metadata/Cargo.toml
@@ -24,7 +24,7 @@ features = ["elf64"]
 path = "../../libs/cow_arc"
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 features = ["nightly"]
 
 [dependencies.memory]

--- a/kernel/crate_swap/Cargo.toml
+++ b/kernel/crate_swap/Cargo.toml
@@ -20,7 +20,7 @@ features = ["spin_no_std"]
 version = "1.4.0"
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 features = ["nightly"]
 
 [dependencies.memory]

--- a/kernel/debug_info/Cargo.toml
+++ b/kernel/debug_info/Cargo.toml
@@ -26,7 +26,7 @@ default-features = false
 features = ["elf64"]
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 features = ["nightly"]
 
 [dependencies.util]

--- a/kernel/framebuffer_compositor/Cargo.toml
+++ b/kernel/framebuffer_compositor/Cargo.toml
@@ -22,7 +22,7 @@ features = ["spin_no_std"]
 version = "1.4.0"
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 features = ["nightly"]
 
 [lib]

--- a/kernel/ixgbe/Cargo.toml
+++ b/kernel/ixgbe/Cargo.toml
@@ -15,7 +15,7 @@ static_assertions = "1.1.0"
 mpmc = "0.1.6"
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 features = ["nightly"]
 
 [dependencies.log]

--- a/kernel/libtest/Cargo.toml
+++ b/kernel/libtest/Cargo.toml
@@ -33,7 +33,7 @@ path = "../acpi/hpet"
 path = "../pmu_x86"
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 features = ["nightly"]
 
 [lib]

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -48,7 +48,7 @@ path = "../root"
 path = "../fs_node"
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 features = ["nightly"]
 
 [dependencies.vfs_node]

--- a/kernel/multiple_heaps/Cargo.toml
+++ b/kernel/multiple_heaps/Cargo.toml
@@ -43,5 +43,5 @@ path = "../slabmalloc_unsafe"
 path = "../heap"
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 features = ["nightly"]

--- a/kernel/wasi_interpreter/Cargo.toml
+++ b/kernel/wasi_interpreter/Cargo.toml
@@ -8,7 +8,7 @@ build = "../../build.rs"
 
 [dependencies]
 core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
-hashbrown = { version = "0.9.1", features = ["nightly"] }
+hashbrown = { version = "0.11.2", features = ["nightly"] }
 wasi = { git = "https://github.com/bytecodealliance/wasi", rev = "45536ac956a6211e3cff047f36cf19d6da82fd95", default-features = false }
 wasmi = { version = "0.9.0", default-features = false, features = ["core"] }
 


### PR DESCRIPTION
Needed for easier wasmtime version compatibility

Closes #364 