### PR TITLE
Streamline task code with a little bit better naming and panic ergonomics

### DIFF
--- a/applications/bm/src/lib.rs
+++ b/applications/bm/src/lib.rs
@@ -233,7 +233,7 @@ fn do_null() -> Result<(), &'static str> {
 }
 
 /// Internal function that actually calculates the time for null syscall.
-/// Measures this by calling `get_my_current_task_id` of the current task. 
+/// Measures this by calling `current_task_id` of the current task. 
 fn do_null_inner(overhead_ct: u64, th: usize, nr: usize) -> Result<u64, &'static str> {
 	let start_hpet: u64;
 	let end_hpet: u64;
@@ -245,7 +245,7 @@ fn do_null_inner(overhead_ct: u64, th: usize, nr: usize) -> Result<u64, &'static
 
 	start_hpet = hpet.get_counter();
 	for _ in 0..tmp_iterations {
-		mypid = task::get_my_current_task_id();
+		mypid = task::current_task_id();
 	}
 	end_hpet = hpet.get_counter();
 
@@ -321,8 +321,8 @@ fn do_spawn_inner(overhead_ct: u64, th: usize, nr: usize, _child_core: u8) -> Re
 	let hpet = get_hpet().ok_or("Could not retrieve hpet counter")?;
 
 	// Get path to application "hello" that we're going to spawn
-	let namespace = task::get_my_current_task().get_namespace().clone();
-	let namespace_dir = task::get_my_current_task().get_namespace().dir().clone();
+	let namespace = task::current_task().get_namespace().clone();
+	let namespace_dir = task::current_task().get_namespace().dir().clone();
 	let app_path = namespace_dir.get_file_starting_with("hello-")
 		.map(|f| Path::new(f.lock().get_absolute_path()))
 		.ok_or("Could not find the application 'hello'")?;
@@ -1543,12 +1543,12 @@ fn do_fs_delete_inner(fsize_b: usize, overhead_ct: u64) -> Result<(), &'static s
 
 /// Helper function to get the name of current task
 fn get_prog_name() -> String {
-    task::get_my_current_task().name.clone()
+    task::current_task().name.clone()
 }
 
 /// Helper function to get the PID of current task
 fn getpid() -> usize {
-    task::get_my_current_task().id
+    task::current_task().id
 }
 
 
@@ -1567,7 +1567,7 @@ fn hpet_2_time(msg_header: &str, hpet: u64) -> u64 {
 
 /// Helper function to get current working directory
 fn get_cwd() -> Option<DirRef> {
-	Arc::clone(&task::get_my_current_task().get_env().lock().working_dir)
+	Arc::clone(&task::current_task().get_env().lock().working_dir)
 }
 
 /// Helper function to make a temporary file to be used to measure read open latencies

--- a/applications/bm/src/lib.rs
+++ b/applications/bm/src/lib.rs
@@ -245,7 +245,7 @@ fn do_null_inner(overhead_ct: u64, th: usize, nr: usize) -> Result<u64, &'static
 
 	start_hpet = hpet.get_counter();
 	for _ in 0..tmp_iterations {
-		mypid = task::get_my_current_task_id().unwrap();
+		mypid = task::get_my_current_task_id();
 	}
 	end_hpet = hpet.get_counter();
 
@@ -321,12 +321,8 @@ fn do_spawn_inner(overhead_ct: u64, th: usize, nr: usize, _child_core: u8) -> Re
 	let hpet = get_hpet().ok_or("Could not retrieve hpet counter")?;
 
 	// Get path to application "hello" that we're going to spawn
-	let namespace = task::get_my_current_task()
-		.map(|t| t.get_namespace().clone())
-		.ok_or("could not find the application namespace")?;
-	let namespace_dir = task::get_my_current_task()
-		.map(|t| t.get_namespace().dir().clone())
-		.ok_or("could not find the application namespace")?;
+	let namespace = task::get_my_current_task().get_namespace().clone();
+	let namespace_dir = task::get_my_current_task().get_namespace().dir().clone();
 	let app_path = namespace_dir.get_file_starting_with("hello-")
 		.map(|f| Path::new(f.lock().get_absolute_path()))
 		.ok_or("Could not find the application 'hello'")?;
@@ -1547,28 +1543,12 @@ fn do_fs_delete_inner(fsize_b: usize, overhead_ct: u64) -> Result<(), &'static s
 
 /// Helper function to get the name of current task
 fn get_prog_name() -> String {
-	let taskref = match task::get_my_current_task() {
-	   Some(t) => t,
-        None => {
-            printlninfo!("failed to get current task");
-            return "Unknown".to_string();
-        }
-    };
-
-    taskref.name.clone()
+    task::get_my_current_task().name.clone()
 }
 
 /// Helper function to get the PID of current task
 fn getpid() -> usize {
-	let taskref = match task::get_my_current_task() {
-        Some(t) => t,
-        None => {
-            printlninfo!("failed to get current task");
-            return 0;
-        }
-    };
-
-    taskref.id
+    task::get_my_current_task().id
 }
 
 
@@ -1587,9 +1567,7 @@ fn hpet_2_time(msg_header: &str, hpet: u64) -> u64 {
 
 /// Helper function to get current working directory
 fn get_cwd() -> Option<DirRef> {
-	task::get_my_current_task().map(|t| 
-		Arc::clone(&t.get_env().lock().working_dir)
-	)
+	Arc::clone(&task::get_my_current_task().get_env().lock().working_dir)
 }
 
 /// Helper function to make a temporary file to be used to measure read open latencies

--- a/applications/bm/src/lib.rs
+++ b/applications/bm/src/lib.rs
@@ -321,8 +321,8 @@ fn do_spawn_inner(overhead_ct: u64, th: usize, nr: usize, _child_core: u8) -> Re
 	let hpet = get_hpet().ok_or("Could not retrieve hpet counter")?;
 
 	// Get path to application "hello" that we're going to spawn
-	let namespace = task::current_task().get_namespace().clone();
-	let namespace_dir = task::current_task().get_namespace().dir().clone();
+	let namespace = task::current_task().namespace.clone();
+	let namespace_dir = task::current_task().namespace.dir().clone();
 	let app_path = namespace_dir.get_file_starting_with("hello-")
 		.map(|f| Path::new(f.lock().get_absolute_path()))
 		.ok_or("Could not find the application 'hello'")?;

--- a/applications/cat/src/lib.rs
+++ b/applications/cat/src/lib.rs
@@ -44,16 +44,9 @@ pub fn main(args: Vec<String>) -> isize {
         }
         return 0;
     }
-    let taskref = match task::get_my_current_task() {
-        Some(t) => t,
-        None => {
-            println!("failed to get current task");
-            return -1;
-        }
-    };
 
     // grabs the current working directory pointer; this is scoped so that we drop the lock on the task as soon as we get the working directory pointer
-    let curr_wr = Arc::clone(&taskref.get_env().lock().working_dir);
+    let curr_wr = Arc::clone(&task::get_my_current_task().get_env().lock().working_dir);
     let path = Path::new(matches.free[0].to_string());
     
     // navigate to the filepath specified by first argument

--- a/applications/cat/src/lib.rs
+++ b/applications/cat/src/lib.rs
@@ -46,7 +46,7 @@ pub fn main(args: Vec<String>) -> isize {
     }
 
     // grabs the current working directory pointer; this is scoped so that we drop the lock on the task as soon as we get the working directory pointer
-    let curr_wr = Arc::clone(&task::get_my_current_task().get_env().lock().working_dir);
+    let curr_wr = Arc::clone(&task::current_task().get_env().lock().working_dir);
     let path = Path::new(matches.free[0].to_string());
     
     // navigate to the filepath specified by first argument

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -31,7 +31,7 @@ pub fn main(args: Vec<String>) -> isize {
         }
     };
 
-    let taskref = task::get_my_current_task();
+    let taskref = task::current_task();
     let curr_env = taskref.get_env();
     let curr_wr = Arc::clone(&curr_env.lock().working_dir);
 

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -31,13 +31,7 @@ pub fn main(args: Vec<String>) -> isize {
         }
     };
 
-    let taskref = match task::get_my_current_task() {
-        Some(t) => t,
-        None => {
-            println!("failed to get current task");
-            return -1;
-        }
-    };
+    let taskref = task::get_my_current_task();
     let curr_env = taskref.get_env();
     let curr_wr = Arc::clone(&curr_env.lock().working_dir);
 

--- a/applications/channel_eval/src/lib.rs
+++ b/applications/channel_eval/src/lib.rs
@@ -65,7 +65,7 @@ fn rmain(_matches: Matches) -> Result<(), &'static str> {
 
 /// A simple test that spawns a sender & receiver task to send `iterations` messages.
 fn test_multiple(iterations: usize) -> Result<(), &'static str> {
-    let my_cpu = apic::get_my_apic_id();
+    let my_cpu = apic::current_apic_id();
 
     let (sender, receiver) = unified_channel::new_string_channel(2);
 

