### PR TITLE
Properly handle crates whose compilation results in multiple object files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,26 @@ $(iso): clean-old-build build extra_files
 ## Obviously, if a crate is used by both other application crates and by kernel crates, it is still a kernel crate. 
 ## Then, we give all kernel crate object files the KERNEL_PREFIX and all application crate object files the APP_PREFIX.
 build: $(nano_core_binary)
-## Copy all object files into the main build directory and prepend the kernel or app prefix appropriately. 
+## Here, the main Rust build has just occurred.
+##
+## First, if an .rlib archive contains multiple object files, we need to extract them all out of the archive
+## and combine them into one object file using partial linking (`ld -r ...`), overwriting the rustc-emitted .o file.
+## Note: we skip "normal" .rlib archives that have 2 members: a single .o object file and a single .rmeta file.
+	for f in $(shell find ./target/$(TARGET)/$(BUILD_MODE)/deps/ -name "*.rlib"); do \
+		# echo -e "Found rlib `ar t $${f} | wc -l`: $${f}" ; \
+		if [ "`ar t $${f} | wc -l`" != "2" ]; then \
+			echo -e "Unarchiving non-standard rlib: $${f}"   ; \
+			mkdir -p "$(BUILD_DIR)/extracted_rlibs/`basename $${f}`-unpacked/" ; \
+			ar -xo --output "$(BUILD_DIR)/extracted_rlibs/`basename $${f}`-unpacked/" $${f}   ; \
+			echo -e "OBJECT_FILES: $$(find $(BUILD_DIR)/extracted_rlibs/$$(basename $${f})-unpacked/ -name "*.o")"  ; \
+			mkdir -p "$(BUILD_DIR)/new_test/"  ; \
+			$(CROSS)ld -r  \
+				--output "./target/$(TARGET)/$(BUILD_MODE)/deps/`basename $${f} | cut -c 4- | rev | cut -c 6- | rev `.o"  \
+				$$(find $(BUILD_DIR)/extracted_rlibs/$$(basename $${f})-unpacked/ -name "*.o")  ; \
+		fi ; \
+	done
+
+## Second, copy all object files into the main build directory and prepend the kernel or app prefix appropriately. 
 	@cargo run --release --manifest-path $(ROOT_DIR)/tools/copy_latest_crate_objects/Cargo.toml -- \
 		-i ./target/$(TARGET)/$(BUILD_MODE)/deps \
 		--output-objects $(OBJECT_FILES_BUILD_DIR) \
@@ -159,7 +178,7 @@ build: $(nano_core_binary)
 		--app-prefix $(APP_PREFIX) \
 		-e "$(EXTRA_APP_CRATE_NAMES) libtheseus"
 
-## Create the items needed for future out-of-tree builds that depend upon the parameters of this current build. 
+## Third, create the items needed for future out-of-tree builds that depend upon the parameters of this current build. 
 ## This includes the target file, host OS dependencies (proc macros, etc)., 
 ## and most importantly, a TOML file to describe these and other config variables.
 	@rm -rf $(THESEUS_BUILD_TOML)
@@ -172,7 +191,7 @@ build: $(nano_core_binary)
 	@echo -e 'cargoflags = "$(CARGOFLAGS)"' >> $(THESEUS_BUILD_TOML)
 	@echo -e 'host_deps = "./host_deps"' >> $(THESEUS_BUILD_TOML)
 
-## Strip debug information if requested. This reduces object file size, improving load times and reducing memory usage.
+## Fourth, strip debug information if requested. This reduces object file size, improving load times and reducing memory usage.
 	@mkdir -p $(DEBUG_SYMBOLS_DIR)
 ifeq ($(debug),full)
 # don't strip any files

--- a/cfg/Config.mk
+++ b/cfg/Config.mk
@@ -50,7 +50,10 @@ BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
 BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
 
 
-## emit obj gives us the object file for the crate, instead of an rlib that we have to unpack.
+## Tell rustc to output the native object file for each crate,
+## which avoids always having to unpack the crate's .rlib archive to extract the object files within.
+## Note that we still do have to extract and partially link object files from .rlib archives for crates that
+## use a build script to generate additional object files during build time.
 RUSTFLAGS += --emit=obj
 ## enable debug info even for release builds
 RUSTFLAGS += -C debuginfo=2


### PR DESCRIPTION
* Some crates have build scripts that generate multiple arbitrary object files, such as those compiled from external C code. In these cases, those crates' `.rlib` archives will have more content than their rustc-emitted `.o` object files, which leads to missing symbols at load time.

* One important example of this is the `wasmtime-runtime` crate, which builds a `helpers.o` file that is only included in the `.rlib`, not its emitted `.o` file.

* Note: this may actually allow us to use multiple codegen units too, in the future.