### PR TITLE
`theseus_std::fs`: support more `OpenOptions` in `File::open`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3194,6 +3194,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_std_fs"
+version = "0.1.0"
+dependencies = [
+ "core2",
+ "log",
+ "terminal_print",
+ "theseus_std",
+]
+
+[[package]]
 name = "test_thread_local"
 version = "0.1.0"
 dependencies = [
@@ -3237,6 +3247,7 @@ dependencies = [
  "fs_node",
  "io",
  "lockable",
+ "memfs",
  "path",
  "spin 0.9.0",
  "task",

--- a/applications/test_std_fs/Cargo.toml
+++ b/applications/test_std_fs/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test_std_fs"
+version = "0.1.0"
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+build = "../../build.rs"
+
+[dependencies]
+log = "0.4.8"
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
+
+[dependencies.theseus_std]
+path = "../../ports/theseus_std"
+
+[dependencies.terminal_print]
+path = "../../kernel/terminal_print"

--- a/applications/test_std_fs/src/lib.rs
+++ b/applications/test_std_fs/src/lib.rs
@@ -1,0 +1,35 @@
+//! Tests the basic features of Theseus's port of `std::fs` modules from Rust `std`.
+//! 
+#![no_std]
+
+extern crate alloc;
+extern crate log;
+extern crate theseus_std;
+extern crate core2;
+#[macro_use] extern crate terminal_print;
+
+use alloc::{string::String, vec::Vec};
+use core2::io::{self, Result, Error, Read, Write};
+use theseus_std::fs::File;
+
+
+pub fn main(_args: Vec<String>) -> isize {
+    match rmain(_args) {
+        Ok(_) => {
+            println!("test_std_fs complete!");
+            0
+        }
+        Err(e) => {
+            println!("test_std_fs error: {:?}", e);
+            -1
+        }    
+    }
+}
+
+
+fn rmain(_args: Vec<String>) -> io::Result<()> {
+    let mut out = theseus_std::fs::File::create("test.txt")?;
+    out.write(b"yo what's up\nhey there!")?;
+    out.write_all(b"take 2: yo what's up, hey there!")?;
+    Ok(())
+}

--- a/ports/theseus_std/Cargo.toml
+++ b/ports/theseus_std/Cargo.toml
@@ -12,5 +12,6 @@ theseus_task = { path = "../../kernel/task", package = "task" }
 theseus_path = { path = "../../kernel/path", package = "path" }
 theseus_fs_node = { path = "../../kernel/fs_node", package = "fs_node" }
 theseus_io = { path = "../../kernel/io", package = "io" }
+theseus_memfs = { path = "../../kernel/memfs", package = "memfs" }
 spin = "0.9.0"
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }


### PR DESCRIPTION
Basic support for the following:
* `OpenOptions::create`
* `OpenOptions::create_new`
* `OpenOptions::append`

`OpenOptions::read` and `OpenOptions::write` were already supported.