### PR TITLE
Use mutable closures in `unwind` and `stack_trace` functions

### DIFF
--- a/kernel/exceptions_full/src/lib.rs
+++ b/kernel/exceptions_full/src/lib.rs
@@ -133,7 +133,7 @@ fn kill_and_halt(exception_number: u8, stack_frame: &ExceptionStackFrame, print_
         if print_stack_trace {
             println_both!("------------------ Stack Trace (DWARF) ---------------------------");
             let stack_trace_result = stack_trace::stack_trace(
-                &|stack_frame, stack_frame_iter| {
+                &mut |stack_frame, stack_frame_iter| {
                     let symbol_offset = stack_frame_iter.namespace().get_section_containing_address(
                         VirtualAddress::new_canonical(stack_frame.call_site_address() as usize),
                         false

--- a/kernel/panic_wrapper/src/lib.rs
+++ b/kernel/panic_wrapper/src/lib.rs
@@ -39,7 +39,7 @@ pub fn panic_wrapper(panic_info: &PanicInfo) -> Result<(), &'static str> {
         #[cfg(not(frame_pointers))] {
             error!("------------------ Stack Trace (DWARF) ---------------------------");
             stack_trace::stack_trace(
-                &|stack_frame, stack_frame_iter| {
+                &mut |stack_frame, stack_frame_iter| {
                     let symbol_offset = stack_frame_iter.namespace().get_section_containing_address(
                         VirtualAddress::new_canonical(stack_frame.call_site_address() as usize),
                         false

--- a/kernel/stack_trace/src/lib.rs
+++ b/kernel/stack_trace/src/lib.rs
@@ -33,14 +33,15 @@ use fallible_iterator::FallibleIterator;
 /// # Arguments
 /// * `on_each_stack_frame`: (a mutable reference to) the function that will be called 
 ///   for each stack frame in the call stack.
-///   The function is passed two arguments: 
-///   (1) a `StackFrame` instance that contains information about that frame, 
-///   (2) a reference to the current `StackFrameIter`, which can be used to obtain
+/// 
+///   The function is called with two arguments: 
+///   1. a `StackFrame` instance that contains information about that frame, 
+///   2. a reference to the current `StackFrameIter`, which can be used to obtain
 ///   register values that existed at this frame in the call stack.
+/// 
 ///   The function should return `true` if it wants to continue iterating up the call stack,
 ///   or `false` if it wants the iteration to stop.
 /// * `max_recursion`: an optional maximum number of stack frames to recurse up the call stack.
-///   If not provided, the default maximum will be `64` call stack frames.
 /// 
 /// # Examples
 /// Typical usage would involve using the stack frame's call site address to print out 
@@ -59,7 +60,7 @@ pub fn stack_trace(
     on_each_stack_frame: &mut dyn FnMut(StackFrame, &StackFrameIter) -> bool,
     max_recursion: Option<usize>,
 ) -> Result<(), &'static str> {
-    let max_recursion = max_recursion.unwrap_or(64);
+    let max_recursion = max_recursion.unwrap_or(usize::MAX);
 
     unwind::invoke_with_current_registers(&mut |registers| {
         let namespace = task::get_my_current_task()

--- a/kernel/unwind/src/lib.rs
+++ b/kernel/unwind/src/lib.rs
@@ -448,10 +448,10 @@ type FuncWithRegistersRefMut<'a> = &'a mut dyn FuncWithRegisters;
 /// since we have to start from the current call frame and work backwards up the call stack 
 /// while applying the rules for register value changes in each call frame
 /// in order to arrive at the proper register values for a prior call frame.
-pub fn invoke_with_current_registers<F>(mut f: F) -> Result<(), &'static str> 
+pub fn invoke_with_current_registers<F>(f: &mut F) -> Result<(), &'static str> 
     where F: FuncWithRegisters 
 {
-    let mut f: FuncWithRegistersRefMut = &mut f;
+    let mut f: FuncWithRegistersRefMut = f; // cast to a &mut trait object
     let result = unsafe { 
         let res_ptr = unwind_trampoline(&mut f);
         let res_boxed = Box::from_raw(res_ptr);
@@ -717,7 +717,7 @@ pub fn start_unwinding(reason: KillReason, stack_frames_to_skip: usize) -> Resul
 
 
     // We pass a pointer to the unwinding context to this closure. 
-    let res = invoke_with_current_registers(|registers| {
+    let res = invoke_with_current_registers(&mut |registers| {
         // set the proper register values before start the actual unwinding procedure.
         {  
             // SAFE: we just created this pointer above

--- a/kernel/unwind/src/lib.rs
+++ b/kernel/unwind/src/lib.rs
@@ -437,8 +437,8 @@ unsafe fn deref_ptr(ptr: Pointer) -> u64 {
 }
 
 
-pub trait FuncWithRegisters = Fn(Registers) -> Result<(), &'static str>;
-type RefFuncWithRegisters<'a> = &'a dyn FuncWithRegisters;
+pub trait FuncWithRegisters = FnMut(Registers) -> Result<(), &'static str>;
+type FuncWithRegistersRefMut<'a> = &'a mut dyn FuncWithRegisters;
 
 
 /// This function saves the current CPU register values onto the stack (to preserve them)
@@ -448,12 +448,12 @@ type RefFuncWithRegisters<'a> = &'a dyn FuncWithRegisters;
 /// since we have to start from the current call frame and work backwards up the call stack 
 /// while applying the rules for register value changes in each call frame
 /// in order to arrive at the proper register values for a prior call frame.
-pub fn invoke_with_current_registers<F>(f: F) -> Result<(), &'static str> 
+pub fn invoke_with_current_registers<F>(mut f: F) -> Result<(), &'static str> 
     where F: FuncWithRegisters 
 {
-    let f: RefFuncWithRegisters = &f;
+    let mut f: FuncWithRegistersRefMut = &mut f;
     let result = unsafe { 
-        let res_ptr = unwind_trampoline(&f);
+        let res_ptr = unwind_trampoline(&mut f);
         let res_boxed = Box::from_raw(res_ptr);
         *res_boxed
     };
@@ -470,7 +470,7 @@ pub fn invoke_with_current_registers<F>(f: F) -> Result<(), &'static str>
     /// The argument is a pointer to a function reference, so effectively a pointer to a pointer. 
     #[naked]
     #[inline(never)]
-    unsafe extern "C" fn unwind_trampoline(_func: *const RefFuncWithRegisters) -> *mut Result<(), &'static str> {
+    unsafe extern "C" fn unwind_trampoline(_func: *mut FuncWithRegistersRefMut) -> *mut Result<(), &'static str> {
         // This is a naked function, so you CANNOT place anything here before the asm block, not even log statements.
         // This is because we rely on the value of registers to stay the same as whatever the caller set them to.
         // DO NOT touch RDI register, which has the `_func` function; it needs to be passed into unwind_recorder.
@@ -515,11 +515,11 @@ pub fn invoke_with_current_registers<F>(f: F) -> Result<(), &'static str>
     ///   after we change the register values during unwinding,
     #[no_mangle]
     unsafe extern "C" fn unwind_recorder(
-        func: *const RefFuncWithRegisters,
+        func: *mut FuncWithRegistersRefMut,
         stack: u64,
         saved_regs: *mut SavedRegs,
     ) -> *mut Result<(), &'static str> {
-        let func = &*func;
+        let func = &mut *func;
         let saved_regs = &*saved_regs;
 
         let mut registers = Registers::default();
@@ -718,7 +718,7 @@ pub fn start_unwinding(reason: KillReason, stack_frames_to_skip: usize) -> Resul
 
     // We pass a pointer to the unwinding context to this closure. 
     let res = invoke_with_current_registers(|registers| {
-        // set the proper register values before we used the 
+        // set the proper register values before start the actual unwinding procedure.
         {  
             // SAFE: we just created this pointer above
             let unwinding_context = unsafe { &mut *unwinding_context_ptr };


### PR DESCRIPTION
Needed to support porting the `backtrace` crate to Theseus