### PR TITLE
Upgrade `core2` dependency to 0.4.0 for compatibility reasons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,9 +453,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core2"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf12d2dad3ed124aa116f59561428478993d69ab81ae4d30e5349c9c5b5a5f6"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
 ]

--- a/applications/cat/Cargo.toml
+++ b/applications/cat/Cargo.toml
@@ -6,7 +6,7 @@ build = "../../build.rs"
 
 [dependencies]
 getopts = "0.2.21"
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
 
 [dependencies.log]

--- a/applications/immediate_input_echo/Cargo.toml
+++ b/applications/immediate_input_echo/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
 
 [dependencies]
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.stdio]
 path = "../../libs/stdio"

--- a/applications/input_echo/Cargo.toml
+++ b/applications/input_echo/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
 
 [dependencies]
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.app_io]
 path = "../../kernel/app_io"

--- a/applications/keyboard_echo/Cargo.toml
+++ b/applications/keyboard_echo/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Zhiyao Ma <zm16@pku.edu.cn>"]
 build = "../../build.rs"
 
 [dependencies]
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.scheduler]
 path = "../../kernel/scheduler"

--- a/applications/less/Cargo.toml
+++ b/applications/less/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 [dependencies]
 getopts = "0.2.21"
 spin = "0.9.0"
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.task]
 path = "../../kernel/task"

--- a/applications/shell/Cargo.toml
+++ b/applications/shell/Cargo.toml
@@ -9,7 +9,7 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" }
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.log]
 version = "0.4.8"

--- a/applications/test_block_io/Cargo.toml
+++ b/applications/test_block_io/Cargo.toml
@@ -6,7 +6,7 @@ description = "a simple app for testing IO transfers for block devices"
 build = "../../build.rs"
 
 [dependencies]
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.log]
 version = "0.4.8"

--- a/applications/test_serial_echo/Cargo.toml
+++ b/applications/test_serial_echo/Cargo.toml
@@ -6,7 +6,7 @@ description = "a simple app for testing serial port I/O using higher-level I/O t
 build = "../../build.rs"
 
 [dependencies]
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 log = "0.4.8"
 
 [dependencies.irq_safety]

--- a/kernel/app_io/Cargo.toml
+++ b/kernel/app_io/Cargo.toml
@@ -9,7 +9,7 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 x86_64 = { path = "../../libs/x86_64" }
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/console/Cargo.toml
+++ b/kernel/console/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 log = "0.4.8"
 mpmc = "0.1.6"
 

--- a/kernel/device_manager/Cargo.toml
+++ b/kernel/device_manager/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 derive_more = "0.99.0"
 mpmc = "0.1.6"
 

--- a/kernel/io/Cargo.toml
+++ b/kernel/io/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 delegate = "0.6.0"
 spin = "0.9.0"
 

--- a/kernel/serial_port/Cargo.toml
+++ b/kernel/serial_port/Cargo.toml
@@ -8,7 +8,7 @@ build = "../../build.rs"
 [dependencies]
 log = "0.4.8"
 spin = "0.9.0"
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 x86_64 = { path = "../../libs/x86_64" }
 static_assertions = "1.1.0"
 

--- a/kernel/text_terminal/Cargo.toml
+++ b/kernel/text_terminal/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 bitflags = "1.1.0"
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 unicode-width = "0.1.8"
 vte = "0.10.1"
 derive_more = "0.99.0"

--- a/kernel/wasi_interpreter/Cargo.toml
+++ b/kernel/wasi_interpreter/Cargo.toml
@@ -7,7 +7,7 @@ description = "Interpreter for executing WASI-compliant WASM binaries"
 build = "../../build.rs"
 
 [dependencies]
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 hashbrown = { version = "0.11.2", features = ["nightly"] }
 wasi = { git = "https://github.com/bytecodealliance/wasi", rev = "45536ac956a6211e3cff047f36cf19d6da82fd95", default-features = false }
 wasmi = { version = "0.9.0", default-features = false, features = ["core"] }

--- a/libs/stdio/Cargo.toml
+++ b/libs/stdio/Cargo.toml
@@ -6,7 +6,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
 [dependencies.keycodes_ascii]
 path = "../keycodes_ascii"

--- a/ports/path_std/Cargo.toml
+++ b/ports/path_std/Cargo.toml
@@ -7,4 +7,4 @@ build = "../../build.rs"
 
 [dependencies]
 theseus_task = { path = "../../kernel/task", package = "task" }
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -56,9 +56,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "ap_start"
@@ -280,9 +285,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core2"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf12d2dad3ed124aa116f59561428478993d69ab81ae4d30e5349c9c5b5a5f6"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
 ]
@@ -604,6 +609,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc 0.2.120",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
 ]
@@ -781,6 +797,12 @@ dependencies = [
 [[package]]
 name = "libc"
 version = "0.2.107"
+
+[[package]]
+name = "libc"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
 
 [[package]]
 name = "libterm"
@@ -975,7 +997,9 @@ version = "0.1.0"
 
 [[package]]
 name = "mpmc"
-version = "0.1.6-pre"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf78b1242a953be96e01b5f8ed8ffdfc8055c0a2b779899b3835e5d27a69dced"
 
 [[package]]
 name = "multiboot2"
@@ -1042,6 +1066,12 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "owning_ref"
@@ -1617,7 +1647,7 @@ dependencies = [
  "cstr_core",
  "heap",
  "lazy_static",
- "libc",
+ "libc 0.2.107",
  "log",
  "memchr",
  "memory",
@@ -1696,6 +1726,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "vfs_node"
 version = "0.1.0"
 dependencies = [
@@ -1738,6 +1774,12 @@ checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "window"

--- a/tlibc/Cargo.toml
+++ b/tlibc/Cargo.toml
@@ -10,7 +10,7 @@ spin = "0.9.0"
 log = "0.4.8"
 libc = { path = "../ports/libc", default-features = false }
 cstr_core = "0.2.3"
-core2 = { version = "0.3.2", default-features = false, features = ["alloc", "nightly"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 memchr = { version = "2.2.0", default-features = false }
 cbitset = "0.2.0"
 


### PR DESCRIPTION
Enables full usage of `thiserror_core2` for built-in types, e.g., `String`.