### PR TITLE
Deduplicate the dependencies on `rand`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,71 +2357,18 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.1"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a"
-dependencies = [
- "rand_chacha",
- "rand_core",
- "rand_hc",
- "rand_isaac",
- "rand_pcg",
- "rand_xorshift",
- "rustc_version",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "rand_core",
- "rustc_version",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.3.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
-
-[[package]]
-name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
-dependencies = [
- "rand_core",
- "rustc_version",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3"
-dependencies = [
- "rand_core",
-]
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 
 [[package]]
 name = "rangemap"

--- a/kernel/ixgbe/Cargo.toml
+++ b/kernel/ixgbe/Cargo.toml
@@ -54,9 +54,9 @@ path = "../pit_clock"
 path = "../interrupts"
 
 [dependencies.rand]
-version = "0.6"
+version = "0.8"
 default-features = false 
-features = [ "alloc" ]
+features = [ "alloc", "small_rng" ]
 
 [dependencies.hpet]
 path = "../acpi/hpet"

--- a/kernel/ota_update_client/Cargo.toml
+++ b/kernel/ota_update_client/Cargo.toml
@@ -50,9 +50,9 @@ features = [
 ]
 
 [dependencies.rand]
-version = "0.6"
+version = "0.8"
 default-features = false 
-features = [ "alloc" ]
+features = [ "alloc", "small_rng" ]
 
 [dependencies.smoltcp_helper]
 path = "../smoltcp_helper"


### PR DESCRIPTION
* Removes unneeded sub-crates in the `rand` tree

* Matches `rand` versions used by `wasmtime`