### PR TITLE
Support loading/linking .text.unlikely. sections

### DIFF
--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -1243,12 +1243,10 @@ impl CrateNamespace {
                 // Note: we only *truly* have to do this for global sections, because other crates
                 //       might depend on their correct section name after the ".text.unlikely." prefix.
                 let name = if is_global && name.starts_with(UNLIKELY_PREFIX) {
-                    let new_name = name.get(UNLIKELY_PREFIX.len() ..).ok_or_else(|| {
+                    name.get(UNLIKELY_PREFIX.len() ..).ok_or_else(|| {
                         error!("Failed to get the .text.unlikely. section's name: {:?}", sec_name);
                         "Failed to get the .text.unlikely. section's name after the prefix"
-                    })?;
-                    warn!("Note: adjusting section name:\n{}\n{}", name, new_name);
-                    new_name
+                    })?
                 } else {
                     name
                 };

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -1106,6 +1106,7 @@ impl CrateNamespace {
         let (mut rodata_offset, mut data_offset) = (0 , 0);
                     
         const TEXT_PREFIX:             &'static str = ".text.";
+        const UNLIKELY_PREFIX:         &'static str = "unlikely."; // the full section prefix is ".text.unlikely."
         const RODATA_PREFIX:           &'static str = ".rodata.";
         const DATA_PREFIX:             &'static str = ".data.";
         const BSS_PREFIX:              &'static str = ".bss.";
@@ -1235,7 +1236,22 @@ impl CrateNamespace {
 
             // First, check for executable sections, which can only be .text sections.
             if is_exec && !is_write {
+                let is_global = global_sections.contains(&shndx);
                 let name = try_get_symbol_name_after_prefix!(sec_name, TEXT_PREFIX);
+                // Handle cold sections, which have a section prefix of ".text.unlikely."
+                // Currently, we ignore the cold/hot designation in terms of placing a section in memory.
+                // Note: we only *truly* have to do this for global sections, because other crates
+                //       might depend on their correct section name after the ".text.unlikely." prefix.
+                let name = if is_global && name.starts_with(UNLIKELY_PREFIX) {
+                    let new_name = name.get(UNLIKELY_PREFIX.len() ..).ok_or_else(|| {
+                        error!("Failed to get the .text.unlikely. section's name: {:?}", sec_name);
+                        "Failed to get the .text.unlikely. section's name after the prefix"
+                    })?;
+                    warn!("Note: adjusting section name:\n{}\n{}", name, new_name);
+                    new_name
+                } else {
+                    name
+                };
                 let demangled = demangle(name).to_string();
 
                 // We already copied the content of all .text sections above, 
@@ -1253,7 +1269,7 @@ impl CrateNamespace {
                             text_offset,
                             dest_vaddr,
                             sec_size,
-                            global_sections.contains(&shndx),
+                            is_global,
                             new_crate_weak_ref.clone(),
                         ))
                     );


### PR DESCRIPTION
Some sections in the compiled object files are now labeled `.text.unlikely.<name>`, which the module management (crate loading) code did not previously account for. It now handles that for global `.text.unlikely` sections only, because those are the ones that need the proper name to be parsed in order to be added to the current namespace's symbol map. 

This occurs in the `wasmtime_runtime` crate at the very least, and perhaps others as well. In any case, it's a good idea to support it.

Note that I attempted to disable the hot-cold splitting of function sections that causes this by passing a variety of different `-C llvm-args=...` arguments to rustc, but none of them made a difference.