### PR TITLE
Support unwinding using externally-registered unwind information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "external_unwind_info"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "memory",
+ "spin 0.9.0",
+]
+
+[[package]]
 name = "fadt"
 version = "0.1.0"
 dependencies = [
@@ -3306,15 +3316,13 @@ dependencies = [
 name = "unwind"
 version = "0.1.0"
 dependencies = [
- "apic",
+ "external_unwind_info",
  "fallible-iterator",
  "gimli",
  "interrupts",
  "log",
  "memory",
  "mod_mgmt",
- "runqueue",
- "scheduler",
  "task",
 ]
 

--- a/kernel/external_unwind_info/Cargo.toml
+++ b/kernel/external_unwind_info/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "external_unwind_info"
+description = "Registers and stores unwind info from external or legacy components, à la libunwind"
+version = "0.1.0"
+build = "../../build.rs"
+edition = "2018"
+
+[dependencies]
+log = "0.4.8"
+lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
+spin = "0.9.0"
+
+[dependencies.memory]
+path = "../memory"

--- a/kernel/external_unwind_info/src/lib.rs
+++ b/kernel/external_unwind_info/src/lib.rs
@@ -56,7 +56,6 @@ pub struct ExternalUnwindInfo {
     /// The bounds of the text section that this unwinding info pertains to.
     pub text_section: Range<VirtualAddress>,
     /// The bounds of the unwinding information (e.g., `.eh_frame`) for the above text section.
-    /// 
     pub unwind_info: Range<VirtualAddress>,
 }
 

--- a/kernel/external_unwind_info/src/lib.rs
+++ b/kernel/external_unwind_info/src/lib.rs
@@ -1,0 +1,121 @@
+//! Registers and stores unwind information from external components.
+//! 
+//! Typically, Theseus maintains metadata about all crates loaded and linked into system.
+//! Unwind info is part of this (the `.eh_frame` section data).
+//! 
+//! However, for other components compiled outside of Theseus and beyond it's knowledge,
+//! we don't necessarily have control over or access to those components' section structure
+//! and miscellaneous internal information.
+//! Nevertheless, we still want to be able to handle their resource management properly
+//! by unwinding through their stack frames and running cleanup handlers as needed.
+//! 
+//! Hence, this crate allows those external components to register their own 
+//! unwind information as needed.
+//! Currently, we use this crate to support [`wasmtime-jit`], which needs to 
+//! [register unwinding information] for JIT-compiled native code built from WASM binaries
+//! and then deregister it when those JIT-ted modules are destroyed.
+//!
+//! The API here is loosely similar to `libunwind`'s two-part API: 
+//! `__register_frame()` and `__deregister_frame()`.
+//! Because it must accept raw pointers to sections, all APIs are inherently unsafe.
+//! 
+//! ## Future TODOs
+//! Currently, this crate unsafely assumes that the third party component that registers its unwind info
+//! will ensure that unwind info is valid for the full duration of it being registered.
+//! 
+//! In the future, ideally we would redesign this crate to offer a safer API
+//! that obtains shared ownership
+//! However, that would of course require modifying the dependent crates and redesigning them
+//! to utilize this safer API.
+//! 
+//! [register unwinding information]: https://github.com/bytecodealliance/wasmtime/blob/7cf5f058303d2ee8c42df658d4ca608771a8561d/crates/jit/src/code_memory.rs#L185
+//! [`wasmtime-jit`]: https://docs.rs/wasmtime-jit/latest/wasmtime_jit/
+
+#![no_std]
+#![feature(map_try_insert)]
+
+extern crate alloc;
+
+use core::ops::{Range, Bound::{Included, Unbounded}};
+use alloc::collections::BTreeMap;
+use lazy_static::lazy_static;
+use memory::VirtualAddress;
+use spin::Mutex;
+use log::*;
+
+lazy_static! {
+    /// The system-wide set of unwind information registered by external components.
+    /// 
+    /// The map key is the text section's base `VirtualAddress`.
+    static ref EXTERNAL_UNWIND_INFO: Mutex<BTreeMap<VirtualAddress, ExternalUnwindInfo>> = Mutex::new(BTreeMap::new());
+}
+
+/// Unwinding information for an external (non-Theseus) component.
+#[derive(Debug, Clone)]
+pub struct ExternalUnwindInfo {
+    /// The bounds of the text section that this unwinding info pertains to.
+    pub text_section: Range<VirtualAddress>,
+    /// The bounds of the unwinding information (e.g., `.eh_frame`) for the above text section.
+    /// 
+    pub unwind_info: Range<VirtualAddress>,
+}
+
+/// Register  a new section of external unwinding information.
+/// 
+/// Returns an error if unwinding information has already been registered 
+/// for the given `text_section_base_address`.
+pub unsafe fn register_unwind_info(
+    text_section_base_address: *mut u8,
+    text_section_len: usize,
+    unwind_info: *mut u8,
+    unwind_len: usize,
+) -> Result<(), ()> {
+
+    let mut uw = EXTERNAL_UNWIND_INFO.lock();
+    let text_start = VirtualAddress::new_canonical(text_section_base_address as usize);
+    let text_end   = VirtualAddress::new_canonical(text_section_base_address as usize + text_section_len);
+    let uw_start   = VirtualAddress::new_canonical(unwind_info as usize);
+    let uw_end     = VirtualAddress::new_canonical(unwind_info as usize + unwind_len);
+
+    let uw_info = ExternalUnwindInfo {
+        text_section: text_start .. text_end,
+        unwind_info:  uw_start   .. uw_end,
+    };
+
+    uw.try_insert(text_start, uw_info).map_err(|_e| {
+        error!("External unwind info for {text_start:#X} was already registered");
+        ()
+    })?;
+
+    Ok(())
+}
+
+
+/// Remove a previously-registered section of external unwinding information.
+/// 
+/// Returns an error if no unwinding information was registered
+/// for the given `text_section_base_address`.
+pub unsafe fn deregister_unwind_info(
+    text_section_base_address: *mut u8
+) -> Result<(), ()> {
+    EXTERNAL_UNWIND_INFO.lock()
+        .remove(&VirtualAddress::new_canonical(text_section_base_address as usize))
+        .map(|_| ())
+        .ok_or(())
+}
+
+
+/// Returns the registered external unwind information that covers
+/// the given address in its text section.
+pub fn get_unwind_info(
+    text_section_address: VirtualAddress
+) -> Option<ExternalUnwindInfo> {
+    // iterate over the entries in sorted order, up to the given `text_section_address` inclusively.
+    for (_text_base_addr, uw_info) in EXTERNAL_UNWIND_INFO.lock().range((Unbounded, Included(text_section_address))) {
+        if uw_info.text_section.contains(&text_section_address) {
+            return Some(uw_info.clone());
+        }
+    }
+
+    None
+}

--- a/kernel/unwind/Cargo.toml
+++ b/kernel/unwind/Cargo.toml
@@ -25,17 +25,11 @@ path = "../mod_mgmt"
 [dependencies.task]
 path = "../task"
 
-[dependencies.apic]
-path = "../apic"
-
-[dependencies.runqueue]
-path = "../runqueue"
-
 [dependencies.interrupts]
 path = "../interrupts"
 
-[dependencies.scheduler]
-path = "../scheduler"
+[dependencies.external_unwind_info]
+path = "../external_unwind_info"
 
 [lib]
 crate-type = ["rlib"]


### PR DESCRIPTION
The `wasmtime-jit` crate needs system support for registering unwind info that came from WASM binaries that were JIT-compiled to native code.

Unfortunately there's no real way to make any of that safe (without significantly modifying how wasmtime interacts with the OS's memory regions), so for now it is left unsafe.