### PR TITLE
Implement the `Lockable` trait for `MutexSleep` and `RwLockSleep`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,7 @@ dependencies = [
 name = "mutex_sleep"
 version = "0.1.0"
 dependencies = [
+ "lockable",
  "log",
  "owning_ref",
  "spin 0.9.0",

--- a/kernel/mutex_sleep/Cargo.toml
+++ b/kernel/mutex_sleep/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "mutex_sleep"
 description = "A Mutex abstraction that puts a Task to sleep while waiting for the lock"
 version = "0.1.0"
+edition = "2018"
 build = "../../build.rs"
 
 [dependencies]
@@ -29,6 +30,9 @@ path = "../wait_queue"
 
 [dependencies.task]
 path = "../task"
+
+[dependencies.lockable]
+path = "../../libs/lockable"
 
 
 [lib]

--- a/kernel/mutex_sleep/src/lib.rs
+++ b/kernel/mutex_sleep/src/lib.rs
@@ -6,12 +6,6 @@
 
 #![no_std]
 
-extern crate spin;
-extern crate owning_ref;
-extern crate stable_deref_trait;
-extern crate wait_queue;
-extern crate task;
-
 mod mutex;
 mod rwlock;
 


### PR DESCRIPTION
Needed for a `std`-style filesystem implementation