### PR TITLE
Fix clippy `deny`-by-default errors

### DIFF
--- a/kernel/iommu/src/regs.rs
+++ b/kernel/iommu/src/regs.rs
@@ -156,6 +156,7 @@ impl fmt::Debug for ExtendedCapability {
 }
 
 /// Bits corresponding to commands in the Global Command register.
+#[repr(u32)]
 pub enum GlobalCommand {
     /// Compatibility Format Interrupt
     CFI   = 1 << 23,

--- a/kernel/pmu_x86/src/lib.rs
+++ b/kernel/pmu_x86/src/lib.rs
@@ -690,7 +690,14 @@ pub fn start_samples(event_type: EventType, event_per_sample: u32, task_id: Opti
 
     sampled_events.sample_count = sample_count;
 
-    if event_per_sample > core::u32::MAX || event_per_sample <= core::u32::MIN {
+    if event_per_sample == 0 {
+        return Err("Number of events per sample invalid: must be nonzero");
+    }
+    // This check can never trigger since `event_per_sample` is a `u32`
+    // and is therefore by definition in the range `u32::MIN..=u32::MAX`.
+    // We'll check anyways, just in case `event_per_sample`'s type is changed.
+    #[allow(clippy::absurd_extreme_comparisons)]
+    if event_per_sample > core::u32::MAX || event_per_sample < core::u32::MIN {
         return Err("Number of events per sample invalid: must be within unsigned 32 bit");
     }
 

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -861,7 +861,7 @@ impl fmt::Display for Task {
 /// two `TaskRef`s are considered equal if they point to the same underlying `Task`.
 /// 
 /// `TaskRef` also auto-derefs into an immutable `Task` reference.
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone)]
 pub struct TaskRef(Arc<Task>);
 
 impl TaskRef {
@@ -1024,6 +1024,12 @@ impl PartialEq for TaskRef {
     }
 }
 impl Eq for TaskRef { }
+
+impl Hash for TaskRef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.0).hash(state);
+    }
+}
 
 impl Deref for TaskRef {
     type Target = Task;

--- a/kernel/text_terminal/src/lib.rs
+++ b/kernel/text_terminal/src/lib.rs
@@ -1371,21 +1371,24 @@ impl ScreenSize {
 /// in which `(0, 0)` represents the top-left corner.
 /// Thus, a valid `ScreenPoint` must fit be the bounds of 
 /// the current [`ScreenSize`].
-#[derive(Copy, Clone, Default, PartialEq, Eq, Ord)]
+#[derive(Copy, Clone, Default, PartialEq, Eq)]
 #[derive(Add, AddAssign, Sub, SubAssign)]
 pub struct ScreenPoint {
     column: Column,
     row: Row,
 } 
-impl PartialOrd for ScreenPoint {
-    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+impl Ord for ScreenPoint {
+    fn cmp(&self, other: &Self) -> Ordering {
         if self.row == other.row {
-            self.column.partial_cmp(&other.column)
-        } else if self.row < other.row {
-            Some(Ordering::Less)
+            self.column.cmp(&other.column)
         } else {
-            Some(Ordering::Greater)
+            self.row.cmp(&other.row)
         }
+    }
+}
+impl PartialOrd for ScreenPoint {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 impl fmt::Debug for ScreenPoint {
@@ -1483,21 +1486,24 @@ pub struct Column(u16);
 
 /// A 2D position value that represents a point in the scrollback buffer,
 /// in which `(0, 0)` represents the `Unit` at the first column of the first line.
-#[derive(Copy, Clone, Default, PartialEq, Eq, Ord)]
+#[derive(Copy, Clone, Default, PartialEq, Eq)]
 #[derive(Add, AddAssign, Sub, SubAssign)]
 pub struct ScrollbackBufferPoint {
     unit_idx: UnitIndex,
     line_idx: LineIndex,
 }
-impl PartialOrd for ScrollbackBufferPoint {
-    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+impl Ord for ScrollbackBufferPoint {
+    fn cmp(&self, other: &Self) -> Ordering {
         if self.line_idx == other.line_idx {
-            self.unit_idx.partial_cmp(&other.unit_idx)
-        } else if self.line_idx < other.line_idx {
-            Some(Ordering::Less)
+            self.unit_idx.cmp(&other.unit_idx)
         } else {
-            Some(Ordering::Greater)
+            self.line_idx.cmp(&other.line_idx)
         }
+    }
+}
+impl PartialOrd for ScrollbackBufferPoint {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 impl fmt::Debug for ScrollbackBufferPoint {


### PR DESCRIPTION
Clippy generates a lot of diagnostics. Fixing all the warnings would be a big undertaking, but it's quite doable to fix its handful of `deny` errors.

`cargo clippy -- -A warnings`, which runs clippy with warnings suppressed, is now error-free.