### PR TITLE
Ignore input on the serial port being used for system logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ version = "0.1.0"
 dependencies = [
  "acpi",
  "apic",
+ "console",
  "core2",
  "derive_more",
  "e1000",

--- a/kernel/deferred_interrupt_tasks/src/lib.rs
+++ b/kernel/deferred_interrupt_tasks/src/lib.rs
@@ -155,9 +155,9 @@ fn deferred_task_entry_point<DIA, Arg, Success, Failure>(
           Arg: Send + 'static,
 {
     let curr_task = get_my_current_task().expect("BUG: deferred_task_entry_point: couldn't get current task.");
-    trace!("Entered {:?}:\n\t action: {:?}\n\t arg:    {:?}", 
-        curr_task.name, debugit!(deferred_interrupt_action), debugit!(deferred_action_argument)
-    );
+    // trace!("Entered {:?}:\n\t action: {:?}\n\t arg:    {:?}", 
+    //     curr_task.name, debugit!(deferred_interrupt_action), debugit!(deferred_action_argument)
+    // );
 
     loop {
         let _res = deferred_interrupt_action(&deferred_action_argument);

--- a/kernel/device_manager/Cargo.toml
+++ b/kernel/device_manager/Cargo.toml
@@ -31,6 +31,9 @@ path = "../apic"
 [dependencies.serial_port]
 path = "../serial_port"
 
+[dependencies.console]
+path = "../console"
+
 [dependencies.logger]
 path = "../logger"
 

--- a/kernel/serial_port_basic/src/lib.rs
+++ b/kernel/serial_port_basic/src/lib.rs
@@ -260,6 +260,19 @@ impl SerialPort {
 
     }
 
+    /// Enable or disable interrupts on this serial port for various events.
+    pub fn enable_interrupt(&mut self, event: SerialPortInterruptEvent, enable: bool) {
+        let existing = self.interrupt_enable.read();
+        let new = if enable {
+            existing | event as u8
+        } else {
+            existing & !(event as u8)
+        };
+        unsafe {
+            self.interrupt_enable.write(new);
+        }
+    }
+
     /// Write the given string to the serial port, blocking until data can be transmitted.
     ///
     /// # Special characters
@@ -347,4 +360,14 @@ impl fmt::Write for SerialPort {
         self.out_str(s); 
         Ok(())
     }
+}
+
+/// The types of events that can trigger an interrupt on a serial port.
+#[derive(Debug)]
+#[repr(u8)]
+pub enum SerialPortInterruptEvent {
+    DataReceived     = 1 << 0,
+    TransmitterEmpty = 1 << 1,
+    ErrorOrBreak     = 1 << 2,
+    StatusChange     = 1 << 3,
 }


### PR DESCRIPTION
The current behavior of spawning a new console on _every_ serial port was annoying, as it would print a lot of confusing text intermixed with logger output if you mistyped something other than <kbd>Ctrl</kbd> + <kbd>A</kbd>, <kbd>X</kbd>  to exit QEMU on the default terminal that it was run on.

Now, the terminal used for logging ignores serial port inputs by default, allowing one to only open a Theseus console connection on different serial ports. For example, by default `COM1` is used for logging output, so any input on that port is now ignored; only `COM2` would accept inputs and be usable for an interactive console.