### PR TITLE
Merge core logic of allocators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,13 +1684,8 @@ dependencies = [
 name = "memory_structs"
 version = "0.1.0"
 dependencies = [
- "bit_field 0.7.0",
- "derive_more",
  "entryflags_x86_64",
  "kernel_config",
- "multiboot2",
- "paste",
- "xmas-elf",
  "zerocopy",
 ]
 
@@ -2183,12 +2178,6 @@ name = "parity-wasm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
-
-[[package]]
-name = "paste"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "path"

--- a/kernel/memory_structs/Cargo.toml
+++ b/kernel/memory_structs/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2021"
 
 [dependencies]
 zerocopy = "0.5.0"
+intrusive-collections = "0.9.0"
+spin = "0.9.0"
+
+[dependencies.log]
+version = "0.4.8"
 
 [dependencies.kernel_config]
 path = "../kernel_config"

--- a/kernel/memory_structs/Cargo.toml
+++ b/kernel/memory_structs/Cargo.toml
@@ -6,8 +6,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-multiboot2 = "0.10.1"
-bit_field = "0.7.0"
 zerocopy = "0.5.0"
 
 [dependencies.kernel_config]

--- a/kernel/memory_structs/Cargo.toml
+++ b/kernel/memory_structs/Cargo.toml
@@ -3,14 +3,12 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "memory_structs"
 description = "Common types used in the memory management subsystem"
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 multiboot2 = "0.10.1"
-xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 bit_field = "0.7.0"
 zerocopy = "0.5.0"
-derive_more = "0.99.0"
-paste = "1.0.5"
 
 [dependencies.kernel_config]
 path = "../kernel_config"

--- a/kernel/memory_structs/src/address.rs
+++ b/kernel/memory_structs/src/address.rs
@@ -26,6 +26,16 @@ impl<T> Address<T>
 where
     T: MemoryType,
 {
+    pub const MIN: Self = Self {
+        address: T::MIN_ADDRESS,
+        phantom_data: PhantomData,
+    };
+
+    pub const MAX: Self = Self {
+        address: T::MAX_ADDRESS,
+        phantom_data: PhantomData,
+    };
+
     /// Creates a new address, returning an error if the address is not canonical.
     ///
     /// This is useful for checking whether an address is valid before using it. For example on

--- a/kernel/memory_structs/src/address.rs
+++ b/kernel/memory_structs/src/address.rs
@@ -1,0 +1,286 @@
+use crate::MemoryType;
+use core::{
+    fmt::{self, Binary, Debug, Display, LowerHex, Octal, Pointer, UpperHex},
+    hash::Hash,
+    marker::PhantomData,
+    ops::{
+        Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub,
+        SubAssign,
+    },
+};
+use kernel_config::memory::PAGE_SIZE;
+use zerocopy::FromBytes;
+
+/// Either a physical or virtual address which is a [`usize`] under the hood.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, FromBytes)]
+#[repr(transparent)]
+pub struct Address<T>
+where
+    T: MemoryType,
+{
+    address: usize,
+    phantom_data: PhantomData<fn() -> T>,
+}
+
+impl<T> Address<T>
+where
+    T: MemoryType,
+{
+    /// Creates a new address, returning an error if the address is not canonical.
+    ///
+    /// This is useful for checking whether an address is valid before using it. For example on
+    /// x86_64, virtual addresses are canonical if their upper bits `(64:68]` are sign-extended
+    /// from bit 47, and physical addresses are canonical if their upper bits `(64:52]` are 0.
+    #[inline]
+    pub fn new(address: usize) -> Option<Self> {
+        if T::is_canonical_address(address) {
+            Some(Self {
+                address,
+                phantom_data: PhantomData,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Creates a new address that is guaranteed to be canonical.
+    pub fn new_canonical(address: usize) -> Self {
+        Self {
+            address: T::canonicalize_address(address),
+            phantom_data: PhantomData,
+        }
+    }
+
+    /// Creates a new address with a value of zero.
+    #[inline]
+    pub fn zero() -> Self {
+        Self {
+            address: 0,
+            phantom_data: PhantomData,
+        }
+    }
+
+    /// Returns the underlying usize value.
+    #[inline]
+    pub fn value(&self) -> usize {
+        self.address
+    }
+
+    /// Returns the offsets from the chunk boundary specified by this address.
+    ///
+    /// For example if the [`PAGE_SIZE`] is 4096 (4KiB) then this will return the least significant
+    /// 12 bits `(12:0]` of the address.
+    #[inline]
+    pub fn chunk_offset(&self) -> usize {
+        self.value() & (PAGE_SIZE - 1)
+    }
+}
+
+// Formatting Traits
+
+impl<T> Debug for Address<T>
+where
+    T: MemoryType,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}{:#X}", T::PREFIX, self.address)
+    }
+}
+
+macro_rules! format_impl {
+    ($trait:path, $char:tt) => {
+        impl<T> $trait for Address<T>
+        where
+            T: MemoryType,
+        {
+            #[inline]
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, concat!("{:", stringify!($char), "}"), self)
+            }
+        }
+    };
+}
+
+format_impl!(Display, ?);
+format_impl!(Pointer, ?);
+format_impl!(Binary, b);
+format_impl!(Octal, o);
+format_impl!(LowerHex, x);
+format_impl!(UpperHex, X);
+
+// Bit Traits
+
+impl<T> BitAnd<Address<T>> for Address<T>
+where
+    T: MemoryType,
+{
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        // TODO: new_canonical or raw?
+        Self::new_canonical(self.address & rhs.address)
+    }
+}
+
+impl<T> BitAndAssign<Address<T>> for Address<T>
+where
+    T: MemoryType,
+{
+    fn bitand_assign(&mut self, rhs: Self) {
+        // TODO: new_canonical or raw?
+        *self = Self::new_canonical(self.address & rhs.address)
+    }
+}
+
+impl<T> BitOr<Address<T>> for Address<T>
+where
+    T: MemoryType,
+{
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        // TODO: new_canonical or raw?
+        Self::new_canonical(self.address | rhs.address)
+    }
+}
+
+impl<T> BitOrAssign<Address<T>> for Address<T>
+where
+    T: MemoryType,
+{
+    fn bitor_assign(&mut self, rhs: Self) {
+        // TODO: new_canonical or raw?
+        *self = Self::new_canonical(self.address | rhs.address)
+    }
+}
+
+impl<T> BitXor<Address<T>> for Address<T>
+where
+    T: MemoryType,
+{
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        // TODO: new_canonical or raw?
+        Self::new_canonical(self.address ^ rhs.address)
+    }
+}
+
+impl<T> BitXorAssign<Address<T>> for Address<T>
+where
+    T: MemoryType,
+{
+    fn bitxor_assign(&mut self, rhs: Self) {
+        // TODO: new_canonical or raw?
+        *self = Self::new_canonical(self.address ^ rhs.address)
+    }
+}
+
+// Computation Traits (self)
+
+impl<T> Add<Address<T>> for Address<T>
+where
+    T: MemoryType,
+{
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self::Output {
+        // TODO: new_canonical or raw?
+        Self::new_canonical(self.address + rhs.address)
+    }
+}
+
+impl<T> AddAssign<Address<T>> for Address<T>
+where
+    T: MemoryType,
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        // TODO: new_canonical or raw?
+        *self = Self::new_canonical(self.address.saturating_add(rhs.address));
+    }
+}
+
+impl<T> Sub<Address<T>> for Address<T>
+where
+    T: MemoryType,
+{
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        // TODO: new_canonical or raw?
+        Self::new_canonical(self.address.saturating_sub(rhs.address))
+    }
+}
+
+impl<T> SubAssign<Address<T>> for Address<T>
+where
+    T: MemoryType,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        // TODO: new_canonical or raw?
+        *self = Self::new_canonical(self.address.saturating_sub(rhs.address));
+    }
+}
+
+// Computation Traits (usize)
+
+impl<T> Add<usize> for Address<T>
+where
+    T: MemoryType,
+{
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: usize) -> Self {
+        Self::new_canonical(self.address.saturating_add(rhs))
+    }
+}
+
+impl<T> AddAssign<usize> for Address<T>
+where
+    T: MemoryType,
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: usize) {
+        *self = Self::new_canonical(self.address.saturating_add(rhs));
+    }
+}
+
+impl<T> Sub<usize> for Address<T>
+where
+    T: MemoryType,
+{
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: usize) -> Self {
+        Self::new_canonical(self.address.saturating_sub(rhs))
+    }
+}
+
+impl<T> SubAssign<usize> for Address<T>
+where
+    T: MemoryType,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: usize) {
+        *self = Self::new_canonical(self.address.saturating_sub(rhs));
+    }
+}
+
+// Conversion Traits
+
+impl<T> From<Address<T>> for usize
+where
+    T: MemoryType,
+{
+    #[inline]
+    fn from(address: Address<T>) -> Self {
+        address.address
+    }
+}

