### PR TITLE
Use upstream `x86_64` crate instead of our own fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,11 +2,6 @@
 	path = libs/dfqueue
 	url = https://github.com/theseus-os/DFQueue
 	ignore = dirty
-[submodule "libs/x86_64"]
-	path = libs/x86_64
-	url = https://github.com/theseus-os/x86_64
-	branch = master
-	ignore = dirty
 [submodule "libs/object"]
 	path = libs/object
 	url = https://github.com/theseus-os/object.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,7 @@ name = "exceptions_early"
 version = "0.1.0"
 dependencies = [
  "gdt",
+ "locked_idt",
  "memory",
  "mod_mgmt",
  "spin 0.9.0",
@@ -894,6 +895,7 @@ dependencies = [
  "apic",
  "debug_info",
  "fault_log",
+ "locked_idt",
  "log",
  "memory",
  "pmu_x86",
@@ -1248,6 +1250,7 @@ dependencies = [
  "kernel_config",
  "keyboard",
  "lazy_static",
+ "locked_idt",
  "log",
  "memory",
  "mouse",
@@ -1536,6 +1539,14 @@ version = "0.1.0"
 dependencies = [
  "irq_safety",
  "spin 0.9.0",
+]
+
+[[package]]
+name = "locked_idt"
+version = "0.1.0"
+dependencies = [
+ "irq_safety",
+ "x86_64",
 ]
 
 [[package]]
@@ -2563,6 +2574,12 @@ checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "scheduler"
@@ -3738,11 +3755,13 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.14.8"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958cd5cb28e720db2f59ee9dc4235b5f82a183d079fb0e6caf43ad074cfdc66a"
 dependencies = [
  "bit_field 0.10.1",
  "bitflags",
- "irq_safety",
+ "rustversion",
  "volatile 0.4.4",
 ]
 

--- a/kernel/apic/Cargo.toml
+++ b/kernel/apic/Cargo.toml
@@ -8,7 +8,7 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 volatile = "0.2.7"
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 crossbeam-utils = { version = "0.8.5", default-features = false }
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 bit_field = "0.7.0"

--- a/kernel/deferred_interrupt_tasks/Cargo.toml
+++ b/kernel/deferred_interrupt_tasks/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 log = "0.4.8"
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 
 [dependencies.task]
 path = "../task"

--- a/kernel/e1000/Cargo.toml
+++ b/kernel/e1000/Cargo.toml
@@ -8,7 +8,7 @@ build = "../../build.rs"
 [dependencies]
 spin = "0.9.0"
 volatile = "0.2.7"
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.5.0"
 static_assertions = "1.1.0"

--- a/kernel/exceptions_early/Cargo.toml
+++ b/kernel/exceptions_early/Cargo.toml
@@ -4,10 +4,12 @@ name = "exceptions_early"
 description = "Early exception handlers that do nothing but print an error and hang."
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 spin = "0.9.0"
+locked_idt = { path = "../../libs/locked_idt" }
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/exceptions_early/src/lib.rs
+++ b/kernel/exceptions_early/src/lib.rs
@@ -3,18 +3,10 @@
 #![no_std]
 #![feature(abi_x86_interrupt)]
 
-#[macro_use] extern crate vga_buffer; // for println_raw!()
-extern crate x86_64;
-extern crate mod_mgmt;
-extern crate memory; 
-extern crate spin;
-extern crate tss;
-extern crate gdt;
-
 use spin::Mutex;
 use x86_64::{
     structures::{
-        idt::{LockedIdt, InterruptStackFrame, PageFaultErrorCode},
+        idt::{InterruptStackFrame, PageFaultErrorCode},
         tss::TaskStateSegment,
     },
     instructions::{
@@ -22,7 +14,9 @@ use x86_64::{
         tables::load_tss,
     },
 };
+use locked_idt::LockedIdt;
 use gdt::{Gdt, create_gdt};
+use vga_buffer::{print_raw, println_raw};
 
 /// An initial Interrupt Descriptor Table (IDT) with only very simple CPU exceptions handlers.
 /// This is no longer used after interrupts are set up properly, it's just a failsafe.

--- a/kernel/exceptions_full/Cargo.toml
+++ b/kernel/exceptions_full/Cargo.toml
@@ -4,10 +4,12 @@ name = "exceptions_full"
 description = "Exception handlers that are fully-featured, i.e., aware of the apic/task subsystems, and kill tasks on an exception"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 log = "0.4.8"
+locked_idt = { path = "../../libs/locked_idt" }
 
 [dependencies.vga_buffer]
 path = "../vga_buffer"

--- a/kernel/exceptions_full/src/lib.rs
+++ b/kernel/exceptions_full/src/lib.rs
@@ -3,33 +3,17 @@
 #![no_std]
 #![feature(abi_x86_interrupt)]
 
-extern crate x86_64;
-extern crate task;
-// extern crate apic;
-extern crate tlb_shootdown;
-extern crate pmu_x86;
-#[macro_use] extern crate log;
-#[macro_use] extern crate vga_buffer; // for println_raw!()
-#[macro_use] extern crate print; // for regular println!()
-extern crate unwind;
-extern crate debug_info;
-extern crate signal_handler;
-
-extern crate memory;
-extern crate tss;
-extern crate stack_trace;
-extern crate fault_log;
-
+use log::{warn, debug, trace};
 use memory::{VirtualAddress, Page};
 use signal_handler::{Signal, SignalContext, ErrorCode};
 use x86_64::{
     registers::control::Cr2,
     structures::idt::{
-        LockedIdt,
         InterruptStackFrame,
         PageFaultErrorCode
     },
 };
+use locked_idt::LockedIdt;
 use fault_log::log_exception;
 
 
@@ -78,15 +62,15 @@ pub fn init(idt_ref: &'static LockedIdt) {
 }
 
 
-/// calls println!() and then println_raw!()
+/// calls print!() and then print_raw!()
 macro_rules! println_both {
     ($fmt:expr) => {
-        print_raw!(concat!($fmt, "\n"));
-        print!(concat!($fmt, "\n"));
+        vga_buffer::print_raw!(concat!($fmt, "\n"));
+        print::print!(concat!($fmt, "\n"));
     };
     ($fmt:expr, $($arg:tt)*) => {
-        print_raw!(concat!($fmt, "\n"), $($arg)*);
-        print!(concat!($fmt, "\n"), $($arg)*);
+        vga_buffer::print_raw!(concat!($fmt, "\n"), $($arg)*);
+        print::print!(concat!($fmt, "\n"), $($arg)*);
     };
 }
 

--- a/kernel/gdt/Cargo.toml
+++ b/kernel/gdt/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 bit_field = "0.7.0"
 bitflags = "1.1.0"
 

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -4,11 +4,12 @@ name = "interrupts"
 description = "Interrupt configuration and handlers for Theseus"
 version = "0.1.0"
 build = "../../build.rs"
+edition = "2018"
 
 [dependencies]
 spin = "0.9.0"
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
-
+x86_64 = "0.14.8"
+locked_idt = { path = "../../libs/locked_idt" }
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/ixgbe/Cargo.toml
+++ b/kernel/ixgbe/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Ramla <ijazramla@gmail.com>"]
 [dependencies]
 spin = "0.9.0"
 volatile = "0.2.4"
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 bit_field = "0.7.0"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.5.0"

--- a/kernel/memory/Cargo.toml
+++ b/kernel/memory/Cargo.toml
@@ -11,7 +11,7 @@ bitflags = "1.1.0"
 multiboot2 = "0.10.1"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 bit_field = "0.7.0"
-x86_64 = { path = "../../libs/x86_64" }
+x86_64 = "0.14.8"
 zerocopy = "0.5.0"
 
 [dependencies.log]

--- a/kernel/memory_x86_64/Cargo.toml
+++ b/kernel/memory_x86_64/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 multiboot2 = "0.10.1"
-x86_64 = { path = "../../libs/x86_64" }
+x86_64 = "0.14.8"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/pmu_x86/Cargo.toml
+++ b/kernel/pmu_x86/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 bit_field = "0.10.0"
 
 [dependencies.apic]

--- a/kernel/rtc/Cargo.toml
+++ b/kernel/rtc/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-x86_64 = { path = "../../libs/x86_64" }
+x86_64 = "0.14.8"
 
 [dependencies.lazy_static]
 features = ["spin_no_std"]

--- a/kernel/serial_port/Cargo.toml
+++ b/kernel/serial_port/Cargo.toml
@@ -9,7 +9,7 @@ build = "../../build.rs"
 log = "0.4.8"
 spin = "0.9.0"
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
-x86_64 = { path = "../../libs/x86_64" }
+x86_64 = "0.14.8"
 static_assertions = "1.1.0"
 
 [dependencies.serial_port_basic]

--- a/kernel/signal_handler/Cargo.toml
+++ b/kernel/signal_handler/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 edition = "2018"
 
 [dependencies]
-x86_64 = { path = "../../libs/x86_64" }
+x86_64 = "0.14.8"
 log = "0.4.8"
 bitflags = "1.3"
 spin = "0.9"

--- a/kernel/task/Cargo.toml
+++ b/kernel/task/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 static_assertions = "1.1.0"
 crossbeam-utils = { version = "0.8.5", default-features = false }
 

--- a/kernel/tlb_shootdown/Cargo.toml
+++ b/kernel/tlb_shootdown/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 build = "../../build.rs"
 
 [dependencies]
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 
 
 [dependencies.log]

--- a/kernel/tss/Cargo.toml
+++ b/kernel/tss/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 
 
 [dependencies.log]

--- a/libs/locked_idt/Cargo.toml
+++ b/libs/locked_idt/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "locked_idt"
+description = "A struct that wraps an x86_64 IDT (Interrupt Descriptor Table) in an interrupt-safe mutex lock"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
+x86_64 = "0.14.8"

--- a/libs/locked_idt/src/lib.rs
+++ b/libs/locked_idt/src/lib.rs
@@ -1,0 +1,39 @@
+//! A simple wrapper struct around an x86_64 Interrupt Descriptor Table (IDT).
+
+#![no_std]
+
+use irq_safety::{MutexIrqSafe, MutexIrqSafeGuard};
+use x86_64::structures::idt::InterruptDescriptorTable;
+
+/// A thread-safe and interrupt-safe wrapper around [`InterruptDescriptorTable`]. 
+/// 
+/// This type offers interior mutability, allowing interrupt handlers to be added/changed/removed,
+/// but preserves safety by guaranteeing that only a static object can be loaded.
+#[derive(Debug)]
+pub struct LockedIdt {
+    idt: MutexIrqSafe<InterruptDescriptorTable>,
+}
+impl LockedIdt {
+    /// Creates a new IDT filled with non-present entries.
+    pub const fn new() -> LockedIdt {
+        LockedIdt {
+            idt: MutexIrqSafe::new(InterruptDescriptorTable::new()),
+        }
+    }
+
+    /// Obtains the lock on the inner IDT and loads it into the current CPU
+    /// using the `lidt` command.
+    pub fn load(&'static self) {
+        unsafe { self.idt.lock().load_unsafe(); }
+    } 
+
+    /// Obtains the lock on the inner IDT and returns a guard that derefs into it.
+    /// 
+    /// Interrupts are also disabled until the guard falls out of scope,
+    /// at which point they are re-enabled iff they were previously enabled
+    /// when this function was invoked. 
+    /// and the lock will be dropped when the guard falls out of scope.
+    pub fn lock(&self) -> MutexIrqSafeGuard<InterruptDescriptorTable> {
+        self.idt.lock()
+    }
+}

--- a/old_crates/syscall/Cargo.toml
+++ b/old_crates/syscall/Cargo.toml
@@ -7,7 +7,7 @@ build = "../../build.rs"
 
 [dependencies]
 spin = "0.9.0"
-x86_64 = { path = "../../libs/x86_64" } # currently using our local copy, forked from Phil Opp's crate
+x86_64 = "0.14.8"
 
 
 [dependencies.log]


### PR DESCRIPTION
We no longer need our own fork of the `x86_64` crate ever since this PR went through: https://github.com/rust-osdev/x86_64/pull/354

Other related changes:
* Move `LockedIdt` wrapper type to its own library crate.
* Upgrade crates that use `x86_64` or `LockedIdt` to the 2018 edition.