### PR TITLE
Fix `grub-mkrescue` command on Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,14 @@ else
 	UNMOUNT = umount
 	USB_DRIVES = $(shell lsblk -O | grep -i usb | awk '{print $$2}' | grep --color=never '[^0-9]$$')
 endif
-GRUB_MKRESCUE = $(GRUB_CROSS)grub-mkrescue
 
+ifneq (,$(shell command -v $(GRUB_CROSS)grub-mkrescue))
+	GRUB_MKRESCUE = $(GRUB_CROSS)grub-mkrescue
+else ifneq (,$(shell command -v $(GRUB_CROSS)grub2-mkrescue))
+	GRUB_MKRESCUE = $(GRUB_CROSS)grub2-mkrescue
+else
+	$(error grub-mkrescue not found)
+endif
 
 
 ###################################################################################################

--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,13 @@ else
 	USB_DRIVES = $(shell lsblk -O | grep -i usb | awk '{print $$2}' | grep --color=never '[^0-9]$$')
 endif
 
+## Look for `grub-mkrescue` (Debian-like distros) or `grub2-mkrescue` (Fedora)
 ifneq (,$(shell command -v $(GRUB_CROSS)grub-mkrescue))
 	GRUB_MKRESCUE = $(GRUB_CROSS)grub-mkrescue
 else ifneq (,$(shell command -v $(GRUB_CROSS)grub2-mkrescue))
 	GRUB_MKRESCUE = $(GRUB_CROSS)grub2-mkrescue
 else
-	$(error grub-mkrescue not found)
+	$(error Error: could not find 'grub-mkrescue' or 'grub2-mkrescue', please install 'grub' or 'grub2')
 endif
 
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ git submodule update --init --recursive
 
 Currently, we support building Theseus on the following platforms:
  * Linux, 64-bit Debian-based distributions like Ubuntu, tested on Ubuntu 16.04, 18.04, 20.04. 
-   - Arch Linux has also been reported to work correctly. 
+   - Arch Linux and Fedora have also been reported to work correctly. 
  * Windows, using the Windows Subsystem for Linux (WSL), tested on the Ubuntu version of WSL and WSL2.
  * MacOS, tested on versions High Sierra (10.13) and Catalina (10.15.2).
  * Docker, atop any host OS that can run a Docker container.
@@ -60,13 +60,17 @@ curl https://sh.rustup.rs -sSf | sh
 
 ### Building on Linux or WSL (Windows Subsystem for Linux)
 Install the following dependencies using your package manager:
-```sh
+```bash
 sudo apt-get install make gcc nasm pkg-config grub-pc-bin mtools xorriso qemu qemu-kvm
 ```
 
-  * Or on Arch Linux:
+  * Or:
     ```bash
+    # Arch Linux
     sudo pacman -S make gcc nasm pkg-config grub mtools xorriso qemu
+
+    # Fedora
+    sudo dnf install make gcc nasm pkg-config grub2 mtools xorriso qemu
     ```
 
 If you're on WSL, also do the following steps:


### PR DESCRIPTION
`grub-mkrescue` is called `grub2-mkrescue` on Fedora. I think this is a sound way of implementing it, but I am illiterate in Make.