--- a/kernel/memory_structs/src/address.rs
+++ b/kernel/memory_structs/src/address.rs
@@ -32,7 +32,10 @@ where
     /// x86_64, virtual addresses are canonical if their upper bits `(64:68]` are sign-extended
     /// from bit 47, and physical addresses are canonical if their upper bits `(64:52]` are 0.
     #[inline]
-    pub fn new(address: usize) -> Option<Self> {
+    pub const fn new(address: usize) -> Option<Self>
+    where
+        T: ~const MemoryType,
+    {
         if T::is_canonical_address(address) {
             Some(Self {
                 address,
@@ -44,7 +47,10 @@ where
     }
 
     /// Creates a new address that is guaranteed to be canonical.
-    pub fn new_canonical(address: usize) -> Self {
+    pub const fn new_canonical(address: usize) -> Self
+    where
+        T: ~const MemoryType,
+    {
         Self {
             address: T::canonicalize_address(address),
             phantom_data: PhantomData,
@@ -53,7 +59,7 @@ where
 
     /// Creates a new address with a value of zero.
     #[inline]
-    pub fn zero() -> Self {
+    pub const fn zero() -> Self {
         Self {
             address: 0,
             phantom_data: PhantomData,
@@ -62,7 +68,7 @@ where
 
     /// Returns the underlying usize value.
     #[inline]
-    pub fn value(&self) -> usize {
+    pub const fn value(&self) -> usize {
         self.address
     }
 
@@ -71,7 +77,7 @@ where
     /// For example if the [`PAGE_SIZE`] is 4096 (4KiB) then this will return the least significant
     /// 12 bits `(12:0]` of the address.
     #[inline]
-    pub fn chunk_offset(&self) -> usize {
+    pub const fn chunk_offset(&self) -> usize {
         self.value() & (PAGE_SIZE - 1)
     }
 }
@@ -111,13 +117,16 @@ format_impl!(UpperHex, X);
 
 // Bit Traits
 
-impl<T> BitAnd<Address<T>> for Address<T>
+impl<T> const BitAnd<Address<T>> for Address<T>
 where
     T: MemoryType,
 {
     type Output = Self;
 
-    fn bitand(self, rhs: Self) -> Self::Output {
+    fn bitand(self, rhs: Self) -> Self::Output
+    where
+        T: ~const MemoryType,
+    {
         // TODO: new_canonical or raw?
         Self::new_canonical(self.address & rhs.address)
     }
@@ -133,13 +142,16 @@ where
     }
 }
 
-impl<T> BitOr<Address<T>> for Address<T>
+impl<T> const BitOr<Address<T>> for Address<T>
 where
     T: MemoryType,
 {
     type Output = Self;
 
-    fn bitor(self, rhs: Self) -> Self::Output {
+    fn bitor(self, rhs: Self) -> Self::Output
+    where
+        T: ~const MemoryType,
+    {
         // TODO: new_canonical or raw?
         Self::new_canonical(self.address | rhs.address)
     }
@@ -155,13 +167,16 @@ where
     }
 }
 
-impl<T> BitXor<Address<T>> for Address<T>
+impl<T> const BitXor<Address<T>> for Address<T>
 where
     T: MemoryType,
 {
     type Output = Self;
 
-    fn bitxor(self, rhs: Self) -> Self::Output {
+    fn bitxor(self, rhs: Self) -> Self::Output
+    where
+        T: ~const MemoryType,
+    {
         // TODO: new_canonical or raw?
         Self::new_canonical(self.address ^ rhs.address)
     }
@@ -179,14 +194,17 @@ where
 
 // Computation Traits (self)
 
-impl<T> Add<Address<T>> for Address<T>
+impl<T> const Add<Address<T>> for Address<T>
 where
     T: MemoryType,
 {
     type Output = Self;
 
     #[inline]
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, rhs: Self) -> Self::Output
+    where
+        T: ~const MemoryType,
+    {
         // TODO: new_canonical or raw?
         Self::new_canonical(self.address + rhs.address)
     }
@@ -203,14 +221,17 @@ where
     }
 }
 
-impl<T> Sub<Address<T>> for Address<T>
+impl<T> const Sub<Address<T>> for Address<T>
 where
     T: MemoryType,
 {
     type Output = Self;
 
     #[inline]
-    fn sub(self, rhs: Self) -> Self {
+    fn sub(self, rhs: Self) -> Self
+    where
+        T: ~const MemoryType,
+    {
         // TODO: new_canonical or raw?
         Self::new_canonical(self.address.saturating_sub(rhs.address))
     }
@@ -229,14 +250,17 @@ where
 
 // Computation Traits (usize)
 
-impl<T> Add<usize> for Address<T>
+impl<T> const Add<usize> for Address<T>
 where
     T: MemoryType,
 {
     type Output = Self;
 
     #[inline]
-    fn add(self, rhs: usize) -> Self {
+    fn add(self, rhs: usize) -> Self
+    where
+        T: ~const MemoryType,
+    {
         Self::new_canonical(self.address.saturating_add(rhs))
     }
 }
@@ -251,14 +275,17 @@ where
     }
 }
 
-impl<T> Sub<usize> for Address<T>
+impl<T> const Sub<usize> for Address<T>
 where
     T: MemoryType,
 {
     type Output = Self;
 
     #[inline]
-    fn sub(self, rhs: usize) -> Self {
+    fn sub(self, rhs: usize) -> Self
+    where
+        T: ~const MemoryType,
+    {
         Self::new_canonical(self.address.saturating_sub(rhs))
     }
 }
@@ -275,7 +302,7 @@ where
 
 // Conversion Traits
 
-impl<T> From<Address<T>> for usize
+impl<T> const From<Address<T>> for usize
 where
     T: MemoryType,
 {

--- a/kernel/memory_structs/src/allocator/allocated.rs
+++ b/kernel/memory_structs/src/allocator/allocated.rs
@@ -1,0 +1,207 @@
+use super::chunk_range_wrapper::{
+    ChunkRangeWrapper, ChunkRangeWrapperPhysical, ChunkRangeWrapperVirtual, MemoryRegionType,
+};
+use crate::{
+    allocator::{physical, virt},
+    Chunk, ChunkRange, MemoryType, Physical, Virtual,
+};
+use core::ops::{Deref, DerefMut};
+use log::error;
+
+#[derive(Debug)]
+pub struct AllocatedChunks<T>
+where
+    T: MemoryType,
+{
+    /// Drop can't be specialized (i.e. different drop impls for `AllocatedChunks<Virtual>` vs.
+    /// `AllocatedChunks<Physical>`). This inner type has a custom drop implementation letting
+    /// us work around the limitation.
+    inner: T::AllocatedChunksInner,
+}
+
+impl<T> AllocatedChunks<T>
+where
+    T: MemoryType,
+{
+    pub const fn new(chunks: ChunkRange<T>) -> Self
+    where
+        T::AllocatedChunksInner: ~const AllocatedChunksInner,
+    {
+        Self {
+            inner: T::AllocatedChunksInner::new(chunks),
+        }
+    }
+
+    pub const fn empty() -> Self
+    where
+        <T as MemoryType>::AllocatedChunksInner: ~const AllocatedChunksInner,
+    {
+        Self::new(ChunkRange::empty())
+    }
+
+    pub fn merge(&mut self, other: Self) -> Result<(), Self> {
+        // TODO: Different to AllocatedFrames impl.
+
+        if *self.start() == *other.end() + 1 {
+            // `other` comes contiguously before `self`
+            *self.inner = ChunkRange::new(*other.start(), *self.end());
+        } else if *self.end() + 1 == *other.start() {
+            // `self` comes contiguously before `other`
+            *self.inner = ChunkRange::new(*self.start(), *other.end());
+        } else {
+            // non-contiguous
+            return Err(other);
+        }
+
+        // Ensure the now-merged AllocatedFrames doesn't run its drop handler and free its frames.
+        core::mem::forget(other);
+        Ok(())
+    }
+
+    pub fn split(self, at_frame: Chunk<T>) -> Result<(Self, Self), Self> {
+        let end_of_first = at_frame - 1;
+
+        let (first, second) = if at_frame == *self.start() && at_frame <= *self.end() {
+            let first = ChunkRange::empty();
+            let second = ChunkRange::new(at_frame, *self.end());
+            (first, second)
+        } else if at_frame == (*self.end() + 1) && end_of_first >= *self.start() {
+            let first = ChunkRange::new(*self.start(), *self.end());
+            let second = ChunkRange::empty();
+            (first, second)
+        } else if at_frame > *self.start() && end_of_first <= *self.end() {
+            let first = ChunkRange::new(*self.start(), end_of_first);
+            let second = ChunkRange::new(at_frame, *self.end());
+            (first, second)
+        } else {
+            return Err(self);
+        };
+
+        // ensure the original AllocatedFrames doesn't run its drop handler and free its frames.
+        core::mem::forget(self);
+        Ok((Self::new(first), Self::new(second)))
+    }
+}
+
+impl<T> const Deref for AllocatedChunks<T>
+where
+    T: MemoryType,
+{
+    type Target = ChunkRange<T>;
+
+    fn deref(&self) -> &Self::Target
+    where
+        T::AllocatedChunksInner: ~const Deref,
+    {
+        self.inner.deref()
+    }
+}
+
+pub trait AllocatedChunksInner:
+    Deref<Target = ChunkRange<Self::MemoryType>> + DerefMut<Target = ChunkRange<Self::MemoryType>>
+{
+    type MemoryType: MemoryType;
+
+    fn new(chunks: ChunkRange<Self::MemoryType>) -> Self;
+}
+
+macro_rules! allocated_chunk_inner {
+    ($type:ident, $memory_type:ident) => {
+        pub struct $type {
+            chunks: ChunkRange<$memory_type>,
+        }
+
+        impl const AllocatedChunksInner for $type {
+            type MemoryType = $memory_type;
+
+            fn new(chunks: ChunkRange<Self::MemoryType>) -> Self {
+                Self { chunks }
+            }
+        }
+
+        impl const Deref for $type {
+            type Target = ChunkRange<<Self as AllocatedChunksInner>::MemoryType>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.chunks
+            }
+        }
+
+        // `DerefMut` is implemented for inner but it is NOT implemented for `AllocatedChunks<T>`.
+        impl DerefMut for $type {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.chunks
+            }
+        }
+    };
+}
+
+allocated_chunk_inner!(AllocatedChunksVirtual, Virtual);
+
+impl Drop for AllocatedChunksVirtual {
+    fn drop(&mut self) {
+        if self.size_in_chunks() == 0 {
+            return;
+        }
+
+        // Simply add the newly-deallocated chunk to the free pages list.
+        let mut locked_list = virt::FREE_PAGE_LIST.lock();
+        let res = locked_list.insert(ChunkRangeWrapper {
+            chunks: self.chunks.clone(),
+            inner: ChunkRangeWrapperVirtual,
+        });
+        match res {
+            Ok(_inserted_free_chunk) => (),
+            Err(c) => error!(
+                "BUG: couldn't insert deallocated chunk {:?} into free page list",
+                c
+            ),
+        }
+
+        // Here, we could optionally use above `_inserted_free_chunk` to merge the adjacent (contiguous) chunks
+        // before or after the newly-inserted free chunk.
+        // However, there's no *need* to do so until we actually run out of address space or until
+        // a requested address is in a chunk that needs to be merged.
+        // Thus, for performance, we save that for those future situations.
+    }
+}
+
+allocated_chunk_inner!(AllocatedChunksPhysical, Physical);
+
+impl Drop for AllocatedChunksPhysical {
+    fn drop(&mut self) {
+        if self.size_in_chunks() == 0 {
+            return;
+        }
+
+        let (list, ty) =
+            if physical::frame_is_in_list(&physical::RESERVED_REGIONS.lock(), self.start()) {
+                (
+                    &physical::FREE_RESERVED_FRAMES_LIST,
+                    MemoryRegionType::Reserved,
+                )
+            } else {
+                (&physical::FREE_GENERAL_FRAMES_LIST, MemoryRegionType::Free)
+            };
+
+        // Simply add the newly-deallocated chunk to the free frames list.
+        let mut locked_list = list.lock();
+        let res = locked_list.insert(ChunkRangeWrapper {
+            chunks: self.chunks.clone(),
+            inner: ChunkRangeWrapperPhysical { ty },
+        });
+        match res {
+            Ok(_inserted_free_chunk) => (),
+            Err(c) => error!(
+                "BUG: couldn't insert deallocated chunk {:?} into free frame list",
+                c
+            ),
+        }
+
+        // Here, we could optionally use above `_inserted_free_chunk` to merge the adjacent (contiguous) chunks
+        // before or after the newly-inserted free chunk.
+        // However, there's no *need* to do so until we actually run out of address space or until
+        // a requested address is in a chunk that needs to be merged.
+        // Thus, for performance, we save that for those future situations.
+    }
+}

--- a/kernel/memory_structs/src/allocator/chunk_range_wrapper.rs
+++ b/kernel/memory_structs/src/allocator/chunk_range_wrapper.rs
@@ -1,0 +1,120 @@
+use core::{borrow::Borrow, cmp::Ordering, ops::Deref};
+
+use super::AllocatedChunks;
+use crate::{Chunk, ChunkRange, MemoryType};
+
+#[derive(Debug, Clone, Eq)]
+pub(crate) struct ChunkRangeWrapper<T>
+where
+    T: MemoryType,
+{
+    pub(crate) chunks: ChunkRange<T>,
+    pub(crate) inner: T::ChunkRangeWrapperInner,
+}
+
+impl<T> ChunkRangeWrapper<T>
+where
+    T: MemoryType,
+{
+    const fn empty() -> Self
+    where
+        T::ChunkRangeWrapperInner: ~const ChunkRangeWrapperInner,
+    {
+        Self {
+            chunks: ChunkRange::empty(),
+            inner: T::ChunkRangeWrapperInner::empty(),
+        }
+    }
+
+    fn as_allocated_chunks(&self) -> AllocatedChunks<T> {
+        AllocatedChunks::new(self.chunks.clone())
+    }
+}
+
+impl<T> const Deref for ChunkRangeWrapper<T>
+where
+    T: MemoryType,
+{
+    type Target = ChunkRange<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.chunks
+    }
+}
+
+impl<T> Ord for ChunkRangeWrapper<T>
+where
+    T: MemoryType,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.chunks.start().cmp(other.chunks.start())
+    }
+}
+
+impl<T> PartialOrd for ChunkRangeWrapper<T>
+where
+    T: MemoryType,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> PartialEq for ChunkRangeWrapper<T>
+where
+    T: MemoryType,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.chunks.start() == other.chunks.start()
+    }
+}
+
+impl<T> Borrow<Chunk<T>> for &'_ ChunkRangeWrapper<T>
+where
+    T: MemoryType,
+{
+    fn borrow(&self) -> &Chunk<T> {
+        self.chunks.start()
+    }
+}
+
+pub trait ChunkRangeWrapperInner: core::fmt::Debug + Clone + Eq {
+    fn empty() -> Self;
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ChunkRangeWrapperVirtual;
+
+impl const ChunkRangeWrapperInner for ChunkRangeWrapperVirtual {
+    fn empty() -> Self {
+        Self
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ChunkRangeWrapperPhysical {
+    pub(crate) ty: MemoryRegionType,
+}
+
+/// Types of physical memory. See each variant's documentation.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum MemoryRegionType {
+    /// Memory that is available for any general purpose.
+    Free,
+    /// Memory that is reserved for special use and is only ever allocated from if specifically requested.
+    /// This includes custom memory regions added by third parties, e.g.,
+    /// device memory discovered and added by device drivers later during runtime.
+    Reserved,
+    /// Memory of an unknown type.
+    /// This is a default value that acts as a sanity check, because it is invalid
+    /// to do any real work (e.g., allocation, access) with an unknown memory region.
+    Unknown,
+}
+
+impl const ChunkRangeWrapperInner for ChunkRangeWrapperPhysical {
+    fn empty() -> Self {
+        Self {
+            ty: MemoryRegionType::Unknown,
+        }
+    }
+}

--- a/kernel/memory_structs/src/allocator/mod.rs
+++ b/kernel/memory_structs/src/allocator/mod.rs
@@ -1,0 +1,21 @@
+// TODO: Remove
+#![allow(dead_code)]
+
+use crate::MemoryType;
+use core::marker::PhantomData;
+
+pub(crate) mod allocated;
+pub(crate) mod chunk_range_wrapper;
+mod physical;
+mod static_array_rb_tree;
+mod virt;
+
+pub use allocated::AllocatedChunks;
+pub(crate) use static_array_rb_tree::StaticArrayRBTree;
+
+pub struct Allocator<T>
+where
+    T: MemoryType,
+{
+    phantom_data: PhantomData<fn() -> T>,
+}

--- a/kernel/memory_structs/src/allocator/physical.rs
+++ b/kernel/memory_structs/src/allocator/physical.rs
@@ -1,0 +1,51 @@
+use super::{
+    chunk_range_wrapper::ChunkRangeWrapper, static_array_rb_tree::Inner, StaticArrayRBTree,
+};
+use crate::{Chunk, Physical};
+use core::ops::Deref;
+use intrusive_collections::Bound;
+use spin::Mutex;
+
+/// The single, system-wide list of free physical memory frames available for general usage.
+pub(crate) static FREE_GENERAL_FRAMES_LIST: Mutex<StaticArrayRBTree<ChunkRangeWrapper<Physical>>> =
+    Mutex::new(StaticArrayRBTree::empty());
+/// The single, system-wide list of free physical memory frames reserved for specific usage.
+pub(crate) static FREE_RESERVED_FRAMES_LIST: Mutex<StaticArrayRBTree<ChunkRangeWrapper<Physical>>> =
+    Mutex::new(StaticArrayRBTree::empty());
+
+/// The fixed list of all known regions that are available for general use.
+/// This does not indicate whether these regions are currently allocated,
+/// rather just where they exist and which regions are known to this allocator.
+pub(crate) static GENERAL_REGIONS: Mutex<StaticArrayRBTree<ChunkRangeWrapper<Physical>>> =
+    Mutex::new(StaticArrayRBTree::empty());
+/// The fixed list of all known regions that are reserved for specific purposes.
+/// This does not indicate whether these regions are currently allocated,
+/// rather just where they exist and which regions are known to this allocator.
+pub(crate) static RESERVED_REGIONS: Mutex<StaticArrayRBTree<ChunkRangeWrapper<Physical>>> =
+    Mutex::new(StaticArrayRBTree::empty());
+
+/// Returns whether the given `Chunk<Physical>` is contained within the given `list`.
+pub(crate) fn frame_is_in_list(
+    list: &StaticArrayRBTree<ChunkRangeWrapper<Physical>>,
+    frame: &Chunk<Physical>,
+) -> bool {
+    match &list.0 {
+        Inner::Array(ref arr) => {
+            for chunk in arr.iter().flatten() {
+                if chunk.contains(frame) {
+                    return true;
+                }
+            }
+        }
+        Inner::RBTree(ref tree) => {
+            let cursor = tree.upper_bound(Bound::Included(frame));
+            if let Some(chunk) = cursor.get().map(|w| w.deref()) {
+                if chunk.contains(frame) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}

--- a/kernel/memory_structs/src/allocator/static_array_rb_tree.rs
+++ b/kernel/memory_structs/src/allocator/static_array_rb_tree.rs
@@ -1,0 +1,210 @@
+extern crate alloc;
+
+use alloc::boxed::Box;
+use core::ops::{Deref, DerefMut};
+use intrusive_collections::{
+    intrusive_adapter,
+    rbtree::{CursorMut, RBTree},
+    KeyAdapter, RBTreeLink,
+};
+
+/// A wrapper for the type stored in the `StaticArrayRBTree::Inner::RBTree` variant.
+#[derive(Debug)]
+pub struct Wrapper<T: Ord> {
+    link: RBTreeLink,
+    inner: T,
+}
+intrusive_adapter!(pub WrapperAdapter<T> = Box<Wrapper<T>>: Wrapper<T> { link: RBTreeLink } where T: Ord);
+
+// Use the inner type `T` (which must implement `Ord`) to define the key
+// for properly ordering the elements in the RBTree.
+impl<'a, T: Ord + 'a> KeyAdapter<'a> for WrapperAdapter<T> {
+    type Key = &'a T;
+    fn get_key(&self, value: &'a Wrapper<T>) -> Self::Key {
+        &value.inner
+    }
+}
+impl<T: Ord> Deref for Wrapper<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+impl<T: Ord> DerefMut for Wrapper<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+impl<T: Ord> Wrapper<T> {
+    /// Convenience method for creating a new link
+    pub(crate) fn new_link(value: T) -> Box<Self> {
+        Box::new(Wrapper {
+            link: RBTreeLink::new(),
+            inner: value,
+        })
+    }
+}
+
+/// A convenience wrapper that abstracts either an intrustive `RBTree<T>` or a primitive array `[T; N]`.
+///
+/// This allows the caller to create an array statically in a const context,
+/// and then abstract over both that and the inner `RBTree` when using it.
+///
+/// TODO: use const generics to allow this to be of any arbitrary size beyond 32 elements.
+pub struct StaticArrayRBTree<T: Ord>(pub(crate) Inner<T>);
+
+/// The inner enum, hidden for visibility reasons because Rust lacks private enum variants.
+pub(crate) enum Inner<T: Ord> {
+    Array([Option<T>; 32]),
+    RBTree(RBTree<WrapperAdapter<T>>),
+}
+
+impl<T: Ord> Default for StaticArrayRBTree<T> {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+impl<T: Ord> StaticArrayRBTree<T> {
+    const NONE: Option<T> = None;
+
+    /// Create a new empty collection (the default).
+    pub const fn empty() -> Self {
+        StaticArrayRBTree(Inner::Array([Self::NONE; 32]))
+    }
+
+    /// Create a new collection based on the given array of values.
+    pub const fn new(arr: [Option<T>; 32]) -> Self {
+        StaticArrayRBTree(Inner::Array(arr))
+    }
+}
+
+impl<T: Ord + 'static> StaticArrayRBTree<T> {
+    /// Push the given `value` into this collection.
+    ///
+    /// If the inner collection is an array, it is pushed onto the back of the array.
+    /// If there is no space left in the array, an `Err` containing the given `value` is returned.
+    ///
+    /// If success
+    pub fn insert(&mut self, value: T) -> Result<ValueRefMut<T>, T> {
+        match &mut self.0 {
+            Inner::Array(arr) => {
+                for elem in arr {
+                    if elem.is_none() {
+                        *elem = Some(value);
+                        return Ok(ValueRefMut::Array(elem));
+                    }
+                }
+                log::error!(
+                    "Out of space in StaticArrayRBTree's inner array, failed to insert value."
+                );
+                Err(value)
+            }
+            Inner::RBTree(tree) => Ok(ValueRefMut::RBTree(tree.insert(Wrapper::new_link(value)))),
+        }
+    }
+
+    /// Converts the contained collection from a primitive array into a RBTree.
+    /// If the contained collection is already using heap allocation, this is a no-op.
+    ///
+    /// Call this function once heap allocation is available.
+    pub fn convert_to_heap_allocated(&mut self) {
+        let new_tree = match &mut self.0 {
+            Inner::Array(arr) => {
+                let mut tree = RBTree::new(WrapperAdapter::new());
+                for elem in arr {
+                    if let Some(e) = elem.take() {
+                        tree.insert(Wrapper::new_link(e));
+                    }
+                }
+                tree
+            }
+            Inner::RBTree(_tree) => return,
+        };
+        *self = StaticArrayRBTree(Inner::RBTree(new_tree));
+    }
+
+    /// Returns the number of elements in this collection.
+    ///
+    /// Note that this an O(N) linear-time operation, not an O(1) constant-time operation.
+    /// This is because the internal collection types do not separately maintain their current length.
+    pub fn len(&self) -> usize {
+        match &self.0 {
+            Inner::Array(arr) => arr.iter().filter(|e| e.is_some()).count(),
+            Inner::RBTree(tree) => tree.iter().count(),
+        }
+    }
+
+    /// Returns a forward iterator over immutable references to items in this collection.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        let mut iter_a = None;
+        let mut iter_b = None;
+        match &self.0 {
+            Inner::Array(arr) => iter_a = Some(arr.iter().flatten()),
+            Inner::RBTree(tree) => iter_b = Some(tree.iter()),
+        }
+        iter_a
+            .into_iter()
+            .flatten()
+            .chain(iter_b.into_iter().flatten().map(|wrapper| &wrapper.inner))
+    }
+
+    // /// Returns a forward iterator over mutable references to items in this collection.
+    // pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+    // 	let mut iter_a = None;
+    // 	let mut iter_b = None;
+    // 	match self {
+    // 		StaticArrayRBTree::Array(arr)     => iter_a = Some(arr.iter_mut().flatten()),
+    // 		StaticArrayRBTree::RBTree(ll) => iter_b = Some(ll.iter_mut()),
+    // 	}
+    // 	iter_a.into_iter().flatten().chain(iter_b.into_iter().flatten())
+    // }
+}
+
+pub enum RemovedValue<T: Ord> {
+    Array(Option<T>),
+    RBTree(Option<Box<Wrapper<T>>>),
+}
+impl<T: Ord> RemovedValue<T> {
+    pub fn as_ref(&self) -> Option<&T> {
+        match self {
+            Self::Array(opt) => opt.as_ref(),
+            Self::RBTree(opt) => opt.as_ref().map(|bw| &bw.inner),
+        }
+    }
+}
+
+/// A mutable reference to a value in the `StaticArrayRBTree`.
+pub enum ValueRefMut<'list, T: Ord> {
+    Array(&'list mut Option<T>),
+    RBTree(CursorMut<'list, WrapperAdapter<T>>),
+}
+
+impl<'list, T: Ord> ValueRefMut<'list, T> {
+    /// Removes this value from the collection and returns the removed value, if one existed.
+    pub fn remove(&mut self) -> RemovedValue<T> {
+        match self {
+            Self::Array(ref mut arr_ref) => RemovedValue::Array(arr_ref.take()),
+            Self::RBTree(ref mut cursor_mut) => RemovedValue::RBTree(cursor_mut.remove()),
+        }
+    }
+
+    /// Removes this value from the collection and replaces it with the given `new_value`.
+    ///
+    /// Returns the removed value, if one existed. If not, the
+    pub fn replace_with(&mut self, new_value: T) -> Result<Option<T>, T> {
+        match self {
+            Self::Array(ref mut arr_ref) => Ok(arr_ref.replace(new_value)),
+            Self::RBTree(ref mut cursor_mut) => cursor_mut
+                .replace_with(Wrapper::new_link(new_value))
+                .map(|removed| Some(removed.inner))
+                .map_err(|e| e.inner),
+        }
+    }
+
+    pub fn get(&self) -> Option<&T> {
+        match self {
+            Self::Array(ref arr_ref) => arr_ref.as_ref(),
+            Self::RBTree(ref cursor_mut) => cursor_mut.get().map(|w| w.deref()),
+        }
+    }
+}

--- a/kernel/memory_structs/src/allocator/virt.rs
+++ b/kernel/memory_structs/src/allocator/virt.rs
@@ -1,0 +1,12 @@
+use super::chunk_range_wrapper::ChunkRangeWrapper;
+use crate::{allocator::StaticArrayRBTree, Address, Chunk, Virtual};
+use kernel_config::memory::KERNEL_HEAP_START;
+use spin::{Mutex, Once};
+
+pub(crate) static DESIGNATED_PAGES_LOW_END: Once<Chunk<Virtual>> = Once::new();
+
+pub(crate) static DESIGNATED_PAGES_HIGH_START: Chunk<Virtual> =
+    Chunk::containing_address(Address::new_canonical(KERNEL_HEAP_START));
+
+pub(crate) static FREE_PAGE_LIST: Mutex<StaticArrayRBTree<ChunkRangeWrapper<Virtual>>> =
+    Mutex::new(StaticArrayRBTree::empty());

--- a/kernel/memory_structs/src/chunk.rs
+++ b/kernel/memory_structs/src/chunk.rs
@@ -21,6 +21,10 @@ impl<T> Chunk<T>
 where
     T: MemoryType,
 {
+    pub const MIN: Self = Self::containing_address(Address::<T>::MIN);
+
+    pub const MAX: Self = Self::containing_address(Address::<T>::MAX);
+
     #[inline]
     pub const fn new(number: usize) -> Self {
         Self {

--- a/kernel/memory_structs/src/chunk.rs
+++ b/kernel/memory_structs/src/chunk.rs
@@ -1,0 +1,154 @@
+use crate::{Address, MemoryType, Virtual};
+use core::{
+    cmp::min,
+    fmt,
+    iter::Step,
+    marker::PhantomData,
+    ops::{Add, AddAssign, Sub, SubAssign},
+};
+use kernel_config::memory::{MAX_PAGE_NUMBER, PAGE_SIZE};
+
+/// A chunk of either physical or virtual memory aligned to a [`PAGE_SIZE`] boundary.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Chunk<T>
+where
+    T: MemoryType,
+{
+    number: usize,
+    phantom_data: PhantomData<fn() -> T>,
+}
+
+impl<T> Chunk<T>
+where
+    T: MemoryType,
+{
+    #[inline]
+    pub fn new(number: usize) -> Self {
+        Self {
+            number,
+            phantom_data: PhantomData,
+        }
+    }
+
+    /// Returns the address at the start of this chunk.
+    #[inline]
+    pub fn start_address(&self) -> Address<T> {
+        Address::<T>::new_canonical(self.number() * PAGE_SIZE)
+    }
+
+    /// Returns the number of this chunk.
+    #[inline]
+    pub fn number(&self) -> usize {
+        self.number
+    }
+
+    /// Returns the chunk containing the given address.
+    #[inline]
+    pub fn containing_address(address: Address<T>) -> Self {
+        Self::new(address.value() / PAGE_SIZE)
+    }
+}
+
+impl<T> fmt::Debug for Chunk<T>
+where
+    T: MemoryType,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({}{:#X})", T::PREFIX, self.start_address())
+    }
+}
+
+impl<T> Add<usize> for Chunk<T>
+where
+    T: MemoryType,
+{
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: usize) -> Self {
+        // Cannot exceed max page number (which is also max frame number)
+        Self::new(min(MAX_PAGE_NUMBER, self.number.saturating_add(rhs)))
+    }
+}
+
+impl<T> AddAssign<usize> for Chunk<T>
+where
+    T: MemoryType,
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: usize) {
+        *self = Self::new(min(MAX_PAGE_NUMBER, self.number.saturating_add(rhs)));
+    }
+}
+
+impl<T> Sub<usize> for Chunk<T>
+where
+    T: MemoryType,
+{
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: usize) -> Self {
+        Self::new(self.number.saturating_sub(rhs))
+    }
+}
+
+impl<T> SubAssign<usize> for Chunk<T>
+where
+    T: MemoryType,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: usize) {
+        *self = Self::new(self.number.saturating_sub(rhs));
+    }
+}
+
+/// Implementing [`Step`] allows [`Chunk`] to be used as an [`Iterator`].
+impl<T> Step for Chunk<T>
+where
+    T: MemoryType,
+{
+    #[inline]
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        Step::steps_between(&start.number, &end.number)
+    }
+
+    #[inline]
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        Step::forward_checked(start.number, count).map(|n| Self::new(n))
+    }
+
+    #[inline]
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        Step::backward_checked(start.number, count).map(|n| Self::new(n))
+    }
+}
+
+// Implement other functions for the virtual chunks (i.e. pages) that aren't relevant for physical
+// chunks (i.e. frames).
+impl Chunk<Virtual> {
+    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P4 page table entries list.
+    pub const fn p4_index(&self) -> usize {
+        (self.number >> 27) & 0x1FF
+    }
+
+    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P3 page table entries list.
+    pub const fn p3_index(&self) -> usize {
+        (self.number >> 18) & 0x1FF
+    }
+
+    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P2 page table entries list.
+    pub const fn p2_index(&self) -> usize {
+        (self.number >> 9) & 0x1FF
+    }
+
+    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P1 page table entries list.
+    ///
+    /// Returns a new seperate range that is extended to include the given chunk.
+    /// Using this returned `usize` value as an index into the P1 entries list will give you the final PTE,
+    /// from which you can extract the mapped [`Frame`]  using `PageTableEntry::pointed_frame()`.
+    pub const fn p1_index(&self) -> usize {
+        self.number & 0x1FF
+    }
+}

--- a/kernel/memory_structs/src/chunk_range.rs
+++ b/kernel/memory_structs/src/chunk_range.rs
@@ -1,0 +1,172 @@
+use crate::{Address, Chunk, MemoryType};
+use core::{
+    cmp::{max, min},
+    marker::PhantomData,
+    ops::{Deref, DerefMut, RangeInclusive},
+};
+use kernel_config::memory::PAGE_SIZE;
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct ChunkRange<T>
+where
+    T: MemoryType,
+{
+    inner: RangeInclusive<Chunk<T>>,
+    phantom_data: PhantomData<fn() -> T>,
+}
+
+impl<T> ChunkRange<T>
+where
+    T: MemoryType,
+{
+    /// Creates a new chunk that spans from `start` to `end`, both inclusize bounds.
+    #[inline]
+    pub fn new(start: Chunk<T>, end: Chunk<T>) -> Self {
+        Self {
+            inner: RangeInclusive::new(start, end),
+            phantom_data: PhantomData,
+        }
+    }
+
+    /// Creates a chunk range that will always yield [`Option::None`] when iterated.
+    #[inline]
+    pub fn empty() -> Self {
+        Self::new(Chunk::new(1), Chunk::new(0))
+    }
+
+    /// A convenience method for creating a new chunk range that spans all chunks from the given
+    /// address to an end bound based on the given size.
+    #[inline]
+    pub fn from_address(starting_addr: Address<T>, size_in_bytes: usize) -> Self {
+        assert!(size_in_bytes > 0);
+        let start = Chunk::containing_address(starting_addr);
+        // The end bound is inclusive, hence the -1. Parentheses are needed to avoid overflow.
+        let end = Chunk::containing_address(starting_addr + (size_in_bytes - 1));
+        Self::new(start, end)
+    }
+
+    /// Returns the address of the starting chunk in this range.
+    #[inline]
+    pub fn start_address(&self) -> Address<T> {
+        self.start().start_address()
+    }
+
+    /// Returns the number of chunks covered by this iterator.
+    ///
+    /// Use this instead of the [`Iterator::count()`] method. This is instant, because it doesn't
+    /// need to iterate over each entry, unlike [`Iterator::count()`].
+    #[inline]
+    pub fn size_in_chunks(&self) -> usize {
+        // Add 1 because it's an inclusive range.
+        (self.end().number() + 1).saturating_sub(self.start().number())
+    }
+
+    /// Returns the size of this range in number of bytes.
+    #[inline]
+    pub fn size_in_bytes(&self) -> usize {
+        self.size_in_chunks() * PAGE_SIZE
+    }
+
+    /// Returns true if the given address is contained by self.
+    #[inline]
+    pub fn contains_address(&self, address: Address<T>) -> bool {
+        self.inner
+            .contains(&Chunk::<T>::containing_address(address))
+    }
+
+    /// Returns the offset of the given address within this range (i.e. `addr - self.start_address()`).
+    ///
+    /// If the given address is not covered by this range of chunks, the function returns
+    /// [`Option::None`].
+    ///
+    /// # Examples
+    /// If the range covers addresses `0x2000` to `0x4000` then `offset_of_address(0x3500)` would
+    /// return `Some(0x1500)`.
+    #[inline]
+    pub fn offset_of_address(&self, addr: Address<T>) -> Option<usize> {
+        if self.contains_address(addr) {
+            Some(addr.value() - self.start_address().value())
+        } else {
+            None
+        }
+    }
+
+    /// Returns the address at the given `offset` into this chunk range (i.e. `addr - self.start_address()`).
+    ///
+    /// If the given `offset` is not within this range of chunks, the function returns [`Option::None`]
+    ///
+    /// # Examples
+    /// If the range covers addresses `0x2000` to `0x4000` then `address_at_offset(0x1500)` would
+    /// return `Some(0x3500)`.
+    #[inline]
+    pub fn address_at_offset(&self, offset: usize) -> Option<Address<T>> {
+        if offset <= self.size_in_bytes() {
+            Some(self.start_address() + offset)
+        } else {
+            None
+        }
+    }
+
+    /// Returns a new separate range that is extended to include the given chunk.
+    #[inline]
+    pub fn to_extended(&self, to_include: Chunk<T>) -> Self {
+        // If the current range was empty, return a new range containing only the given page/frame.
+        if self.is_empty() {
+            return Self::new(to_include, to_include);
+        }
+        let start = min(self.start(), &to_include);
+        let end = max(self.end(), &to_include);
+        Self::new(*start, *end)
+    }
+
+    /// Returns an inclusive chunk range representing the chunks that overlap across this chunk
+    /// range and the given chunk range.
+    ///
+    /// If there is no overlap between the two ranges, [`Option::None`] is returned.
+    #[inline]
+    pub fn overlap(&self, other: &Self) -> Option<Self> {
+        let starts = max(*self.start(), *other.start());
+        let ends = min(*self.end(), *other.end());
+        if starts <= ends {
+            Some(Self::new(starts, ends))
+        } else {
+            None
+        }
+    }
+}
+
+impl<T> Deref for ChunkRange<T>
+where
+    T: MemoryType,
+{
+    type Target = RangeInclusive<Chunk<T>>;
+
+    #[inline]
+    fn deref(&self) -> &RangeInclusive<Chunk<T>> {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for ChunkRange<T>
+where
+    T: MemoryType,
+{
+    #[inline]
+    fn deref_mut(&mut self) -> &mut RangeInclusive<Chunk<T>> {
+        &mut self.inner
+    }
+}
+
+impl<T> IntoIterator for ChunkRange<T>
+where
+    T: MemoryType,
+{
+    type Item = Chunk<T>;
+
+    type IntoIter = RangeInclusive<Chunk<T>>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner
+    }
+}

--- a/kernel/memory_structs/src/lib.rs
+++ b/kernel/memory_structs/src/lib.rs
@@ -1,467 +1,105 @@
-//! This crate contains common types used for memory mapping. 
+//! This crate contains common types used for memory mapping.
 
 #![no_std]
 #![feature(step_trait)]
 
-extern crate kernel_config;
-extern crate multiboot2;
-extern crate xmas_elf;
-#[macro_use] extern crate derive_more;
-extern crate bit_field;
-#[cfg(target_arch = "x86_64")]
-extern crate entryflags_x86_64;
-extern crate zerocopy;
-extern crate paste;
-
-
 use bit_field::BitField;
-use core::{
-    cmp::{min, max},
-    fmt,
-    iter::Step,
-    ops::{Add, AddAssign, Deref, DerefMut, RangeInclusive, Sub, SubAssign},
-};
-use kernel_config::memory::{MAX_PAGE_NUMBER, PAGE_SIZE};
+
 #[cfg(target_arch = "x86_64")]
 pub use entryflags_x86_64::EntryFlags;
-use zerocopy::FromBytes;
-use paste::paste;
 
+mod address;
+mod chunk;
+mod chunk_range;
 
-/// A macro for defining `VirtualAddress` and `PhysicalAddress` structs
-/// and implementing their common traits, which are generally identical.
-macro_rules! implement_address {
-    ($TypeName:ident, $desc:literal, $prefix:literal, $is_canonical:ident, $canonicalize:ident, $chunk:ident) => {
-        paste! { // using the paste crate's macro for easy concatenation
+pub use address::Address;
+pub use chunk::Chunk;
+pub use chunk_range::ChunkRange;
 
-            #[doc = "A " $desc " memory address, which is a `usize` under the hood."]
-            #[derive(
-                Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, 
-                Binary, Octal, LowerHex, UpperHex, 
-                BitAnd, BitOr, BitXor, BitAndAssign, BitOrAssign, BitXorAssign, 
-                Add, Sub, AddAssign, SubAssign,
-                FromBytes,
-            )]
-            #[repr(transparent)]
-            pub struct $TypeName(usize);
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Virtual;
 
-            impl $TypeName {
-                #[doc = "Creates a new `" $TypeName "`, returning an error if the address is not canonical.\n\n \
-                    This is useful for checking whether an address is valid before using it. 
-                    For example, on x86_64, virtual addresses are canonical
-                    if their upper bits `(64:48]` are sign-extended from bit 47,
-                    and physical addresses are canonical if their upper bits `(64:52]` are 0."]
-                pub fn new(addr: usize) -> Option<$TypeName> {
-                    if $is_canonical(addr) { Some($TypeName(addr)) } else { None }
-                }
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Physical;
 
-                #[doc = "Creates a new `" $TypeName "` that is guaranteed to be canonical."]
-                pub const fn new_canonical(addr: usize) -> $TypeName {
-                    $TypeName($canonicalize(addr))
-                }
-
-                #[doc = "Creates a new `" $TypeName "` with a value 0."]
-                pub const fn zero() -> $TypeName {
-                    $TypeName(0)
-                }
-
-                #[doc = "Returns the underlying `usize` value for this `" $TypeName "`."]
-                #[inline]
-                pub const fn value(&self) -> usize {
-                    self.0
-                }
-
-                #[doc = "Returns the offset from the " $chunk " boundary specified by this `"
-                    $TypeName ".\n\n \
-                    For example, if the [`PAGE_SIZE`] is 4096 (4KiB), then this will return
-                    the least significant 12 bits `(12:0]` of this `" $TypeName "`."]
-                pub const fn [<$chunk _offset>](&self) -> usize {
-                    self.0 & (PAGE_SIZE - 1)
-                }
-            }
-            impl fmt::Debug for $TypeName {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    write!(f, concat!($prefix, "{:#X}"), self.0)
-                }
-            }
-            impl fmt::Display for $TypeName {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    write!(f, "{:?}", self)
-                }
-            }
-            impl fmt::Pointer for $TypeName {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    write!(f, "{:?}", self)
-                }
-            }
-            impl Add<usize> for $TypeName {
-                type Output = $TypeName;
-                fn add(self, rhs: usize) -> $TypeName {
-                    $TypeName::new_canonical(self.0.saturating_add(rhs))
-                }
-            }
-            impl AddAssign<usize> for $TypeName {
-                fn add_assign(&mut self, rhs: usize) {
-                    *self = $TypeName::new_canonical(self.0.saturating_add(rhs));
-                }
-            }
-            impl Sub<usize> for $TypeName {
-                type Output = $TypeName;
-                fn sub(self, rhs: usize) -> $TypeName {
-                    $TypeName::new_canonical(self.0.saturating_sub(rhs))
-                }
-            }
-            impl SubAssign<usize> for $TypeName {
-                fn sub_assign(&mut self, rhs: usize) {
-                    *self = $TypeName::new_canonical(self.0.saturating_sub(rhs));
-                }
-            }
-            impl Into<usize> for $TypeName {
-                #[inline]
-                fn into(self) -> usize {
-                    self.0
-                }
-            }
-        }
-    };
+mod private {
+    pub trait Sealed {}
+    impl Sealed for super::Virtual {}
+    impl Sealed for super::Physical {}
 }
 
-#[inline]
-fn is_canonical_virtual_address(virt_addr: usize) -> bool {
-    match virt_addr.get_bits(47..64) {
-        0 | 0b1_1111_1111_1111_1111 => true,
-        _ => false,
+// TODO: Constify functions
+pub trait MemoryType:
+    private::Sealed + Clone + Copy + PartialEq + Eq + PartialOrd + Ord + core::hash::Hash + Default
+{
+    const PREFIX: &'static str;
+
+    fn is_canonical_address(address: usize) -> bool;
+
+    fn canonicalize_address(address: usize) -> usize;
+}
+
+impl MemoryType for Virtual {
+    const PREFIX: &'static str = "v";
+
+    fn is_canonical_address(address: usize) -> bool {
+        matches!(address.get_bits(47..64), 0 | 0b1_1111_1111_1111_1111)
+    }
+
+    fn canonicalize_address(address: usize) -> usize {
+        // match virt_addr.get_bit(47) {
+        //     false => virt_addr.set_bits(48..64, 0),
+        //     true =>  virt_addr.set_bits(48..64, 0xffff),
+        // };
+
+        // The below code is semantically equivalent to the above, but it works in const functions.
+        ((address << 16) as isize >> 16) as usize
     }
 }
 
-#[inline]
-const fn canonicalize_virtual_address(virt_addr: usize) -> usize {
-    // match virt_addr.get_bit(47) {
-    //     false => virt_addr.set_bits(48..64, 0),
-    //     true =>  virt_addr.set_bits(48..64, 0xffff),
-    // };
+impl MemoryType for Physical {
+    const PREFIX: &'static str = "p";
 
-    // The below code is semantically equivalent to the above, but it works in const functions.
-    ((virt_addr << 16) as isize >> 16) as usize
-}
-
-#[inline]
-fn is_canonical_physical_address(phys_addr: usize) -> bool {
-    match phys_addr.get_bits(52..64) {
-        0 => true,
-        _ => false,
-    }
-}
-
-#[inline]
-const fn canonicalize_physical_address(phys_addr: usize) -> usize {
-    phys_addr & 0x000F_FFFF_FFFF_FFFF
-}
-
-implement_address!(
-    VirtualAddress,
-    "virtual",
-    "v",
-    is_canonical_virtual_address,
-    canonicalize_virtual_address,
-    page
-);
-
-implement_address!(
-    PhysicalAddress,
-    "physical",
-    "p",
-    is_canonical_physical_address,
-    canonicalize_physical_address,
-    frame
-);
-
-
-
-/// A macro for defining `Page` and `Frame` structs
-/// and implementing their common traits, which are generally identical.
-macro_rules! implement_page_frame {
-    ($TypeName:ident, $desc:literal, $prefix:literal, $address:ident) => {
-        paste! { // using the paste crate's macro for easy concatenation
-
-            #[doc = "A `" $TypeName "` is a chunk of **" $desc "** memory aligned to a [`PAGE_SIZE`] boundary."]
-            #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-            pub struct $TypeName {
-                number: usize,
-            }
-
-            impl $TypeName {
-                #[doc = "Returns the `" $address "` at the start of this `" $TypeName "`."]
-                pub const fn start_address(&self) -> $address {
-                    $address::new_canonical(self.number * PAGE_SIZE)
-                }
-
-                #[doc = "Returns the number of this `" $TypeName "`."]
-                #[inline(always)]
-                pub const fn number(&self) -> usize {
-                    self.number
-                }
-                
-                #[doc = "Returns the `" $TypeName "` containing the given `" $address "`."]
-                pub const fn containing_address(addr: $address) -> $TypeName {
-                    $TypeName {
-                        number: addr.value() / PAGE_SIZE,
-                    }
-                }
-            }
-            impl fmt::Debug for $TypeName {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    write!(f, concat!(stringify!($TypeName), "(", $prefix, "{:#X})"), self.start_address())
-                }
-            }
-            impl Add<usize> for $TypeName {
-                type Output = $TypeName;
-                fn add(self, rhs: usize) -> $TypeName {
-                    // cannot exceed max page number (which is also max frame number)
-                    $TypeName {
-                        number: core::cmp::min(MAX_PAGE_NUMBER, self.number.saturating_add(rhs)),
-                    }
-                }
-            }
-            impl AddAssign<usize> for $TypeName {
-                fn add_assign(&mut self, rhs: usize) {
-                    *self = $TypeName {
-                        number: core::cmp::min(MAX_PAGE_NUMBER, self.number.saturating_add(rhs)),
-                    };
-                }
-            }
-            impl Sub<usize> for $TypeName {
-                type Output = $TypeName;
-                fn sub(self, rhs: usize) -> $TypeName {
-                    $TypeName {
-                        number: self.number.saturating_sub(rhs),
-                    }
-                }
-            }
-            impl SubAssign<usize> for $TypeName {
-                fn sub_assign(&mut self, rhs: usize) {
-                    *self = $TypeName {
-                        number: self.number.saturating_sub(rhs),
-                    };
-                }
-            }
-            #[doc = "Implementing `Step` allows `" $TypeName "` to be used in an [`Iterator`]."]
-            impl Step for $TypeName {
-                #[inline]
-                fn steps_between(start: &$TypeName, end: &$TypeName) -> Option<usize> {
-                    Step::steps_between(&start.number, &end.number)
-                }
-                #[inline]
-                fn forward_checked(start: $TypeName, count: usize) -> Option<$TypeName> {
-                    Step::forward_checked(start.number, count).map(|n| $TypeName { number: n })
-                }
-                #[inline]
-                fn backward_checked(start: $TypeName, count: usize) -> Option<$TypeName> {
-                    Step::backward_checked(start.number, count).map(|n| $TypeName { number: n })
-                }
-            }
-        }
-    };
-}
-
-implement_page_frame!(Page, "virtual", "v", VirtualAddress);
-implement_page_frame!(Frame, "physical", "p", PhysicalAddress);
-
-// Implement other functions for the `Page` type that aren't relevant for `Frame.
-impl Page {
-    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P4 page table entries list.
-    pub const fn p4_index(&self) -> usize {
-        (self.number >> 27) & 0x1FF
+    fn is_canonical_address(address: usize) -> bool {
+        address.get_bits(52..64) == 0
     }
 
-    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P3 page table entries list.
-    pub const fn p3_index(&self) -> usize {
-        (self.number >> 18) & 0x1FF
-    }
-
-    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P2 page table entries list.
-    pub const fn p2_index(&self) -> usize {
-        (self.number >> 9) & 0x1FF
-    }
-
-    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P1 page table entries list.
-    ///
-    /// Using this returned `usize` value as an index into the P1 entries list will give you the final PTE,
-    /// from which you can extract the mapped [`Frame`]  using `PageTableEntry::pointed_frame()`.
-    pub const fn p1_index(&self) -> usize {
-        (self.number >> 0) & 0x1FF
+    fn canonicalize_address(address: usize) -> usize {
+        address & 0x000F_FFFF_FFFF_FFFF
     }
 }
-
-
-
-/// A macro for defining `PageRange` and `FrameRange` structs
-/// and implementing their common traits, which are generally identical.
-macro_rules! implement_page_frame_range {
-    ($TypeName:ident, $desc:literal, $short:ident, $chunk:ident, $address:ident) => {
-        paste! { // using the paste crate's macro for easy concatenation
-                        
-            #[doc = "A range of [`" $chunk "`]s that are contiguous in " $desc " memory."]
-            #[derive(Clone, PartialEq, Eq)]
-            pub struct $TypeName(RangeInclusive<$chunk>);
-
-            impl $TypeName {
-                #[doc = "Creates a new range of [`" $chunk "`]s that spans from `start` to `end`, both inclusive bounds."]
-                pub const fn new(start: $chunk, end: $chunk) -> $TypeName {
-                    $TypeName(RangeInclusive::new(start, end))
-                }
-
-                #[doc = "Creates a `" $TypeName "` that will always yield `None` when iterated."]
-                pub const fn empty() -> $TypeName {
-                    $TypeName::new($chunk { number: 1 }, $chunk { number: 0 })
-                }
-
-                #[doc = "A convenience method for creating a new `" $TypeName "` that spans \
-                    all [`" $chunk "`]s from the given [`" $address "`] to an end bound based on the given size."]
-                pub fn [<from_ $short _addr>](starting_addr: $address, size_in_bytes: usize) -> $TypeName {
-                    assert!(size_in_bytes > 0);
-                    let start = $chunk::containing_address(starting_addr);
-                    // The end bound is inclusive, hence the -1. Parentheses are needed to avoid overflow.
-                    let end = $chunk::containing_address(starting_addr + (size_in_bytes - 1));
-                    $TypeName::new(start, end)
-                }
-
-                #[doc = "Returns the [`" $address "`] of the starting [`" $chunk "`] in this `" $TypeName "`."]
-                pub const fn start_address(&self) -> $address {
-                    self.0.start().start_address()
-                }
-
-                #[doc = "Returns the number of [`" $chunk "`]s covered by this iterator.\n\n \
-                    Use this instead of [`Iterator::count()`] method. \
-                    This is instant, because it doesn't need to iterate over each entry, unlike normal iterators."]
-                pub const fn [<size_in_ $chunk:lower s>](&self) -> usize {
-                    // add 1 because it's an inclusive range
-                    (self.0.end().number + 1).saturating_sub(self.0.start().number)
-                }
-
-                /// Returns the size of this range in number of bytes.
-                pub const fn size_in_bytes(&self) -> usize {
-                    self.[<size_in_ $chunk:lower s>]() * PAGE_SIZE
-                }
-
-                #[doc = "Returns `true` if this `" $TypeName "` contains the given [`" $address "`]."]
-                pub fn contains_address(&self, addr: $address) -> bool {
-                    self.0.contains(&$chunk::containing_address(addr))
-                }
-
-                #[doc = "Returns the offset of the given [`" $address "`] within this `" $TypeName "`, \
-                    i.e., `addr - self.start_address()`.\n\n \
-                    If the given `addr` is not covered by this range of [`" $chunk "`]s, this returns `None`.\n\n \
-                    # Examples\n \
-                    If the range covers addresses `0x2000` to `0x4000`, then `offset_of_address(0x3500)` would return `Some(0x1500)`."]
-                pub fn offset_of_address(&self, addr: $address) -> Option<usize> {
-                    if self.contains_address(addr) {
-                        Some(addr.value() - self.start_address().value())
-                    } else {
-                        None
-                    }
-                }
-
-                #[doc = "Returns the [`" $address "`] at the given `offset` into this `" $TypeName "`within this `" $TypeName "`, \
-                    i.e., `addr - self.start_address()`.\n\n \
-                    If the given `offset` is not within this range of [`" $chunk "`]s, this returns `None`.\n\n \
-                    # Examples\n \
-                    If the range covers addresses `0x2000` to `0x4000`, then `address_at_offset(0x1500)` would return `Some(0x3500)`."]
-                pub fn address_at_offset(&self, offset: usize) -> Option<$address> {
-                    if offset <= self.size_in_bytes() {
-                        Some(self.start_address() + offset)
-                    }
-                    else {
-                        None
-                    }
-                }
-
-                #[doc = "Returns a new separate `" $TypeName "` that is extended to include the given [`" $chunk "`]."]
-                pub fn to_extended(&self, to_include: $chunk) -> $TypeName {
-                    // if the current range was empty, return a new range containing only the given page/frame
-                    if self.is_empty() {
-                        return $TypeName::new(to_include.clone(), to_include);
-                    }
-                    let start = core::cmp::min(self.0.start(), &to_include);
-                    let end = core::cmp::max(self.0.end(), &to_include);
-                    $TypeName::new(start.clone(), end.clone())
-                }
-
-                #[doc = "Returns an inclusive `" $TypeName "` representing the [`" $chunk "`]s that overlap \
-                    across this `" $TypeName "` and the given other `" $TypeName "`.\n\n \
-                    If there is no overlap between the two ranges, `None` is returned."]
-                pub fn overlap(&self, other: &$TypeName) -> Option<$TypeName> {
-                    let starts = max(*self.start(), *other.start());
-                    let ends   = min(*self.end(),   *other.end());
-                    if starts <= ends {
-                        Some($TypeName::new(starts, ends))
-                    } else {
-                        None
-                    }
-                }
-            }
-            impl fmt::Debug for $TypeName {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    write!(f, "{:?}", self.0)
-                }
-            }
-            impl Deref for $TypeName {
-                type Target = RangeInclusive<$chunk>;
-                fn deref(&self) -> &RangeInclusive<$chunk> {
-                    &self.0
-                }
-            }
-            impl DerefMut for $TypeName {
-                fn deref_mut(&mut self) -> &mut RangeInclusive<$chunk> {
-                    &mut self.0
-                }
-            }
-            impl IntoIterator for $TypeName {
-                type Item = $chunk;
-                type IntoIter = RangeInclusive<$chunk>;
-                fn into_iter(self) -> Self::IntoIter {
-                    self.0
-                }
-            }
-        }
-    };
-}
-
-implement_page_frame_range!(PageRange, "virtual", virt, Page, VirtualAddress);
-implement_page_frame_range!(FrameRange, "physical", phys, Frame, PhysicalAddress);
-
 
 /// The address bounds and mapping flags of a section's memory region.
 #[derive(Debug)]
 pub struct SectionMemoryBounds {
     /// The starting virtual address and physical address.
-    pub start: (VirtualAddress, PhysicalAddress),
+    pub start: (Address<Virtual>, Address<Physical>),
     /// The ending virtual address and physical address.
-    pub end: (VirtualAddress, PhysicalAddress),
+    pub end: (Address<Virtual>, Address<Physical>),
     /// The page table entry flags that should be used for mapping this section.
     pub flags: EntryFlags,
 }
 
-/// The address bounds and flags of the initial kernel sections that need mapping. 
-/// 
+/// The address bounds and flags of the initial kernel sections that need mapping.
+///
 /// Individual sections in the kernel's ELF image are combined here according to their flags,
 /// as described below, but some are kept separate for the sake of correctness or ease of use.
-/// 
+///
 /// It contains three main items, in which each item includes all sections that have identical flags:
 /// * The `text` section bounds cover all sections that are executable.
 /// * The `rodata` section bounds cover those that are read-only (.rodata, .gcc_except_table, .eh_frame).
 ///   * The `rodata` section also includes thread-local storage (TLS) areas (.tdata, .tbss) if they exist,
 ///     because they can be mapped using the same page table flags.
 /// * The `data` section bounds cover those that are writable (.data, .bss).
-/// 
+///
 /// It also contains:
-/// * The `page_table` section bounds cover the initial page table's top-level (root) P4 frame. 
+/// * The `page_table` section bounds cover the initial page table's top-level (root) P4 frame.
 /// * The `stack` section bounds cover the initial stack, which are maintained separately.
 #[derive(Debug)]
 pub struct AggregatedSectionMemoryBounds {
-   pub text:        SectionMemoryBounds,
-   pub rodata:      SectionMemoryBounds,
-   pub data:        SectionMemoryBounds,
-   pub page_table:  SectionMemoryBounds,
-   pub stack:       SectionMemoryBounds,
+    pub text: SectionMemoryBounds,
+    pub rodata: SectionMemoryBounds,
+    pub data: SectionMemoryBounds,
+    pub page_table: SectionMemoryBounds,
+    pub stack: SectionMemoryBounds,
 }


### PR DESCRIPTION
This is an implementation of the first dot point under "Rust Oriented" projects in the [wiki](https://github.com/theseus-os/Theseus/wiki). It uses generics on `Address<T>`, `Chunk<T>` and `ChunkRange<T>` to differentiate between physical and virtual memory (e.g. `Address<Physical>` is equivalent to `PhysicalAddress`, `Chunk<Physical>` is equivalent to `Frame`).

I'm not too sure about the naming of `Chunk` and `ChunkRange`. The Theseus book explicitly uses frames to refer to physical memory, and pages to refer to virtual memory, but online, the line is blurred (usually physical = "Page Frame" and virtual = "Virtual Page"). @jkugelman suggested renaming `Chunk` to `Page`, and I think that does make sense, but it would require changing the terminology across the entire project. The term `Chunk` also conflicts with the `Chunk` struct in the allocators.