### PR TITLE
Ignore empty placeholder sections (`.rodata`, `.data`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22bc6cd49b0ec407b680c3e380182b6ac63b73991cb7602de350352fc309b614"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef196d5d972878a48da7decb7686eded338b4858fbabeed513d63a7c98b2b82d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "context_switch"
 version = "0.1.0"
 dependencies = [
@@ -1708,6 +1728,7 @@ name = "mod_mgmt"
 version = "0.1.0"
 dependencies = [
  "bootloader_modules",
+ "const_format",
  "cow_arc",
  "crate_metadata",
  "crate_name_utils",

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -4,6 +4,7 @@ name = "mod_mgmt"
 description = "Module management, including parsing, loading, linking, unloading, and metadata management."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.9.0"
@@ -12,6 +13,7 @@ rustc-demangle = "0.1.19"
 qp-trie = "0.7.3"
 cstr_core = "0.2.3"
 rangemap = "0.1.13"
+const_format = "0.2.2"
 
 [dependencies.lazy_static]
 features = ["spin_no_std"]

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -1130,7 +1130,7 @@ impl CrateNamespace {
                 if let Some(name) = $sec_name.get($prefix.len() ..) {
                     name
                 } else {
-                    // Ignore special "empty" placeholder sections: .text, .rodata, .data
+                    // Ignore special "empty" placeholder sections
                     match $sec_name {
                         ".text"   => continue,
                         ".rodata" => continue,

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -1118,11 +1118,10 @@ impl CrateNamespace {
         /// A convenient macro to obtain the rest of the symbol name after its prefix,
         /// i.e., the characters after '.text', '.rodata', '.data', etc.
         /// 
-        /// The `$prefix` argument must be `const` so it can be `concat!()`-ed into a const &str.
-        /// 
-        /// If the name isn't long enough, the macro prints and returns an error str.
-        /// If the name isn't long enough but is an empty section (".text", ".rodata", or ".data")
-        /// this macro `continue`s to the next iteration of the loop.
+        /// * If the name isn't long enough, the macro prints and returns an error str.
+        /// * If the name isn't long enough but is an empty section (".text", ".rodata", or ".data")
+        ///   this macro `continue`s to the next iteration of the loop.
+        /// * The `$prefix` argument must be `const` so it can be `concat!()`-ed into a const &str.
         /// 
         /// Note: I'd prefer this to be a const function that accepts the prefix as a const &'static str,
         ///       but Rust does not support concat!()-ing const generic parameters yet.
@@ -1133,9 +1132,10 @@ impl CrateNamespace {
                 } else {
                     // Ignore special "empty" placeholder sections: .text, .rodata, .data
                     match $sec_name {
-                        TEXT_PREFIX   => continue,
-                        RODATA_PREFIX => continue,
-                        DATA_PREFIX   => continue,
+                        ".text"   => continue,
+                        ".rodata" => continue,
+                        ".data"   => continue,
+                        ".bss"    => continue,
                         _ => {
                             const ERROR_STR: &'static str = const_format::concatcp!(
                                 "Failed to get the ", $prefix, 

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -1119,7 +1119,7 @@ impl CrateNamespace {
         /// i.e., the characters after '.text', '.rodata', '.data', etc.
         /// 
         /// * If the name isn't long enough, the macro prints and returns an error str.
-        /// * If the name isn't long enough but is an empty section (".text", ".rodata", or ".data")
+        /// * If the name isn't long enough but is an empty section (e.g., just ".text", ".rodata", etc)
         ///   this macro `continue`s to the next iteration of the loop.
         /// * The `$prefix` argument must be `const` so it can be `concat!()`-ed into a const &str.
         /// 


### PR DESCRIPTION
Closes #496. 

Note that we already do this for the empty `.text` section, but sometimes object files also contain other empty sections, e.g., named only `.rodata` or `.data`.