### PR TITLE
Export more `libm` functions as `#[no_mangle]`.

### DIFF
--- a/kernel/nano_core/src/libm.rs
+++ b/kernel/nano_core/src/libm.rs
@@ -1,5 +1,5 @@
-//! In no_std compilation environments, the `libm` crate doesn't properly export 
-//! various no_mangle symbols properly, so we do it manually here.
+//! When compiling for certain `no_std` targets, the `libm` crate doesn't properly export 
+//! various `no_mangle` symbols from `libm` properly, so we do it manually here.
 
 #[no_mangle]
 pub extern "C" fn fmod(a: f64, b: f64) -> f64 {
@@ -29,4 +29,34 @@ pub extern "C" fn fmax(a: f64, b: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn fmaxf(a: f32, b: f32) -> f32 {
     libm::fmaxf(a, b)
+}
+
+#[no_mangle]
+pub extern "C" fn ceil(x: f64) -> f64 {
+    libm::ceil(x)
+}
+
+#[no_mangle]
+pub extern "C" fn floor(x: f64) -> f64 {
+    libm::floor(x)
+}
+
+#[no_mangle]
+pub extern "C" fn ceilf(x: f32) -> f32 {
+    libm::ceilf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn floorf(x: f32) -> f32 {
+    libm::floorf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn trunc(x: f64) -> f64 {
+    libm::trunc(x)
+}
+
+#[no_mangle]
+pub extern "C" fn truncf(x: f32) -> f32 {
+    libm::truncf(x)
 }


### PR DESCRIPTION
Adds the following function wrappers:
* `ceil`
* `floor`
* `ceilf`
* `floorf`
* `trunc`
* `truncf`