--- a/applications/deps/src/lib.rs
+++ b/applications/deps/src/lib.rs
@@ -402,7 +402,7 @@ fn find_section(section_name: &str) -> Result<StrongSectionRef, String> {
 
 
 fn get_my_current_namespace() -> Arc<CrateNamespace> {
-    task::try_current_task().map(|t| Arc::clone(t.get_namespace())).ok().unwrap_or_else(|| 
+    task::try_current_task().map(|t| Arc::clone(&t.namespace)).ok().unwrap_or_else(||
         mod_mgmt::get_initial_kernel_namespace().expect("BUG: initial kernel namespace wasn't initialized").clone()
     )
 }

--- a/applications/deps/src/lib.rs
+++ b/applications/deps/src/lib.rs
@@ -402,7 +402,7 @@ fn find_section(section_name: &str) -> Result<StrongSectionRef, String> {
 
 
 fn get_my_current_namespace() -> Arc<CrateNamespace> {
-    task::get_my_current_task().map(|t| Arc::clone(t.get_namespace())).unwrap_or_else(|| 
+    task::try_get_my_current_task().map(|t| Arc::clone(t.get_namespace())).ok().unwrap_or_else(|| 
         mod_mgmt::get_initial_kernel_namespace().expect("BUG: initial kernel namespace wasn't initialized").clone()
     )
 }

--- a/applications/deps/src/lib.rs
+++ b/applications/deps/src/lib.rs
@@ -402,7 +402,7 @@ fn find_section(section_name: &str) -> Result<StrongSectionRef, String> {
 
 
 fn get_my_current_namespace() -> Arc<CrateNamespace> {
-    task::try_get_my_current_task().map(|t| Arc::clone(t.get_namespace())).ok().unwrap_or_else(|| 
+    task::try_current_task().map(|t| Arc::clone(t.get_namespace())).ok().unwrap_or_else(|| 
         mod_mgmt::get_initial_kernel_namespace().expect("BUG: initial kernel namespace wasn't initialized").clone()
     )
 }

--- a/applications/less/src/lib.rs
+++ b/applications/less/src/lib.rs
@@ -41,15 +41,8 @@ struct LineSlice {
 
 /// Read the whole file to a String.
 fn get_content_string(file_path: String) -> Result<String, String> {
-    let taskref = match task::get_my_current_task() {
-        Some(t) => t,
-        None => {
-            return Err("failed to get current task".to_string());
-        }
-    };
-
     // grabs the current working directory pointer; this is scoped so that we drop the lock on the task as soon as we get the working directory pointer
-    let curr_wr = Arc::clone(&taskref.get_env().lock().working_dir);
+    let curr_wr = Arc::clone(&task::get_my_current_task().get_env().lock().working_dir);
     let path = Path::new(file_path);
     
     // navigate to the filepath specified by first argument

--- a/applications/less/src/lib.rs
+++ b/applications/less/src/lib.rs
@@ -42,7 +42,7 @@ struct LineSlice {
 /// Read the whole file to a String.
 fn get_content_string(file_path: String) -> Result<String, String> {
     // grabs the current working directory pointer; this is scoped so that we drop the lock on the task as soon as we get the working directory pointer
-    let curr_wr = Arc::clone(&task::get_my_current_task().get_env().lock().working_dir);
+    let curr_wr = Arc::clone(&task::current_task().get_env().lock().working_dir);
     let path = Path::new(file_path);
     
     // navigate to the filepath specified by first argument

--- a/applications/loadc/src/lib.rs
+++ b/applications/loadc/src/lib.rs
@@ -63,7 +63,7 @@ pub fn main(args: Vec<String>) -> isize {
 
 
 fn rmain(matches: Matches) -> Result<c_int, String> {
-    let curr_task = task::get_my_current_task().unwrap();
+    let curr_task = task::get_my_current_task();
     let curr_wd   = Arc::clone(&curr_task.get_env().lock().working_dir);
     let namespace = curr_task.get_namespace();
     let mmi       = &curr_task.mmi;
@@ -274,7 +274,7 @@ fn parse_and_load_elf_executable<'f>(
         // debug!("Adjusted segment vaddr: {:#X}, size: {:#X}, {:?}", start_vaddr, memory_size_in_bytes, this_ap.start_address());
 
         let initial_flags = EntryFlags::from_elf_program_flags(prog_hdr.flags());
-        let mmi = &task::get_my_current_task().unwrap().mmi;
+        let mmi = &task::get_my_current_task().mmi;
         // Must initially map the memory as writable so we can copy the segment data to it later. 
         let mut mp = mmi.lock().page_table
             .map_allocated_pages(this_ap, initial_flags | EntryFlags::WRITABLE)

--- a/applications/loadc/src/lib.rs
+++ b/applications/loadc/src/lib.rs
@@ -65,7 +65,6 @@ pub fn main(args: Vec<String>) -> isize {
 fn rmain(matches: Matches) -> Result<c_int, String> {
     let curr_task = task::current_task();
     let curr_wd   = Arc::clone(&curr_task.get_env().lock().working_dir);
-    let namespace = curr_task.get_namespace();
     let mmi       = &curr_task.mmi;
 
     let path = matches.free.get(0).ok_or_else(|| format!("Missing path to ELF executable"))?;
@@ -85,7 +84,7 @@ fn rmain(matches: Matches) -> Result<c_int, String> {
     // most important of which are static data sections, 
     // as it is logically incorrect to have duplicates of data that are supposed to be global system-wide singletons.
     // We should throw a warning here if there are no relocations in the file, as it was probably built/linked with the wrong arguments.
-    overwrite_relocations(&namespace, &mut segments, &elf_file, mmi, false)?;
+    overwrite_relocations(&curr_task.namespace, &mut segments, &elf_file, mmi, false)?;
 
     // Remap each segment's mapped pages using the correct flags; they were previously mapped as always writable.
     {

--- a/applications/loadc/src/lib.rs
+++ b/applications/loadc/src/lib.rs
@@ -63,7 +63,7 @@ pub fn main(args: Vec<String>) -> isize {
 
 
 fn rmain(matches: Matches) -> Result<c_int, String> {
-    let curr_task = task::get_my_current_task();
+    let curr_task = task::current_task();
     let curr_wd   = Arc::clone(&curr_task.get_env().lock().working_dir);
     let namespace = curr_task.get_namespace();
     let mmi       = &curr_task.mmi;
@@ -274,7 +274,7 @@ fn parse_and_load_elf_executable<'f>(
         // debug!("Adjusted segment vaddr: {:#X}, size: {:#X}, {:?}", start_vaddr, memory_size_in_bytes, this_ap.start_address());
 
         let initial_flags = EntryFlags::from_elf_program_flags(prog_hdr.flags());
-        let mmi = &task::get_my_current_task().mmi;
+        let mmi = &task::current_task().mmi;
         // Must initially map the memory as writable so we can copy the segment data to it later. 
         let mut mp = mmi.lock().page_table
             .map_allocated_pages(this_ap, initial_flags | EntryFlags::WRITABLE)

--- a/applications/ls/src/lib.rs
+++ b/applications/ls/src/lib.rs
@@ -34,15 +34,7 @@ pub fn main(args: Vec<String>) -> isize {
         return 0;
     }
 
-    let taskref = match task::get_my_current_task() {
-        Some(t) => t,
-        None => {
-            println!("failed to get current task");
-            return -1;
-        }
-    };
-
-    let curr_wd = Arc::clone(&taskref.get_env().lock().working_dir);
+    let curr_wd = Arc::clone(&task::get_my_current_task().get_env().lock().working_dir);
     
     // print children of working directory if no child is specified
     if matches.free.is_empty() {

--- a/applications/ls/src/lib.rs
+++ b/applications/ls/src/lib.rs
@@ -34,7 +34,7 @@ pub fn main(args: Vec<String>) -> isize {
         return 0;
     }
 
-    let curr_wd = Arc::clone(&task::get_my_current_task().get_env().lock().working_dir);
+    let curr_wd = Arc::clone(&task::current_task().get_env().lock().working_dir);
     
     // print children of working directory if no child is specified
     if matches.free.is_empty() {

--- a/applications/mkdir/src/lib.rs
+++ b/applications/mkdir/src/lib.rs
@@ -19,7 +19,7 @@ pub fn main(args: Vec<String>) -> isize {
         for dir_name in args.iter() {
             // add child dir to current directory
             // grabs a pointer to the current working directory; this is scoped so that we drop the lock on the "mkdir" task as soon as we're finished
-            let curr_dir = Arc::clone(&task::get_my_current_task().get_env().lock().working_dir);
+            let curr_dir = Arc::clone(&task::current_task().get_env().lock().working_dir);
             let _new_dir = match VFSDirectory::new(dir_name.to_string(), &curr_dir) {
                 Ok(dir) => dir,
                 Err(err) => {

--- a/applications/mkdir/src/lib.rs
+++ b/applications/mkdir/src/lib.rs
@@ -18,17 +18,15 @@ pub fn main(args: Vec<String>) -> isize {
     if !(args.is_empty()) {
         for dir_name in args.iter() {
             // add child dir to current directory
-            if let Some(taskref) = task::get_my_current_task() {
-                // grabs a pointer to the current working directory; this is scoped so that we drop the lock on the "mkdir" task as soon as we're finished
-                let curr_dir = Arc::clone(&taskref.get_env().lock().working_dir);
-                let _new_dir = match VFSDirectory::new(dir_name.to_string(), &curr_dir) {
-                    Ok(dir) => dir,
-                    Err(err) => {println!("{}", err);
-                                return -1;}
-                };
-            } else {
-                println!("failed to get task ref");    
-            }
+            // grabs a pointer to the current working directory; this is scoped so that we drop the lock on the "mkdir" task as soon as we're finished
+            let curr_dir = Arc::clone(&task::get_my_current_task().get_env().lock().working_dir);
+            let _new_dir = match VFSDirectory::new(dir_name.to_string(), &curr_dir) {
+                Ok(dir) => dir,
+                Err(err) => {
+                    println!("{}", err);
+                    return -1;
+                }
+            };
         }
     } 
 

--- a/applications/ns/src/lib.rs
+++ b/applications/ns/src/lib.rs
@@ -59,7 +59,7 @@ pub fn main(args: Vec<String>) -> isize {
 
 
 fn rmain(matches: Matches) -> Result<(), String> {
-    let curr_task = task::get_my_current_task().ok_or_else(|| format!("unable to get current task"))?;
+    let curr_task = task::get_my_current_task();
     let namespace = curr_task.get_namespace();
     let env = curr_task.get_env();
     let curr_wd = env.lock().working_dir.clone();

--- a/applications/ns/src/lib.rs
+++ b/applications/ns/src/lib.rs
@@ -60,7 +60,7 @@ pub fn main(args: Vec<String>) -> isize {
 
 fn rmain(matches: Matches) -> Result<(), String> {
     let curr_task = task::current_task();
-    let namespace = curr_task.get_namespace();
+    let namespace = &curr_task.namespace;
     let env = curr_task.get_env();
     let curr_wd = env.lock().working_dir.clone();
 
@@ -72,12 +72,12 @@ fn rmain(matches: Matches) -> Result<(), String> {
         let file = path.get_file(&curr_wd).ok_or_else(||
             format!("Couldn't resolve path to crate object file at {:?}", path)
         )?;
-        load_crate(&mut output, file, &namespace)?;
+        load_crate(&mut output, file, namespace)?;
     } else if matches.opt_present("f") {
-        print_files(&mut output, 0, namespace.deref(), recursive)
+        print_files(&mut output, 0, namespace, recursive)
             .map_err(|_e| String::from("String formatting error"))?;
     } else {
-        print_crates(&mut output, 0, namespace.deref(), recursive)
+        print_crates(&mut output, 0, namespace, recursive)
             .map_err(|_e| String::from("String formatting error"))?;
     }
 

--- a/applications/ns/src/lib.rs
+++ b/applications/ns/src/lib.rs
@@ -59,7 +59,7 @@ pub fn main(args: Vec<String>) -> isize {
 
 
 fn rmain(matches: Matches) -> Result<(), String> {
-    let curr_task = task::get_my_current_task();
+    let curr_task = task::current_task();
     let namespace = curr_task.get_namespace();
     let env = curr_task.get_env();
     let curr_wd = env.lock().working_dir.clone();

--- a/applications/pwd/src/lib.rs
+++ b/applications/pwd/src/lib.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 use alloc::string::String;
 
 pub fn main(_args: Vec<String>) -> isize {
-    let curr_env = task::get_my_current_task().get_env();
+    let curr_env = task::current_task().get_env();
     println!("{} \n", curr_env.lock().get_wd_path());
     0
 }

--- a/applications/pwd/src/lib.rs
+++ b/applications/pwd/src/lib.rs
@@ -9,11 +9,7 @@ use alloc::vec::Vec;
 use alloc::string::String;
 
 pub fn main(_args: Vec<String>) -> isize {
-    if let Some(taskref) = task::get_my_current_task() {
-        let curr_env = taskref.get_env();
-        println!("{} \n", curr_env.lock().get_wd_path());
-    } else {
-        println!("failed to get task ref");    
-    }
+    let curr_env = task::get_my_current_task().get_env();
+    println!("{} \n", curr_env.lock().get_wd_path());
     0
 }

--- a/applications/rm/src/lib.rs
+++ b/applications/rm/src/lib.rs
@@ -47,13 +47,7 @@ pub fn remove_node(args: Vec<String>) -> Result<(), String> {
     }
 
 
-    let taskref = match task::get_my_current_task() {
-        Some(t) => t,
-        None => {
-            return Err("failed to get current task".into());
-        }
-    };
-
+    let taskref = task::get_my_current_task();
     let working_dir = Arc::clone(&taskref.get_env().lock().working_dir);
 
     if matches.free.is_empty() {

--- a/applications/rm/src/lib.rs
+++ b/applications/rm/src/lib.rs
@@ -47,7 +47,7 @@ pub fn remove_node(args: Vec<String>) -> Result<(), String> {
     }
 
 
-    let taskref = task::get_my_current_task();
+    let taskref = task::current_task();
     let working_dir = Arc::clone(&taskref.get_env().lock().working_dir);
 
     if matches.free.is_empty() {

--- a/applications/rq_eval/src/lib.rs
+++ b/applications/rq_eval/src/lib.rs
@@ -163,7 +163,7 @@ fn run_single(iterations: usize) -> Result<(), &'static str> {
     let start = hpet.get_counter();
     
     for _i in 0..iterations {
-        runqueue::add_task_to_specific_runqueue(apic::get_my_apic_id(), taskref.clone())?;
+        runqueue::add_task_to_specific_runqueue(apic::current_apic_id(), taskref.clone())?;
 
         #[cfg(runqueue_spillful)] {   
             if let Some(remove_from_runqueue) = task::RUNQUEUE_REMOVAL_FUNCTION.get() {

--- a/applications/scheduler_eval/src/lib.rs
+++ b/applications/scheduler_eval/src/lib.rs
@@ -66,11 +66,7 @@ fn test1(_a: u32) -> u32 {
     //let mut i = 1;
     //loop{
     for i in 0..1000 {
-       let task_id = match task::get_my_current_task_id() {
-            Some(task_id) => {task_id},
-            None => 0
-       };
-       debug!("Task_ID : {} , Instance : {}", task_id, i);
+       debug!("Task_ID : {} , Instance : {}", task::get_my_current_task_id(), i);
        scheduler::schedule();
        //i = i + 1; 
     }
@@ -81,11 +77,7 @@ fn test2(_a: u32) -> u32 {
     //let mut i = 1;
     //loop{
     for i in 0..1000 {
-       let task_id = match task::get_my_current_task_id() {
-            Some(task_id) => {task_id},
-            None => 0
-       };
-       debug!("Task_ID : {} , Instance : {}", task_id, i);
+       debug!("Task_ID : {} , Instance : {}", task::get_my_current_task_id(), i);
        scheduler::schedule();
        //i = i + 1; 
     }
@@ -96,11 +88,7 @@ fn test3(_a: u32) -> u32 {
     //let mut i = 1;
     //loop{
     for i in 0..1000 {
-       let task_id = match task::get_my_current_task_id() {
-            Some(task_id) => {task_id},
-            None => 0
-       };
-       debug!("Task_ID : {} , Instance : {}", task_id, i);
+       debug!("Task_ID : {} , Instance : {}", task::get_my_current_task_id(), i);
        scheduler::schedule();
        //i = i + 1; 
     }

--- a/applications/scheduler_eval/src/lib.rs
+++ b/applications/scheduler_eval/src/lib.rs
@@ -66,7 +66,7 @@ fn test1(_a: u32) -> u32 {
     //let mut i = 1;
     //loop{
     for i in 0..1000 {
-       debug!("Task_ID : {} , Instance : {}", task::get_my_current_task_id(), i);
+       debug!("Task_ID : {} , Instance : {}", task::current_task_id(), i);
        scheduler::schedule();
        //i = i + 1; 
     }
@@ -77,7 +77,7 @@ fn test2(_a: u32) -> u32 {
     //let mut i = 1;
     //loop{
     for i in 0..1000 {
-       debug!("Task_ID : {} , Instance : {}", task::get_my_current_task_id(), i);
+       debug!("Task_ID : {} , Instance : {}", task::current_task_id(), i);
        scheduler::schedule();
        //i = i + 1; 
     }
@@ -88,7 +88,7 @@ fn test3(_a: u32) -> u32 {
     //let mut i = 1;
     //loop{
     for i in 0..1000 {
-       debug!("Task_ID : {} , Instance : {}", task::get_my_current_task_id(), i);
+       debug!("Task_ID : {} , Instance : {}", task::current_task_id(), i);
        scheduler::schedule();
        //i = i + 1; 
     }

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -108,7 +108,7 @@ pub fn main(_args: Vec<String>) -> isize {
 
     loop {
         // block this task, because it never needs to actually run again
-        task::get_my_current_task().block();
+        task::current_task().block();
     }
 
     // TODO: when `join` puts this task to sleep instead of spinning, we can re-enable it.
@@ -658,7 +658,7 @@ impl Shell {
     fn create_single_task(&mut self, cmd: String, args: Vec<String>) -> Result<TaskRef, AppErr> {
 
         // Check that the application actually exists
-        let namespace_dir = task::get_my_current_task().get_namespace().dir().clone();
+        let namespace_dir = task::current_task().get_namespace().dir().clone();
         let cmd_crate_name = format!("{}-", cmd);
         let mut matching_apps = namespace_dir.get_files_starting_with(&cmd_crate_name).into_iter();
         let app_file = matching_apps.next();
@@ -824,7 +824,7 @@ impl Shell {
     /// Try to match the incomplete command against all applications in the same namespace.
     /// Returns a vector that contains all matching results.
     fn find_app_name_match(&mut self, incomplete_cmd: &String) -> Result<Vec<String>, &'static str> {
-        let namespace_dir = task::get_my_current_task().get_namespace().dir().clone();
+        let namespace_dir = task::current_task().get_namespace().dir().clone();
         let mut names = namespace_dir.get_file_and_dir_names_starting_with(&incomplete_cmd);
 
         // Drop the extension name and hash value.
@@ -852,7 +852,7 @@ impl Shell {
         let mut match_list = Vec::new();
 
         // Get current working dir.
-        let mut curr_wd = Arc::clone(&task::get_my_current_task().get_env().lock().working_dir);
+        let mut curr_wd = Arc::clone(&task::current_task().get_env().lock().working_dir);
 
         // Check if the last character is a slash.
         let slash_ending = match incomplete_cmd.chars().last() {

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -658,7 +658,7 @@ impl Shell {
     fn create_single_task(&mut self, cmd: String, args: Vec<String>) -> Result<TaskRef, AppErr> {
 
         // Check that the application actually exists
-        let namespace_dir = task::current_task().get_namespace().dir().clone();
+        let namespace_dir = task::current_task().namespace.dir().clone();
         let cmd_crate_name = format!("{}-", cmd);
         let mut matching_apps = namespace_dir.get_files_starting_with(&cmd_crate_name).into_iter();
         let app_file = matching_apps.next();
@@ -824,7 +824,7 @@ impl Shell {
     /// Try to match the incomplete command against all applications in the same namespace.
     /// Returns a vector that contains all matching results.
     fn find_app_name_match(&mut self, incomplete_cmd: &String) -> Result<Vec<String>, &'static str> {
-        let namespace_dir = task::current_task().get_namespace().dir().clone();
+        let namespace_dir = task::current_task().namespace.dir().clone();
         let mut names = namespace_dir.get_file_and_dir_names_starting_with(&incomplete_cmd);
 
         // Drop the extension name and hash value.

--- a/applications/swap/src/lib.rs
+++ b/applications/swap/src/lib.rs
@@ -158,7 +158,7 @@ fn do_swap(
     cache_old_crates: bool
 ) -> Result<(), String> {
     let kernel_mmi_ref = memory::get_kernel_mmi_ref().ok_or_else(|| "couldn't get kernel_mmi_ref".to_string())?;
-    let namespace = task::try_current_task()?.get_namespace();
+    let namespace = &task::try_current_task()?.namespace;
 
     let swap_requests = {
         let mut requests: Vec<SwapRequest> = Vec::with_capacity(tuples.len());
@@ -179,7 +179,7 @@ fn do_swap(
             
             let swap_req = SwapRequest::new(
                 Some(old_crate_name),
-                Arc::clone(&namespace),
+                Arc::clone(namespace),
                 into_new_crate_file,
                 new_namespace,
                 reexport
@@ -192,7 +192,7 @@ fn do_swap(
     let start = get_hpet().as_ref().ok_or("couldn't get HPET timer")?.get_counter();
 
     let swap_result = crate_swap::swap_crates(
-        &namespace,
+        namespace,
         swap_requests, 
         override_namespace_crate_dir,
         state_transfer_functions,

--- a/applications/swap/src/lib.rs
+++ b/applications/swap/src/lib.rs
@@ -68,10 +68,7 @@ pub fn main(args: Vec<String>) -> isize {
 
 
 fn rmain(matches: Matches) -> Result<(), String> {
-
-    let taskref = task::get_my_current_task()
-        .ok_or_else(|| format!("failed to get current task"))?;
-
+    let taskref = task::get_my_current_task();
     let curr_dir = Arc::clone(&taskref.get_env().lock().working_dir);
 
     let override_namespace_crate_dir = if let Some(path) = matches.opt_str("d") {
@@ -161,7 +158,7 @@ fn do_swap(
     cache_old_crates: bool
 ) -> Result<(), String> {
     let kernel_mmi_ref = memory::get_kernel_mmi_ref().ok_or_else(|| "couldn't get kernel_mmi_ref".to_string())?;
-    let namespace = task::get_my_current_task().ok_or("Couldn't get current task")?.get_namespace();
+    let namespace = task::try_get_my_current_task()?.get_namespace();
 
     let swap_requests = {
         let mut requests: Vec<SwapRequest> = Vec::with_capacity(tuples.len());

--- a/applications/swap/src/lib.rs
+++ b/applications/swap/src/lib.rs
@@ -68,7 +68,7 @@ pub fn main(args: Vec<String>) -> isize {
 
 
 fn rmain(matches: Matches) -> Result<(), String> {
-    let taskref = task::get_my_current_task();
+    let taskref = task::current_task();
     let curr_dir = Arc::clone(&taskref.get_env().lock().working_dir);
 
     let override_namespace_crate_dir = if let Some(path) = matches.opt_str("d") {
@@ -158,7 +158,7 @@ fn do_swap(
     cache_old_crates: bool
 ) -> Result<(), String> {
     let kernel_mmi_ref = memory::get_kernel_mmi_ref().ok_or_else(|| "couldn't get kernel_mmi_ref".to_string())?;
-    let namespace = task::try_get_my_current_task()?.get_namespace();
+    let namespace = task::try_current_task()?.get_namespace();
 
     let swap_requests = {
         let mut requests: Vec<SwapRequest> = Vec::with_capacity(tuples.len());

--- a/applications/test_channel/src/lib.rs
+++ b/applications/test_channel/src/lib.rs
@@ -158,7 +158,7 @@ fn rmain(matches: Matches) -> Result<(), &'static str> {
 
 /// A simple test that spawns a sender & receiver task to send a single message
 fn rendezvous_test_oneshot() -> Result<(), &'static str> {
-    let my_cpu = apic::get_my_apic_id();
+    let my_cpu = apic::current_apic_id();
 
     let (sender, receiver) = rendezvous::new_channel();
 
@@ -196,7 +196,7 @@ fn rendezvous_test_oneshot() -> Result<(), &'static str> {
 /// A simple test that spawns a sender & receiver task to send `send_count` and receive `receive_count` messages.
 /// Optionally can set panics at `send_panic` and `receive_panic` locations
 fn rendezvous_test_multiple(send_count: usize, receive_count: usize, send_panic: Option<usize>, receive_panic: Option<usize>) -> Result<(), &'static str> {
-    let my_cpu = apic::get_my_apic_id();
+    let my_cpu = apic::current_apic_id();
 
     let (sender, receiver) = rendezvous::new_channel();
 
@@ -276,7 +276,7 @@ fn rendezvous_sender_task ((sender, iterations, panic_point): (rendezvous::Sende
 /// A simple test that spawns a sender & receiver task to send a single message
 /// Optionally can set panics at `send_panic` and `receive_panic` locations
 fn asynchronous_test_oneshot() -> Result<(), &'static str> {
-    let my_cpu = apic::get_my_apic_id();
+    let my_cpu = apic::current_apic_id();
 
     let (sender, receiver) = async_channel::new_channel(2);
 
@@ -318,7 +318,7 @@ fn asynchronous_test_oneshot() -> Result<(), &'static str> {
 
 /// A simple test that spawns a sender & receiver task to send `send_count` and receive `receive_count` messages.
 fn asynchronous_test_multiple(send_count: usize, receive_count: usize, send_panic: Option<usize>, receive_panic: Option<usize>) -> Result<(), &'static str> {
-    let my_cpu = apic::get_my_apic_id();
+    let my_cpu = apic::current_apic_id();
 
     let (sender, receiver) = async_channel::new_channel(2);
 

--- a/applications/test_downtime/src/lib.rs
+++ b/applications/test_downtime/src/lib.rs
@@ -44,7 +44,7 @@ pub struct PassStruct {
 }
 
 macro_rules! CPU_ID {
-	() => (apic::get_my_apic_id())
+	() => (apic::current_apic_id())
 }
 
 // ------------------------- Window fault injection section -------------------------------------------

--- a/applications/test_mutex_sleep/src/lib.rs
+++ b/applications/test_mutex_sleep/src/lib.rs
@@ -35,7 +35,7 @@ pub fn main(_args: Vec<String>) -> isize {
 
 /// A simple test that spawns 3 tasks that all contend to increment a shared usize
 fn test_contention() -> Result<(), &'static str> {
-    let my_cpu = apic::get_my_apic_id();
+    let my_cpu = apic::current_apic_id();
 
     let shared_lock = Arc::new(MutexSleep::new(0usize));
 
@@ -71,7 +71,7 @@ fn test_contention() -> Result<(), &'static str> {
 
 
 fn mutex_sleep_task(lock: Arc<MutexSleep<usize>>) -> Result<(), &'static str> {
-    let curr_task = task::try_get_my_current_task()?;
+    let curr_task = task::try_current_task()?;
     let curr_task = format!("{}", curr_task.deref());
     warn!("ENTERED TASK {}", curr_task);
 
@@ -91,7 +91,7 @@ fn mutex_sleep_task(lock: Arc<MutexSleep<usize>>) -> Result<(), &'static str> {
 
 /// A test for running multiple tasks that are synchronized in lockstep
 fn test_lockstep() -> Result<(), &'static str> {
-    let my_cpu = apic::get_my_apic_id();
+    let my_cpu = apic::current_apic_id();
 
     let shared_lock = Arc::new(MutexSleep::new(0usize));
 
@@ -128,7 +128,7 @@ fn test_lockstep() -> Result<(), &'static str> {
 
 fn lockstep_task((lock, remainder): (Arc<MutexSleep<usize>>, usize)) -> Result<(), &'static str> {
     let curr_task = {
-        let t = task::try_get_my_current_task()?;
+        let t = task::try_current_task()?;
         format!("{}", t.deref())
     };
     warn!("ENTERED TASK {}", curr_task);

--- a/applications/test_mutex_sleep/src/lib.rs
+++ b/applications/test_mutex_sleep/src/lib.rs
@@ -71,7 +71,7 @@ fn test_contention() -> Result<(), &'static str> {
 
 
 fn mutex_sleep_task(lock: Arc<MutexSleep<usize>>) -> Result<(), &'static str> {
-    let curr_task = task::get_my_current_task().ok_or("couldn't get current task")?;
+    let curr_task = task::try_get_my_current_task()?;
     let curr_task = format!("{}", curr_task.deref());
     warn!("ENTERED TASK {}", curr_task);
 
@@ -128,7 +128,7 @@ fn test_lockstep() -> Result<(), &'static str> {
 
 fn lockstep_task((lock, remainder): (Arc<MutexSleep<usize>>, usize)) -> Result<(), &'static str> {
     let curr_task = {
-        let t = task::get_my_current_task().ok_or("couldn't get current task")?;
+        let t = task::try_get_my_current_task()?;
         format!("{}", t.deref())
     };
     warn!("ENTERED TASK {}", curr_task);

--- a/applications/test_panic/src/lib.rs
+++ b/applications/test_panic/src/lib.rs
@@ -15,11 +15,11 @@ use alloc::boxed::Box;
 pub fn main(_args: Vec<String>) -> isize {
     info!("test_panic::main(): at top");
 
-    let _res = task::set_my_kill_handler(Box::new(|kill_reason| {
+    task::get_my_current_task().set_kill_handler(Box::new(|kill_reason| {
         println!("test_panic: caught a kill action: {}", kill_reason);
     }));
 
-    info!("test_panic::main(): registering kill handler... {:?}.", _res);
+    info!("test_panic::main(): registered kill handler");
 
     match _args.get(0).map(|s| &**s) {
         // indexing test

--- a/applications/test_panic/src/lib.rs
+++ b/applications/test_panic/src/lib.rs
@@ -15,7 +15,7 @@ use alloc::boxed::Box;
 pub fn main(_args: Vec<String>) -> isize {
     info!("test_panic::main(): at top");
 
-    task::get_my_current_task().set_kill_handler(Box::new(|kill_reason| {
+    task::current_task().set_kill_handler(Box::new(|kill_reason| {
         println!("test_panic: caught a kill action: {}", kill_reason);
     }));
 

--- a/applications/test_wait_queue/src/lib.rs
+++ b/applications/test_wait_queue/src/lib.rs
@@ -32,7 +32,7 @@ pub fn main(_args: Vec<String>) -> isize {
 
 
 fn rmain() -> Result<(), &'static str> {
-    let my_cpu = apic::get_my_apic_id();
+    let my_cpu = apic::current_apic_id();
 
     let ready = Arc::new(Mutex::new(false));
     let ready2 = ready.clone();

--- a/applications/unwind_test/src/lib.rs
+++ b/applications/unwind_test/src/lib.rs
@@ -22,7 +22,7 @@ impl Drop for MyStruct {
 
 #[inline(never)]
 fn foo(cause_page_fault: bool) {
-    task::get_my_current_task().set_kill_handler(Box::new(|kill_reason| {
+    task::current_task().set_kill_handler(Box::new(|kill_reason| {
         info!("unwind_test: caught kill action at {}", kill_reason);
     }));
     
@@ -41,7 +41,7 @@ pub fn main(args: Vec<String>) -> isize {
 
     // // dump some info about the this loaded app crate
     // {
-    //     let curr_task = task::get_my_current_task();
+    //     let curr_task = task::current_task();
     //     let t = curr_task.lock();
     //     let app_crate = t.app_crate.as_ref().unwrap();
     //     let krate = app_crate.lock_as_ref();

--- a/applications/unwind_test/src/lib.rs
+++ b/applications/unwind_test/src/lib.rs
@@ -22,7 +22,7 @@ impl Drop for MyStruct {
 
 #[inline(never)]
 fn foo(cause_page_fault: bool) {
-    let _res = task::set_my_kill_handler(Box::new(|kill_reason| {
+    task::get_my_current_task().set_kill_handler(Box::new(|kill_reason| {
         info!("unwind_test: caught kill action at {}", kill_reason);
     }));
     
@@ -41,7 +41,7 @@ pub fn main(args: Vec<String>) -> isize {
 
     // // dump some info about the this loaded app crate
     // {
-    //     let curr_task = task::get_my_current_task().unwrap();
+    //     let curr_task = task::get_my_current_task();
     //     let t = curr_task.lock();
     //     let app_crate = t.app_crate.as_ref().unwrap();
     //     let krate = app_crate.lock_as_ref();

--- a/applications/upd/src/lib.rs
+++ b/applications/upd/src/lib.rs
@@ -189,7 +189,7 @@ fn download(remote_endpoint: IpEndpoint, update_build: &str, crate_list: Option<
     };
     
     // save each new crate to a file 
-    let curr_dir = task::get_my_current_task().get_env().lock().working_dir.clone();
+    let curr_dir = task::current_task().get_env().lock().working_dir.clone();
     let new_namespace_dir = NamespaceDir::new(make_unique_directory(update_build, &curr_dir)?);
     for df in crates.into_iter() {
         let content = df.content.as_result_err_str()?;
@@ -219,7 +219,7 @@ fn apply(base_dir_path: &Path) -> Result<(), String> {
     }
 
     let kernel_mmi_ref = memory::get_kernel_mmi_ref().ok_or_else(|| format!("couldn't get kernel MMI"))?;
-    let curr_dir = task::get_my_current_task().get_env().lock().working_dir.clone();
+    let curr_dir = task::current_task().get_env().lock().working_dir.clone();
     let new_namespace_dir = match base_dir_path.get(&curr_dir) {
         Some(FileOrDir::Dir(d)) => NamespaceDir::new(d),
         _ => return Err(format!("cannot find an update base directory at path {}", base_dir_path)),
@@ -291,7 +291,7 @@ fn apply(base_dir_path: &Path) -> Result<(), String> {
 
 
 fn get_my_current_namespace() -> Arc<CrateNamespace> {
-    task::try_get_my_current_task()
+    task::try_current_task()
         .map(|t| t.get_namespace().clone())
         .ok()
         .or_else(|| mod_mgmt::get_initial_kernel_namespace().cloned())

--- a/applications/upd/src/lib.rs
+++ b/applications/upd/src/lib.rs
@@ -292,7 +292,7 @@ fn apply(base_dir_path: &Path) -> Result<(), String> {
 
 fn get_my_current_namespace() -> Arc<CrateNamespace> {
     task::try_current_task()
-        .map(|t| t.get_namespace().clone())
+        .map(|t| Arc::clone(&t.namespace))
         .ok()
         .or_else(|| mod_mgmt::get_initial_kernel_namespace().cloned())
         .expect("BUG: initial kernel namespace wasn't initialized")

--- a/applications/upd/src/lib.rs
+++ b/applications/upd/src/lib.rs
@@ -189,7 +189,7 @@ fn download(remote_endpoint: IpEndpoint, update_build: &str, crate_list: Option<
     };
     
     // save each new crate to a file 
-    let curr_dir = task::get_my_current_task().map(|t| t.get_env().lock().working_dir.clone()).ok_or_else(|| format!("couldn't get my current working directory"))?;
+    let curr_dir = task::get_my_current_task().get_env().lock().working_dir.clone();
     let new_namespace_dir = NamespaceDir::new(make_unique_directory(update_build, &curr_dir)?);
     for df in crates.into_iter() {
         let content = df.content.as_result_err_str()?;
@@ -219,7 +219,7 @@ fn apply(base_dir_path: &Path) -> Result<(), String> {
     }
 
     let kernel_mmi_ref = memory::get_kernel_mmi_ref().ok_or_else(|| format!("couldn't get kernel MMI"))?;
-    let curr_dir = task::get_my_current_task().map(|t| t.get_env().lock().working_dir.clone()).ok_or_else(|| format!("couldn't get my current working directory"))?;
+    let curr_dir = task::get_my_current_task().get_env().lock().working_dir.clone();
     let new_namespace_dir = match base_dir_path.get(&curr_dir) {
         Some(FileOrDir::Dir(d)) => NamespaceDir::new(d),
         _ => return Err(format!("cannot find an update base directory at path {}", base_dir_path)),
@@ -291,8 +291,9 @@ fn apply(base_dir_path: &Path) -> Result<(), String> {
 
 
 fn get_my_current_namespace() -> Arc<CrateNamespace> {
-    task::get_my_current_task()
+    task::try_get_my_current_task()
         .map(|t| t.get_namespace().clone())
+        .ok()
         .or_else(|| mod_mgmt::get_initial_kernel_namespace().cloned())
         .expect("BUG: initial kernel namespace wasn't initialized")
 }

--- a/applications/wasm/src/lib.rs
+++ b/applications/wasm/src/lib.rs
@@ -61,7 +61,6 @@ pub fn main(args: Vec<String>) -> isize {
     // Get current working directory.
     let curr_wr = Arc::clone(
         &task::get_my_current_task()
-            .unwrap()
             .get_env()
             .lock()
             .working_dir,

--- a/applications/wasm/src/lib.rs
+++ b/applications/wasm/src/lib.rs
@@ -60,7 +60,7 @@ pub fn main(args: Vec<String>) -> isize {
 
     // Get current working directory.
     let curr_wr = Arc::clone(
-        &task::get_my_current_task()
+        &task::current_task()
             .get_env()
             .lock()
             .working_dir,

--- a/kernel/acpi/madt/src/lib.rs
+++ b/kernel/acpi/madt/src/lib.rs
@@ -16,7 +16,7 @@ extern crate zerocopy;
 
 use core::mem::size_of;
 use memory::{MappedPages, PageTable, PhysicalAddress}; 
-use apic::{LocalApic, get_my_apic_id, get_lapics, get_bsp_id};
+use apic::{LocalApic, current_apic_id, get_lapics, get_bsp_id};
 use irq_safety::RwLockIrqSafe;
 use sdt::Sdt;
 use acpi_table::{AcpiSignature, AcpiTables};
@@ -305,7 +305,7 @@ fn handle_bsp_lapic_entry(madt_iter: MadtIter, page_table: &mut PageTable) -> Re
     use pic::IRQ_BASE_OFFSET;
 
     let all_lapics = get_lapics();
-    let me = get_my_apic_id();
+    let me = current_apic_id();
 
     for madt_entry in madt_iter.clone() {
         if let MadtEntry::LocalApic(lapic_entry) = madt_entry { 

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -92,14 +92,14 @@ pub fn core_count() -> usize {
 
 
 /// Returns the APIC ID of the currently executing processor core.
-pub fn get_my_apic_id() -> u8 {
+pub fn current_apic_id() -> u8 {
     rdmsr(IA32_TSC_AUX) as u8
 }
 
 
 /// Returns a reference to the LocalApic for the currently executing processsor core.
-pub fn get_my_apic() -> Option<&'static RwLockIrqSafe<LocalApic>> {
-    LOCAL_APICS.get(&get_my_apic_id())
+pub fn current_apic() -> Option<&'static RwLockIrqSafe<LocalApic>> {
+    LOCAL_APICS.get(&current_apic_id())
 }
 
 

--- a/kernel/app_io/src/lib.rs
+++ b/kernel/app_io/src/lib.rs
@@ -15,6 +15,7 @@
 //!    destructs all stdio queues
 
 #![no_std]
+#![feature(let_else)]
 
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
@@ -131,11 +132,10 @@ mod shared_maps {
 
 /// An application can call this function to get the terminal to which it should print.
 pub fn get_my_terminal() -> Option<Arc<Mutex<Terminal>>> {
-    task::get_my_current_task_id()
-        .and_then(|id| shared_maps::lock_stream_map()
-            .get(&id)
-            .map(|property| property.terminal.clone())
-        )
+    let task_id = task::get_my_current_task_id();
+    shared_maps::lock_stream_map()
+        .get(&task_id)
+        .map(|property| property.terminal.clone())
 }
 
 /// Lock all shared states (i.e. those defined in `lazy_static!`) and execute the closure.
@@ -172,7 +172,7 @@ pub fn remove_child_streams(task_id: &usize) -> Option<IoStreams> {
 /// make sure to store IoStreams for the newly spawned app first, and then unblocks the app
 /// to let it run.
 pub fn stdin() -> Result<StdioReader, &'static str> {
-    let task_id = task::get_my_current_task_id().ok_or("failed to get task_id to get stdin")?;
+    let task_id = task::get_my_current_task_id();
     let locked_streams = shared_maps::lock_stream_map();
     match locked_streams.get(&task_id) {
         Some(queues) => Ok(queues.stdin.clone()),
@@ -187,7 +187,7 @@ pub fn stdin() -> Result<StdioReader, &'static str> {
 /// make sure to store IoStreams for the newly spawned app first, and then unblocks the app
 /// to let it run.
 pub fn stdout() -> Result<StdioWriter, &'static str> {
-    let task_id = task::get_my_current_task_id().ok_or("failed to get task_id to get stdout")?;
+    let task_id = task::get_my_current_task_id();
     let locked_streams = shared_maps::lock_stream_map();
     match locked_streams.get(&task_id) {
         Some(queues) => Ok(queues.stdout.clone()),
@@ -202,7 +202,7 @@ pub fn stdout() -> Result<StdioWriter, &'static str> {
 /// make sure to store IoStreams for the newly spawned app first, and then unblocks the app
 /// to let it run.
 pub fn stderr() -> Result<StdioWriter, &'static str> {
-    let task_id = task::get_my_current_task_id().ok_or("failed to get task_id to get stderr")?;
+    let task_id = task::get_my_current_task_id();
     let locked_streams = shared_maps::lock_stream_map();
     match locked_streams.get(&task_id) {
         Some(queues) => Ok(queues.stderr.clone()),
@@ -220,7 +220,7 @@ pub fn stderr() -> Result<StdioWriter, &'static str> {
 /// already been taken by some other task, which may be running simultaneously, or be killed
 /// prematurely so that it cannot return the key event reader on exit.
 pub fn take_key_event_queue() -> Result<KeyEventReadGuard, &'static str> {
-    let task_id = task::get_my_current_task_id().ok_or("failed to get task_id to take key event queue")?;
+    let task_id = task::get_my_current_task_id();
     let locked_streams = shared_maps::lock_stream_map();
     match locked_streams.get(&task_id) {
         Some(queues) => {
@@ -239,19 +239,13 @@ pub fn take_key_event_queue() -> Result<KeyEventReadGuard, &'static str> {
 /// This function is automatically invoked upon dropping of `KeyEventReadGuard`.
 /// It returns the reader of key event queue back to the shell.
 fn return_event_queue(reader: &mut Option<KeyEventQueueReader>) {
-    match task::get_my_current_task_id().ok_or("failed to get task_id to return event queue") {
-        Ok(task_id) => {
-            let locked_streams = shared_maps::lock_stream_map();
-            match locked_streams.get(&task_id) {
-                Some(queues) => {
-                    core::mem::swap(&mut *queues.key_event_reader.lock(), reader);
-                },
-                None => { error!("no stderr for this task"); }
-            };
+    let task_id = task::get_my_current_task_id();
+    let locked_streams = shared_maps::lock_stream_map();
+    match locked_streams.get(&task_id) {
+        Some(queues) => {
+            core::mem::swap(&mut *queues.key_event_reader.lock(), reader);
         },
-        Err(e) => {
-            error!("app_io::return_event_queue(): Failed to get task_id to store new event queue. Error: {}", e);
-        }
+        None => { error!("no stderr for this task"); }
     };
 }
 
@@ -261,7 +255,7 @@ fn return_event_queue(reader: &mut Option<KeyEventQueueReader>) {
 /// Errors can occur in two cases, when it fails to get the `task_id` of the calling task,
 /// or it finds no IoControlFlags structure for that task.
 pub fn request_stdin_instant_flush() -> Result<(), &'static str> {
-    let task_id = task::get_my_current_task_id().ok_or("failed to get task_id to request stdin instant flush")?;
+    let task_id = task::get_my_current_task_id();
     let mut locked_flags = shared_maps::lock_flag_map();
     match locked_flags.get_mut(&task_id) {
         Some(flags) => {
@@ -278,7 +272,7 @@ pub fn request_stdin_instant_flush() -> Result<(), &'static str> {
 /// Errors can occur in two cases, when it fails to get the `task_id` of the calling task,
 /// or it finds no IoControlFlags structure for that task.
 pub fn cancel_stdin_instant_flush() -> Result<(), &'static str> {
-    let task_id = task::get_my_current_task_id().ok_or("failed to get task_id to cancel stdin instant flush")?;
+    let task_id = task::get_my_current_task_id();
     let mut locked_flags = shared_maps::lock_flag_map();
     match locked_flags.get_mut(&task_id) {
         Some(flags) => {
@@ -323,27 +317,21 @@ use core2::io::Write;
 /// Converts the given `core::fmt::Arguments` to a `String` and enqueues the string into the correct
 /// terminal print-producer
 pub fn print_to_stdout_args(fmt_args: fmt::Arguments) {
-    let task_id = match task::get_my_current_task_id() {
-        Some(task_id) => task_id,
-        None => {
-            // We cannot use log macros here, because when they're mirrored to the vga, they will cause
-            // infinite loops on an error. Instead, we write directly to the logger's output streams. 
-            let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: failed to get current task id \x1b[0m\n");
-            return;
-        }
+    let Ok(task_id) = task::try_get_my_current_task_id() else {
+        // We cannot use log macros here, because when they're mirrored to the vga, they will cause
+        // infinite loops on an error. Instead, we write directly to the logger's output streams. 
+        let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: failed to get current task id \x1b[0m\n");
+        return;
     };
 
     // Obtains the correct stdout stream and push the output bytes.
     let locked_streams = shared_maps::lock_stream_map();
-    match locked_streams.get(&task_id) {
-        Some(queues) => {
-            if let Err(_) = queues.stdout.lock().write_all(format!("{}", fmt_args).as_bytes()) {
-                let _ = logger::write_str("\x1b[31m [E] failed to write to stdout \x1b[0m\n");
-            }
-        },
-        None => {
-            let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
-            return;
-        }
+    let Some(queues) = locked_streams.get(&task_id) else {
+        let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
+        return;
+    };
+    let Ok(_) = queues.stdout.lock().write_all(format!("{}", fmt_args).as_bytes()) else {
+        let _ = logger::write_str("\x1b[31m [E] failed to write to stdout \x1b[0m\n");
+        return;
     };
 }

--- a/kernel/async_channel/src/lib.rs
+++ b/kernel/async_channel/src/lib.rs
@@ -219,7 +219,7 @@ impl <T: Send> Sender<T> {
             let value = hpet::get_hpet().as_ref().unwrap().get_counter();
             // debug!("Value {} {}", value, value % 1024);
 
-            match task::get_my_current_task() {
+            match task::current_task() {
                 Some(curr_task) => {
 
                     // We restrict the fault to a specific task to make measurements consistent

--- a/kernel/catch_unwind/src/lib.rs
+++ b/kernel/catch_unwind/src/lib.rs
@@ -112,6 +112,6 @@ pub fn resume_unwind(caught_panic_reason: KillReason) -> ! {
     // `start_unwinding` should not return
     panic!("BUG: start_unwinding() returned {:?}. This is an unexpected failure, as no unwinding occurred. Task: {:?}.",
         result,
-        task::get_my_current_task()
+        task::current_task()
     );
 }

--- a/kernel/deferred_interrupt_tasks/src/lib.rs
+++ b/kernel/deferred_interrupt_tasks/src/lib.rs
@@ -56,7 +56,7 @@ extern crate scheduler;
 extern crate interrupts;
 
 use alloc::string::String;
-use task::{TaskRef, get_my_current_task};
+use task::{TaskRef, current_task};
 
 pub type InterruptHandlerFunction = x86_64::structures::idt::HandlerFunc;
 
@@ -154,7 +154,7 @@ fn deferred_task_entry_point<DIA, Arg, Success, Failure>(
     where DIA: Fn(&Arg) -> Result<Success, Failure>,
           Arg: Send + 'static,
 {
-    let curr_task = get_my_current_task();
+    let curr_task = current_task();
     // trace!("Entered {:?}:\n\t action: {:?}\n\t arg:    {:?}", 
     //     curr_task.name, debugit!(deferred_interrupt_action), debugit!(deferred_action_argument)
     // );

--- a/kernel/deferred_interrupt_tasks/src/lib.rs
+++ b/kernel/deferred_interrupt_tasks/src/lib.rs
@@ -154,7 +154,7 @@ fn deferred_task_entry_point<DIA, Arg, Success, Failure>(
     where DIA: Fn(&Arg) -> Result<Success, Failure>,
           Arg: Send + 'static,
 {
-    let curr_task = get_my_current_task().expect("BUG: deferred_task_entry_point: couldn't get current task.");
+    let curr_task = get_my_current_task();
     // trace!("Entered {:?}:\n\t action: {:?}\n\t arg:    {:?}", 
     //     curr_task.name, debugit!(deferred_interrupt_action), debugit!(deferred_action_argument)
     // );

--- a/kernel/exceptions_full/src/lib.rs
+++ b/kernel/exceptions_full/src/lib.rs
@@ -130,7 +130,7 @@ fn kill_and_halt(
 
         if false {
             let mut debug = debug_info::DebugSymbols::Unloaded(debug_symbols_file);
-            let debug_sections = debug.load(&app_crate, &curr_task.get_namespace()).unwrap();
+            let debug_sections = debug.load(&app_crate, &curr_task.namespace).unwrap();
             let instr_ptr = stack_frame.instruction_pointer.as_u64() as usize - 1; // points to the next instruction (at least for a page fault)
 
             let res = debug_sections.find_subprogram_containing(VirtualAddress::new_canonical(instr_ptr));

--- a/kernel/fault_crate_swap/src/lib.rs
+++ b/kernel/fault_crate_swap/src/lib.rs
@@ -305,7 +305,7 @@ pub fn constant_offset_fix(
 /// This function handles 1 and 2 operations and 3 is handled in the call site depending on necessity
 pub fn self_swap_handler(crate_name: &str) -> Result<SwapRanges, String> {
 
-    let taskref = task::try_get_my_current_task()?;
+    let taskref = task::try_current_task()?;
 
     #[cfg(not(downtime_eval))]
     debug!("The taskref is {:?}",taskref);

--- a/kernel/fault_crate_swap/src/lib.rs
+++ b/kernel/fault_crate_swap/src/lib.rs
@@ -305,8 +305,7 @@ pub fn constant_offset_fix(
 /// This function handles 1 and 2 operations and 3 is handled in the call site depending on necessity
 pub fn self_swap_handler(crate_name: &str) -> Result<SwapRanges, String> {
 
-    let taskref = task::get_my_current_task()
-        .ok_or_else(|| format!("failed to get current task"))?;
+    let taskref = task::try_get_my_current_task()?;
 
     #[cfg(not(downtime_eval))]
     debug!("The taskref is {:?}",taskref);

--- a/kernel/fault_log/src/lib.rs
+++ b/kernel/fault_log/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![no_std]
 #![feature(drain_filter)]
+#![feature(let_else)]
 
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate vga_buffer; // for println_raw!()
@@ -149,12 +150,9 @@ fn update_and_insert_fault_entry_internal(
 
     // If current task cannot be obtained we will just add `fault_entry` to 
     // the `fault_log` and return.
-    let curr_task = match task::get_my_current_task() {
-        Some(x) => x,
-        _ => {
-            FAULT_LIST.lock().push(fe);
-            return
-        },
+    let Ok(curr_task) = task::try_get_my_current_task() else {
+        FAULT_LIST.lock().push(fe);
+        return;
     };
 
     let namespace = curr_task.get_namespace();

--- a/kernel/fault_log/src/lib.rs
+++ b/kernel/fault_log/src/lib.rs
@@ -22,7 +22,7 @@ use alloc::{
     vec::Vec,
 };
 use memory::VirtualAddress;
-use apic::get_my_apic_id;
+use apic::current_apic_id;
 use irq_safety::MutexIrqSafe;
 use core::panic::PanicInfo;
 
@@ -146,11 +146,11 @@ fn update_and_insert_fault_entry_internal(
 ) {
 
     // Add the core the fault was detected
-    fe.core = Some(get_my_apic_id());
+    fe.core = Some(current_apic_id());
 
     // If current task cannot be obtained we will just add `fault_entry` to 
     // the `fault_log` and return.
-    let Ok(curr_task) = task::try_get_my_current_task() else {
+    let Ok(curr_task) = task::try_current_task() else {
         FAULT_LIST.lock().push(fe);
         return;
     };

--- a/kernel/fault_log/src/lib.rs
+++ b/kernel/fault_log/src/lib.rs
@@ -155,8 +155,6 @@ fn update_and_insert_fault_entry_internal(
         return;
     };
 
-    let namespace = curr_task.get_namespace();
-
     // Add name of current task
     fe.running_task = {
         Some(curr_task.name.clone())
@@ -170,7 +168,7 @@ fn update_and_insert_fault_entry_internal(
     if let Some(instruction_pointer) = instruction_pointer {
         let instruction_pointer = VirtualAddress::new_canonical(instruction_pointer);
         fe.instruction_pointer = Some(instruction_pointer);
-        fe.crate_error_occured = namespace.get_crate_containing_address(instruction_pointer.clone(), false)
+        fe.crate_error_occured = curr_task.namespace.get_crate_containing_address(instruction_pointer.clone(), false)
                                         .map(|x| x.lock_as_ref().crate_name.clone());
     };
 

--- a/kernel/interrupts/src/lib.rs
+++ b/kernel/interrupts/src/lib.rs
@@ -265,7 +265,7 @@ pub fn deregister_interrupt(interrupt_num: u8, func: HandlerFunc) -> Result<(), 
 pub fn eoi(irq: Option<u8>) {
     match INTERRUPT_CHIP.load() {
         InterruptChip::APIC | InterruptChip::X2APIC => {
-            if let Some(my_apic) = apic::get_my_apic() {
+            if let Some(my_apic) = apic::current_apic() {
                 my_apic.write().eoi();
             } else {
                 error!("BUG: couldn't get my LocalApic instance to send EOI!");
@@ -371,7 +371,7 @@ pub static APIC_TIMER_TICKS: AtomicUsize = AtomicUsize::new(0);
 /// 0x22
 extern "x86-interrupt" fn lapic_timer_handler(_stack_frame: InterruptStackFrame) {
     let _ticks = APIC_TIMER_TICKS.fetch_add(1, Ordering::Relaxed);
-    // info!(" ({}) APIC TIMER HANDLER! TICKS = {}", apic::get_my_apic_id(), _ticks);
+    // info!(" ({}) APIC TIMER HANDLER! TICKS = {}", apic::current_apic_id(), _ticks);
 
     // Callback to the sleep API to unblock tasks whose waiting time is over
     // and alert to update the number of ticks elapsed
@@ -398,7 +398,7 @@ extern "x86-interrupt" fn unimplemented_interrupt_handler(_stack_frame: Interrup
             println_raw!("PIC IRQ Registers: {:?}", irq_regs);
         }
         apic::InterruptChip::APIC | apic::InterruptChip::X2APIC => {
-            if let Some(lapic_ref) = apic::get_my_apic() {
+            if let Some(lapic_ref) = apic::current_apic() {
                 let lapic = lapic_ref.read();
                 let isr = lapic.get_isr(); 
                 let irr = lapic.get_irr();

--- a/kernel/libtest/src/lib.rs
+++ b/kernel/libtest/src/lib.rs
@@ -35,7 +35,7 @@ pub fn hpet_2_us(hpet: u64) -> u64 {
 
 #[macro_export]
 macro_rules! CPU_ID {
-	() => (apic::get_my_apic_id())
+	() => (apic::current_apic_id())
 }
 
 /// Helper function return the tasks in a given core's runqueue

--- a/kernel/multicore_bringup/src/lib.rs
+++ b/kernel/multicore_bringup/src/lib.rs
@@ -33,7 +33,7 @@ use zerocopy::FromBytes;
 use irq_safety::MutexIrqSafe;
 use memory::{VirtualAddress, PhysicalAddress, MappedPages, EntryFlags, MemoryManagementInfo};
 use kernel_config::memory::{PAGE_SIZE, PAGE_SHIFT, KERNEL_STACK_SIZE_IN_PAGES};
-use apic::{LocalApic, get_lapics, get_my_apic_id, has_x2apic, get_bsp_id};
+use apic::{LocalApic, get_lapics, current_apic_id, has_x2apic, get_bsp_id};
 use ap_start::{kstart_ap, AP_READY_FLAG};
 use madt::{Madt, MadtEntry, MadtLocalApic, find_nmi_entry_for_processor};
 use pause::spin_loop_hint;
@@ -123,7 +123,7 @@ pub fn handle_ap_cores(
     }
 
     let all_lapics = get_lapics();
-    let me = get_my_apic_id();
+    let me = current_apic_id();
 
     // Copy the AP startup code (from the kernel's text section pages) into the AP_STARTUP physical address entry point.
     {

--- a/kernel/multiple_heaps/src/lib.rs
+++ b/kernel/multiple_heaps/src/lib.rs
@@ -260,7 +260,7 @@ if #[cfg(unsafe_heap)] {
 /// other value e.g. task id
 #[inline(always)] 
 fn get_key() -> usize {
-    apic::get_my_apic_id() as usize
+    apic::current_apic_id() as usize
 }
 
 // The LockedHeap struct definition changes depending on the slabmalloc version used.

--- a/kernel/panic_wrapper/src/lib.rs
+++ b/kernel/panic_wrapper/src/lib.rs
@@ -56,12 +56,14 @@ pub fn panic_wrapper(panic_info: &PanicInfo) -> Result<(), &'static str> {
         }
         #[cfg(frame_pointers)] {
             error!("------------------ Stack Trace (frame pointers) ------------------");
-            let namespace = task::get_my_current_task()
+            let namespace = task::try_get_my_current_task()
                 .map(|t| t.get_namespace())
+                .ok()
                 .or_else(|| mod_mgmt::get_initial_kernel_namespace())
                 .ok_or("couldn't get current task's or default namespace")?;
-            let mmi_ref = task::get_my_current_task()
+            let mmi_ref = task::try_get_my_current_task()
                 .map(|t| t.mmi.clone())
+                .ok()
                 .or_else(|| memory::get_kernel_mmi_ref())
                 .ok_or("couldn't get current task's or default kernel MMI")?;
             let mmi = mmi_ref.lock();
@@ -90,13 +92,13 @@ pub fn panic_wrapper(panic_info: &PanicInfo) -> Result<(), &'static str> {
 
     // Call this task's kill handler, if it has one.
     {
-        let kill_handler = task::get_my_current_task().and_then(|t| t.take_kill_handler());
+        let kill_handler = task::try_get_my_current_task().ok().and_then(|t| t.take_kill_handler());
         if let Some(ref kh_func) = kill_handler {
             debug!("Found kill handler callback to invoke in Task {:?}", task::get_my_current_task());
             kh_func(&KillReason::Panic(PanicInfoOwned::from(panic_info)));
         }
         else {
-            debug!("No kill handler callback in Task {:?}", task::get_my_current_task());
+            debug!("No kill handler callback in Task {:?}", task::try_get_my_current_task());
         }
     }
 

--- a/kernel/panic_wrapper/src/lib.rs
+++ b/kernel/panic_wrapper/src/lib.rs
@@ -57,7 +57,7 @@ pub fn panic_wrapper(panic_info: &PanicInfo) -> Result<(), &'static str> {
         #[cfg(frame_pointers)] {
             error!("------------------ Stack Trace (frame pointers) ------------------");
             let namespace = task::try_current_task()
-                .map(|t| t.get_namespace())
+                .map(|t| &t.namespace)
                 .ok()
                 .or_else(|| mod_mgmt::get_initial_kernel_namespace())
                 .ok_or("couldn't get current task's or default namespace")?;

--- a/kernel/pmu_x86/src/lib.rs
+++ b/kernel/pmu_x86/src/lib.rs
@@ -781,8 +781,7 @@ pub fn print_samples(sample_results: &SampleResults) {
 
 /// Finds the corresponding function for each instruction pointer and calculates the percentage amount each function occured in the samples
 pub fn find_function_names_from_samples(sample_results: &SampleResults) -> Result<(), &'static str> {
-    let taskref = task::get_my_current_task().ok_or("pmu_x86::get_function_names_from_samples: Could not get reference to current task")?;
-    let namespace = taskref.get_namespace();
+    let namespace = task::get_my_current_task().get_namespace();
     debug!("Analyze Samples:");
 
     let mut sections: BTreeMap<String, usize> = BTreeMap::new();
@@ -853,7 +852,7 @@ pub fn handle_sample(stack_frame: &InterruptStackFrame) -> Result<bool, &'static
     samples.sample_count = current_count - 1;
 
     // if the running task is the requested one or if one isn't requested, records the IP
-    if let Some(taskref) = task::get_my_current_task() {
+    if let Ok(taskref) = task::try_get_my_current_task() {
         let requested_task_id = samples.task_id;
         
         let task_id = taskref.id;

--- a/kernel/pmu_x86/src/lib.rs
+++ b/kernel/pmu_x86/src/lib.rs
@@ -781,7 +781,7 @@ pub fn print_samples(sample_results: &SampleResults) {
 
 /// Finds the corresponding function for each instruction pointer and calculates the percentage amount each function occured in the samples
 pub fn find_function_names_from_samples(sample_results: &SampleResults) -> Result<(), &'static str> {
-    let namespace = task::current_task().get_namespace();
+    let namespace = &task::current_task().namespace;
     debug!("Analyze Samples:");
 
     let mut sections: BTreeMap<String, usize> = BTreeMap::new();

--- a/kernel/pmu_x86/src/lib.rs
+++ b/kernel/pmu_x86/src/lib.rs
@@ -222,7 +222,7 @@ fn more_pmcs_than_expected(num_pmc: u8) -> Result<bool, &'static str> {
 /// This function should only be called after all the cores have been booted up.
 pub fn init() -> Result<(), &'static str> {
     let mut cores_initialized = CORES_INITIALIZED.lock();
-    let core_id = apic::get_my_apic_id();
+    let core_id = apic::current_apic_id();
 
     if cores_initialized.contains(&core_id) {
         warn!("PMU has already been intitialized on core {}", core_id);
@@ -557,7 +557,7 @@ fn create_general_counter(event_mask: u64) -> Result<Counter, &'static str> {
 
 /// Does the work of iterating through programmable counters and using whichever one is free. Returns Err if none free
 fn programmable_start(event_mask: u64) -> Result<Counter, &'static str> {
-    let my_core = apic::get_my_apic_id();
+    let my_core = apic::current_apic_id();
     let num_pmc = num_general_purpose_counters();
 
     for pmc in 0..num_pmc {
@@ -584,7 +584,7 @@ fn programmable_start(event_mask: u64) -> Result<Counter, &'static str> {
 
 /// Creates a counter object for a fixed hardware counter
 fn create_fixed_counter(msr_mask: u32) -> Result<Counter, &'static str> {
-    let my_core = apic::get_my_apic_id();
+    let my_core = apic::current_apic_id();
     let count = rdpmc(msr_mask);
     
     return Ok(Counter {
@@ -598,7 +598,7 @@ fn create_fixed_counter(msr_mask: u32) -> Result<Counter, &'static str> {
 /// Checks that the PMU has been initialized. If it has been,
 /// the version ID tells whether the system has performance monitoring capabilities. 
 fn check_pmu_availability() -> Result<(), &'static str>  {
-    let core_id = apic::get_my_apic_id();
+    let core_id = apic::current_apic_id();
     if !CORES_INITIALIZED.lock().contains(&core_id) {
         if *PMU_VERSION >= MIN_PMU_VERSION {
             error!("PMU version {} is available. It still needs to be initialized on this core", *PMU_VERSION);
@@ -654,7 +654,7 @@ pub fn start_samples(event_type: EventType, event_per_sample: u32, task_id: Opti
     check_pmu_availability()?;
 
     // perform checks to ensure that counter is ready to use and that previous results are not being unintentionally discarded
-    let my_core_id = apic::get_my_apic_id();
+    let my_core_id = apic::current_apic_id();
 
     trace!("start_samples: the core id is : {}", my_core_id);
 
@@ -753,7 +753,7 @@ pub struct SampleResults {
 /// Returns the samples that were stored during sampling in the form of a SampleResults object. 
 /// If samples are not yet finished, forces them to stop.  
 pub fn retrieve_samples() -> Result<SampleResults, &'static str> {
-    let my_core_id = apic::get_my_apic_id();
+    let my_core_id = apic::current_apic_id();
 
     let mut sampling_info = SAMPLING_INFO.lock();
     let mut samples = sampling_info.get_mut(&my_core_id).ok_or("pmu_x86::retrieve_samples: could not retrieve sampling information for this core")?;
@@ -781,7 +781,7 @@ pub fn print_samples(sample_results: &SampleResults) {
 
 /// Finds the corresponding function for each instruction pointer and calculates the percentage amount each function occured in the samples
 pub fn find_function_names_from_samples(sample_results: &SampleResults) -> Result<(), &'static str> {
-    let namespace = task::get_my_current_task().get_namespace();
+    let namespace = task::current_task().get_namespace();
     debug!("Analyze Samples:");
 
     let mut sections: BTreeMap<String, usize> = BTreeMap::new();
@@ -836,7 +836,7 @@ pub fn handle_sample(stack_frame: &InterruptStackFrame) -> Result<bool, &'static
 
     unsafe { Msr::new(IA32_PERF_GLOBAL_OVF_CTRL).write(CLEAR_PERF_STATUS_MSR); }
 
-    let my_core_id = apic::get_my_apic_id();
+    let my_core_id = apic::current_apic_id();
 
     let mut sampling_info = SAMPLING_INFO.lock();
     let mut samples = sampling_info.get_mut(&my_core_id)
@@ -852,7 +852,7 @@ pub fn handle_sample(stack_frame: &InterruptStackFrame) -> Result<bool, &'static
     samples.sample_count = current_count - 1;
 
     // if the running task is the requested one or if one isn't requested, records the IP
-    if let Ok(taskref) = task::try_get_my_current_task() {
+    if let Ok(taskref) = task::try_current_task() {
         let requested_task_id = samples.task_id;
         
         let task_id = taskref.id;
@@ -873,7 +873,7 @@ pub fn handle_sample(stack_frame: &InterruptStackFrame) -> Result<bool, &'static
         Msr::new(IA32_PERFEVTSEL0).write(Msr::new(IA32_PERFEVTSEL0).read());
     }
 
-    if let Some(my_apic) = apic::get_my_apic() {
+    if let Some(my_apic) = apic::current_apic() {
         my_apic.write().clear_pmi_mask();
     }
     else {

--- a/kernel/rendezvous/src/lib.rs
+++ b/kernel/rendezvous/src/lib.rs
@@ -224,7 +224,7 @@ impl <T: Send> Sender<T> {
         let value = hpet::get_hpet().as_ref().unwrap().get_counter();
         // debug!("Value {} {}", value, value % 1024);
 
-        let curr_task = task::try_get_my_current_task()?;
+        let curr_task = task::try_current_task()?;
 
         // Fault mimicing a memory write. Function could panic when getting task
         #[cfg(downtime_eval)]
@@ -382,7 +382,7 @@ impl <T: Send> Receiver<T> {
     /// otherwise returns an error.
     pub fn receive(&self) -> Result<T, &'static str> {
         // trace!("rendezvous: receive() entry");
-        let curr_task = task::try_get_my_current_task()?;
+        let curr_task = task::try_current_task()?;
         
         // obtain a receiver-side exchange slot, blocking if necessary
         let receiver_slot = self.channel.take_receiver_slot().map_err(|_| "failed to take_receiver_slot")?;

--- a/kernel/rendezvous/src/lib.rs
+++ b/kernel/rendezvous/src/lib.rs
@@ -224,7 +224,7 @@ impl <T: Send> Sender<T> {
         let value = hpet::get_hpet().as_ref().unwrap().get_counter();
         // debug!("Value {} {}", value, value % 1024);
 
-        let curr_task = task::get_my_current_task().ok_or("couldn't get current task")?;
+        let curr_task = task::try_get_my_current_task()?;
 
         // Fault mimicing a memory write. Function could panic when getting task
         #[cfg(downtime_eval)]
@@ -382,7 +382,7 @@ impl <T: Send> Receiver<T> {
     /// otherwise returns an error.
     pub fn receive(&self) -> Result<T, &'static str> {
         // trace!("rendezvous: receive() entry");
-        let curr_task = task::get_my_current_task().ok_or("couldn't get current task")?;
+        let curr_task = task::try_get_my_current_task()?;
         
         // obtain a receiver-side exchange slot, blocking if necessary
         let receiver_slot = self.channel.take_receiver_slot().map_err(|_| "failed to take_receiver_slot")?;

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -20,8 +20,8 @@ cfg_if! {
 
 use core::ops::Deref;
 use irq_safety::hold_interrupts;
-use apic::get_my_apic_id;
-use task::{try_get_my_current_task, TaskRef};
+use apic::current_apic_id;
+use task::{try_current_task, TaskRef};
 
 /// Yields the current CPU by selecting a new `Task` to run 
 /// and then performs a task switch to that new `Task`.
@@ -29,9 +29,9 @@ use task::{try_get_my_current_task, TaskRef};
 /// Interrupts will be disabled while this function runs.
 pub fn schedule() -> bool {
     let _held_interrupts = hold_interrupts(); // auto-reenables interrupts on early return
-    let apic_id = get_my_apic_id();
+    let apic_id = current_apic_id();
 
-    let Ok(curr_task) = try_get_my_current_task() else {
+    let Ok(curr_task) = try_current_task() else {
         error!("BUG: schedule(): could not get current task.");
         return false; // keep running the same current task
     };
@@ -51,7 +51,7 @@ pub fn schedule() -> bool {
 
     curr_task.task_switch(next_task.deref(), apic_id); 
 
-    // trace!("AFTER TASK_SWITCH CALL (AP {}) new current: {:?}, interrupts are {}", apic_id, get_my_current_task(), irq_safety::interrupts_enabled());
+    // trace!("AFTER TASK_SWITCH CALL (AP {}) new current: {:?}, interrupts are {}", apic_id, current_task(), irq_safety::interrupts_enabled());
  
     true
 }

--- a/kernel/simd_personality/src/lib.rs
+++ b/kernel/simd_personality/src/lib.rs
@@ -153,7 +153,7 @@ fn internal_setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str
 	simd_app_namespace.disable_fuzzy_symbol_matching();
 
 
-	let this_core = apic::get_my_apic_id();
+	let this_core = apic::current_apic_id();
 	
 	type SimdTestFunc = fn(());
 	let section_ref1 = simd_app_namespace.get_symbol_starting_with("simd_test::test1::")

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -18,7 +18,7 @@ extern crate scheduler;
 use core::sync::atomic::{Ordering, AtomicUsize};
 use alloc::collections::binary_heap::BinaryHeap;
 use irq_safety::MutexIrqSafe;
-use task::{get_my_current_task, TaskRef};
+use task::{current_task, TaskRef};
 
 /// Contains the `TaskRef` and the associated wakeup time for an entry in DELAYED_TASKLIST.
 #[derive(Clone, Eq, PartialEq)]
@@ -112,7 +112,7 @@ pub fn sleep(duration: usize) {
     let current_tick_count = TICK_COUNT.load(Ordering::SeqCst);
     let resume_time = current_tick_count + duration;
 
-    let current_task = get_my_current_task().clone();
+    let current_task = current_task().clone();
     // Add the current task to the delayed tasklist and then block it.
     add_to_delayed_tasklist(SleepingTaskNode{taskref: current_task.clone(), resume_time});
     current_task.block();

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -112,7 +112,7 @@ pub fn sleep(duration: usize) {
     let current_tick_count = TICK_COUNT.load(Ordering::SeqCst);
     let resume_time = current_tick_count + duration;
 
-    let current_task = get_my_current_task().unwrap().clone();
+    let current_task = get_my_current_task().clone();
     // Add the current task to the delayed tasklist and then block it.
     add_to_delayed_tasklist(SleepingTaskNode{taskref: current_task.clone(), resume_time});
     current_task.block();

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -134,7 +134,7 @@ pub fn new_application_task_builder(
     new_namespace: Option<Arc<CrateNamespace>>,
 ) -> Result<TaskBuilder<MainFunc, MainFuncArg, MainFuncRet>, &'static str> {
     
-    let namespace = new_namespace.unwrap_or_else(|| task::current_task().get_namespace().clone());
+    let namespace = new_namespace.unwrap_or_else(|| Arc::clone(&task::current_task().namespace));
     
     let crate_object_file = match crate_object_file.get(namespace.dir())
         .or_else(|| Path::new(format!("{}.o", &crate_object_file)).get(namespace.dir())) // retry with ".o" extension

--- a/kernel/stack_trace/src/lib.rs
+++ b/kernel/stack_trace/src/lib.rs
@@ -25,7 +25,7 @@ extern crate unwind;
 extern crate fallible_iterator;
 
 pub use mod_mgmt::{CrateNamespace, StrongSectionRef};
-pub use task::get_my_current_task;
+pub use task::current_task;
 
 use unwind::{StackFrame, StackFrameIter};
 use fallible_iterator::FallibleIterator;
@@ -66,7 +66,7 @@ pub fn stack_trace(
     let max_recursion = max_recursion.unwrap_or(usize::MAX);
 
     unwind::invoke_with_current_registers(&mut |registers| {
-        let namespace = task::try_get_my_current_task()
+        let namespace = task::try_current_task()
             .map(|t| t.get_namespace())
             .ok()
             .or_else(|| mod_mgmt::get_initial_kernel_namespace())

--- a/kernel/stack_trace/src/lib.rs
+++ b/kernel/stack_trace/src/lib.rs
@@ -67,7 +67,7 @@ pub fn stack_trace(
 
     unwind::invoke_with_current_registers(&mut |registers| {
         let namespace = task::try_current_task()
-            .map(|t| t.get_namespace())
+            .map(|t| &t.namespace)
             .ok()
             .or_else(|| mod_mgmt::get_initial_kernel_namespace())
             .ok_or("couldn't get current task's or default namespace")?;

--- a/kernel/stack_trace/src/lib.rs
+++ b/kernel/stack_trace/src/lib.rs
@@ -66,8 +66,9 @@ pub fn stack_trace(
     let max_recursion = max_recursion.unwrap_or(usize::MAX);
 
     unwind::invoke_with_current_registers(&mut |registers| {
-        let namespace = task::get_my_current_task()
+        let namespace = task::try_get_my_current_task()
             .map(|t| t.get_namespace())
+            .ok()
             .or_else(|| mod_mgmt::get_initial_kernel_namespace())
             .ok_or("couldn't get current task's or default namespace")?;
         let mut stack_frame_iter = StackFrameIter::new(namespace.clone(), registers);

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -482,11 +482,6 @@ impl Task {
         self.runstate() == RunState::Runnable
     }
 
-    /// Returns the namespace in which this `Task` is loaded/linked into and runs within.
-    pub fn get_namespace(&self) -> &Arc<CrateNamespace> {
-        &self.namespace
-    }
-
     /// Exposes read-only access to this `Task`'s [`Stack`] by invoking
     /// the given `func` with a reference to its kernel stack.
     ///

--- a/kernel/terminal_print/src/lib.rs
+++ b/kernel/terminal_print/src/lib.rs
@@ -70,7 +70,7 @@ pub fn remove_child(child_task_id: usize) -> Result<(), &'static str> {
 use core::fmt;
 /// Converts the given `core::fmt::Arguments` to a `String` and enqueues the string into the correct terminal print-producer
 pub fn print_to_stdout_args(fmt_args: fmt::Arguments) {
-    let Ok(task_id) = task::try_get_my_current_task_id() else {
+    let Ok(task_id) = task::try_current_task_id() else {
         // We cannot use log macros here, because when they're mirrored to the vga, they will cause infinite loops on an error.
         // Instead, we write direclty to the serial port.
         let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: failed to get current task id \x1b[0m\n");

--- a/kernel/terminal_print/src/lib.rs
+++ b/kernel/terminal_print/src/lib.rs
@@ -13,6 +13,7 @@
 //! If an application itself spawns child tasks, those will not be able to properly print through these interfaces.
 
 #![no_std]
+#![feature(let_else)]
 
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate lazy_static;
@@ -69,14 +70,11 @@ pub fn remove_child(child_task_id: usize) -> Result<(), &'static str> {
 use core::fmt;
 /// Converts the given `core::fmt::Arguments` to a `String` and enqueues the string into the correct terminal print-producer
 pub fn print_to_stdout_args(fmt_args: fmt::Arguments) {
-    let task_id = match task::get_my_current_task_id() {
-        Some(task_id) => {task_id},
-        None => {
-            // We cannot use log macros here, because when they're mirrored to the vga, they will cause infinite loops on an error.
-            // Instead, we write direclty to the serial port. 
-            let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: failed to get current task id \x1b[0m\n");
-            return;
-        }
+    let Ok(task_id) = task::try_get_my_current_task_id() else {
+        // We cannot use log macros here, because when they're mirrored to the vga, they will cause infinite loops on an error.
+        // Instead, we write direclty to the serial port.
+        let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: failed to get current task id \x1b[0m\n");
+        return;
     };
     
     // Obtains the correct terminal print producer and enqueues the print event, which will later be popped off

--- a/kernel/test_thread_local/src/lib.rs
+++ b/kernel/test_thread_local/src/lib.rs
@@ -62,7 +62,7 @@ impl Complex {
 }
 
 pub fn test_tls(_x: usize) {
-    let curr_task = task::get_my_current_task();
+    let curr_task = task::current_task();
     let local_zero = LOCAL_ZERO.get();
     debug!("Task {:?}, LOCAL_ZERO: {:#X?}", curr_task, local_zero);
 

--- a/kernel/test_thread_local/src/lib.rs
+++ b/kernel/test_thread_local/src/lib.rs
@@ -62,7 +62,7 @@ impl Complex {
 }
 
 pub fn test_tls(_x: usize) {
-    let curr_task = task::get_my_current_task().unwrap();
+    let curr_task = task::get_my_current_task();
     let local_zero = LOCAL_ZERO.get();
     debug!("Task {:?}, LOCAL_ZERO: {:#X?}", curr_task, local_zero);
 

--- a/kernel/tss/src/lib.rs
+++ b/kernel/tss/src/lib.rs
@@ -29,7 +29,7 @@ lazy_static! {
 /// Should be set to an address within the current userspace task's kernel stack.
 /// WARNING: If set incorrectly, the OS will crash upon an interrupt from userspace into kernel space!!
 pub fn tss_set_rsp0(new_privilege_stack_top: VirtualAddress) -> Result<(), &'static str> {
-    let my_apic_id = apic::get_my_apic_id();
+    let my_apic_id = apic::current_apic_id();
     let mut tss_entry = TSS.get(&my_apic_id).ok_or_else(|| {
         error!("tss_set_rsp0(): couldn't find TSS for apic {}", my_apic_id);
         "No TSS for the current core's apid id" 

--- a/kernel/unwind/src/lib.rs
+++ b/kernel/unwind/src/lib.rs
@@ -737,7 +737,7 @@ fn get_eh_frame_info(crate_ref: &StrongCrateRef) -> Option<(StrongSectionRef, Ba
 pub fn start_unwinding(reason: KillReason, stack_frames_to_skip: usize) -> Result<(), &'static str> {
     // Here we have to be careful to have no resources waiting to be dropped/freed/released on the stack. 
     let unwinding_context_ptr = {
-        let curr_task = task::try_get_my_current_task()?;
+        let curr_task = task::try_current_task()?;
         let namespace = curr_task.get_namespace();
 
         Box::into_raw(Box::new(

--- a/kernel/unwind/src/lib.rs
+++ b/kernel/unwind/src/lib.rs
@@ -737,7 +737,7 @@ fn get_eh_frame_info(crate_ref: &StrongCrateRef) -> Option<(StrongSectionRef, Ba
 pub fn start_unwinding(reason: KillReason, stack_frames_to_skip: usize) -> Result<(), &'static str> {
     // Here we have to be careful to have no resources waiting to be dropped/freed/released on the stack. 
     let unwinding_context_ptr = {
-        let curr_task = task::get_my_current_task().ok_or("get_my_current_task() failed")?;
+        let curr_task = task::try_get_my_current_task()?;
         let namespace = curr_task.get_namespace();
 
         Box::into_raw(Box::new(

--- a/kernel/unwind/src/lib.rs
+++ b/kernel/unwind/src/lib.rs
@@ -738,12 +738,10 @@ pub fn start_unwinding(reason: KillReason, stack_frames_to_skip: usize) -> Resul
     // Here we have to be careful to have no resources waiting to be dropped/freed/released on the stack. 
     let unwinding_context_ptr = {
         let curr_task = task::try_current_task()?;
-        let namespace = curr_task.get_namespace();
-
         Box::into_raw(Box::new(
             UnwindingContext {
                 stack_frame_iter: StackFrameIter::new(
-                    Arc::clone(&namespace),
+                    Arc::clone(&curr_task.namespace),
                     // we will set the real register values later, in the `invoke_with_current_registers()` closure.
                     Registers::default()
                 ), 

--- a/kernel/wait_queue/src/lib.rs
+++ b/kernel/wait_queue/src/lib.rs
@@ -108,7 +108,7 @@ impl WaitQueue {
     // /// The `condition` closure is invoked with one argument, an immutable reference to the waitqueue, 
     // /// to allow the closure to examine the condition of the waitqueue if necessary. 
     pub fn wait_until<R>(&self, condition: &dyn Fn(/* &VecDeque<TaskRef> */) -> Option<R>) -> Result<R, WaitError> {
-        let curr_task = task::get_my_current_task().ok_or(WaitError::NoCurrentTask)?;
+        let curr_task = task::try_get_my_current_task().or(Err(WaitError::NoCurrentTask))?;
 
         // Do the following atomically:
         // (1) Obtain the waitqueue lock
@@ -140,7 +140,7 @@ impl WaitQueue {
     /// Similar to [`wait_until`](#method.wait_until), but this function accepts a `condition` closure
     /// that can mutate its environment (a `FnMut`).
     pub fn wait_until_mut<R>(&self, condition: &mut dyn FnMut(/* &VecDeque<TaskRef> */) -> Option<R>) -> Result<R, WaitError> {
-        let curr_task = task::get_my_current_task().ok_or(WaitError::NoCurrentTask)?;
+        let curr_task = task::try_get_my_current_task().or(Err(WaitError::NoCurrentTask))?;
 
         // Do the following atomically:
         // (1) Obtain the waitqueue lock

--- a/kernel/wait_queue/src/lib.rs
+++ b/kernel/wait_queue/src/lib.rs
@@ -108,7 +108,7 @@ impl WaitQueue {
     // /// The `condition` closure is invoked with one argument, an immutable reference to the waitqueue, 
     // /// to allow the closure to examine the condition of the waitqueue if necessary. 
     pub fn wait_until<R>(&self, condition: &dyn Fn(/* &VecDeque<TaskRef> */) -> Option<R>) -> Result<R, WaitError> {
-        let curr_task = task::try_get_my_current_task().or(Err(WaitError::NoCurrentTask))?;
+        let curr_task = task::try_current_task().or(Err(WaitError::NoCurrentTask))?;
 
         // Do the following atomically:
         // (1) Obtain the waitqueue lock
@@ -140,7 +140,7 @@ impl WaitQueue {
     /// Similar to [`wait_until`](#method.wait_until), but this function accepts a `condition` closure
     /// that can mutate its environment (a `FnMut`).
     pub fn wait_until_mut<R>(&self, condition: &mut dyn FnMut(/* &VecDeque<TaskRef> */) -> Option<R>) -> Result<R, WaitError> {
-        let curr_task = task::try_get_my_current_task().or(Err(WaitError::NoCurrentTask))?;
+        let curr_task = task::try_current_task().or(Err(WaitError::NoCurrentTask))?;
 
         // Do the following atomically:
         // (1) Obtain the waitqueue lock

--- a/kernel/wasi_interpreter/src/lib.rs
+++ b/kernel/wasi_interpreter/src/lib.rs
@@ -104,7 +104,6 @@ pub fn execute_binary(wasm_binary: Vec<u8>, args: Vec<String>, preopen_dirs: Vec
 
     // Populate environment variables.
     let pwd: String = task::get_my_current_task()
-        .unwrap()
         .get_env()
         .lock()
         .get_wd_path();
@@ -131,7 +130,6 @@ pub fn execute_binary(wasm_binary: Vec<u8>, args: Vec<String>, preopen_dirs: Vec
                 &preopen_dir,
                 Arc::clone(
                     &task::get_my_current_task()
-                        .unwrap()
                         .get_env()
                         .lock()
                         .working_dir,

--- a/kernel/wasi_interpreter/src/lib.rs
+++ b/kernel/wasi_interpreter/src/lib.rs
@@ -103,7 +103,7 @@ pub fn execute_binary(wasm_binary: Vec<u8>, args: Vec<String>, preopen_dirs: Vec
     .unwrap();
 
     // Populate environment variables.
-    let pwd: String = task::get_my_current_task()
+    let pwd: String = task::current_task()
         .get_env()
         .lock()
         .get_wd_path();
@@ -129,7 +129,7 @@ pub fn execute_binary(wasm_binary: Vec<u8>, args: Vec<String>, preopen_dirs: Vec
             .open_path(
                 &preopen_dir,
                 Arc::clone(
-                    &task::get_my_current_task()
+                    &task::current_task()
                         .get_env()
                         .lock()
                         .working_dir,

--- a/kernel/wasi_interpreter/src/posix_file_system.rs
+++ b/kernel/wasi_interpreter/src/posix_file_system.rs
@@ -150,7 +150,6 @@ impl PosixNode {
         let absolute_path = Path::new(self.theseus_file_or_dir.get_absolute_path());
         let wd_path = Path::new(
             task::get_my_current_task()
-                .unwrap()
                 .get_env()
                 .lock()
                 .get_wd_path(),

--- a/kernel/wasi_interpreter/src/posix_file_system.rs
+++ b/kernel/wasi_interpreter/src/posix_file_system.rs
@@ -149,7 +149,7 @@ impl PosixNode {
     pub fn get_relative_path(&self) -> String {
         let absolute_path = Path::new(self.theseus_file_or_dir.get_absolute_path());
         let wd_path = Path::new(
-            task::get_my_current_task()
+            task::current_task()
                 .get_env()
                 .lock()
                 .get_wd_path(),

--- a/old_crates/spawn_userspace/src/lib.rs
+++ b/old_crates/spawn_userspace/src/lib.rs
@@ -217,7 +217,7 @@ fn userspace_wrapper() -> ! {
     let entry_func: usize; 
 
     { // scoped to release current task's lock before calling jump_to_userspace
-        let currtask = get_my_current_task().expect("userspace_wrapper(): get_my_current_task() failed").lock();
+        let currtask = get_my_current_task().lock();
         ustack_top = currtask.ustack.as_ref().expect("userspace_wrapper(): ustack was None!").top_usable().value();
         entry_func = currtask.new_userspace_entry_addr.expect("userspace_wrapper(): new_userspace_entry_addr was None!").value();
     }

--- a/ports/theseus_std/src/env.rs
+++ b/ports/theseus_std/src/env.rs
@@ -6,7 +6,7 @@ use theseus_fs_node::{FileOrDir, DirRef};
 
 /// Returns a Theseus-specific reference to the current working directory.
 pub fn current_dir() -> io::Result<DirRef> {
-    let task = theseus_task::get_my_current_task();
+    let task = theseus_task::current_task();
 
     match theseus_path::Path::get_absolute(
         &task.get_env().lock().get_wd_path().into()
@@ -22,5 +22,5 @@ pub fn current_dir() -> io::Result<DirRef> {
 
 /// Returns the path of the current working directory.
 pub fn current_dir_path() -> io::Result<PathBuf> {
-    Ok(theseus_task::get_my_current_task().get_env().lock().get_wd_path().into())
+    Ok(theseus_task::current_task().get_env().lock().get_wd_path().into())
 }

--- a/ports/theseus_std/src/env.rs
+++ b/ports/theseus_std/src/env.rs
@@ -6,31 +6,21 @@ use theseus_fs_node::{FileOrDir, DirRef};
 
 /// Returns a Theseus-specific reference to the current working directory.
 pub fn current_dir() -> io::Result<DirRef> {
-    theseus_task::get_my_current_task()
-        .ok_or(io::Error::new(
-            io::ErrorKind::Other, "failed to get Theseus current task")
-        )
-        .and_then(|task| 
-            match theseus_path::Path::get_absolute(
-                &task.get_env().lock().get_wd_path().into()
-            ) {
-                Some(FileOrDir::File(_)) => Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Theseus current working directory path pointed to a file..."
-                )),
-                Some(FileOrDir::Dir(d)) => Ok(d),
-                None => Err(io::ErrorKind::NotFound.into()),
-            }
-        )
+    let task = theseus_task::get_my_current_task();
+
+    match theseus_path::Path::get_absolute(
+        &task.get_env().lock().get_wd_path().into()
+    ) {
+        Some(FileOrDir::File(_)) => Err(io::Error::new(
+            io::ErrorKind::Other,
+            "Theseus current working directory path pointed to a file..."
+        )),
+        Some(FileOrDir::Dir(d)) => Ok(d),
+        None => Err(io::ErrorKind::NotFound.into()),
+    }
 }
 
 /// Returns the path of the current working directory.
 pub fn current_dir_path() -> io::Result<PathBuf> {
-    theseus_task::get_my_current_task()
-        .ok_or(io::Error::new(io::ErrorKind::Other, "failed to get Theseus current task"))
-        .map(|task| task.get_env()
-            .lock()
-            .get_wd_path()
-            .into()
-        )
+    Ok(theseus_task::get_my_current_task().get_env().lock().get_wd_path().into())
 }


### PR DESCRIPTION
# Make fallible and infallible versions of `get_my_current_task` and `get_my_current_task_id`

* Briefly during startup there may not be a task, but once the first task is bootstrapped there's always a task. Application code and OS code that is only run after bootstrapping shouldn't have to check for a `None` current task.

* I've made `get_my_current_task` infallible so it returns a `&'static TaskRef` directly, and added a fallible `try_get_my_current_task` method that returns a `Result` for low-level code that could run during early startup. The same goes for `get_my_current_task_id`.

* I updated all the usage sites of these functions -- and there are a lot. This allowed a lot of `match` blocks, unwraps, and other similar error handlers to be removed from a lot of code, particularly all of the applications. For low-level code that calls the `try_` versions I mainly just had to insert `try_` and then tweak them a little since the fallible functions return `Result` instead of `Option`.

* I made liberal use of the soon-to-be-stabilized `let`-`else` feature in the updated code.

* One knock-on effect is that the shell's `AppErr::NamespaceErr` variant is no longer needed.
 
# Drop `get_my` from function names

* Rename `task::get_my_current_task` to `task::current_task`.
* Rename `task::get_my_current_task_id` to `task::current_task_id`.
* Rename `apic::get_my_apic` to `apic::current_apic`.
* Rename `apic::get_my_apic_id` to `apic::current_apic_id`.


# Inline and remove `Task::get_namespace()`

* `Task::namespace` is already a public field. There's no need for a getter function. Getters aren't idiomatic in Rust.