### PR TITLE
Upgrade `qp-trie` to `v0.8.0` which supports `no_std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,8 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "qp-trie"
-version = "0.7.3"
-source = "git+https://github.com/theseus-os/qp-trie-rs#847923565622e909795bfc96309bc69ed4aa6689"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a075ecba64154fed5429568c9c6a0e0eccc3276209e93e6133206413ea6834b4"
 dependencies = [
  "new_debug_unreachable",
  "unreachable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,8 +106,6 @@ spin = { git = "https://github.com/theseus-os/spin-rs" }
 volatile = { git = "https://github.com/theseus-os/volatile" }
 ### use our own no_std-compatilbe getopts
 getopts = { git = "https://github.com/theseus-os/getopts" }
-### use our own no_std-compatible qp trie
-qp-trie = { git = "https://github.com/theseus-os/qp-trie-rs" }
 ### use the latest version of smoltcp from github; the one on crates.io is out of date
 smoltcp = { git = "https://github.com/m-labs/smoltcp" }
 

--- a/applications/heap_eval/Cargo.toml
+++ b/applications/heap_eval/Cargo.toml
@@ -5,7 +5,7 @@ description = "Benchmarks to evaluate Theseus's heap design"
 authors = ["Ramla Ijaz <ijazramla@gmail.com>"]
 
 [dependencies]
-qp-trie = "0.7.3"
+qp-trie = "0.8.0"
 getopts = "0.2.21"
 
 [dependencies.terminal_print]

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -1041,3 +1041,9 @@ pub fn write_relocation(
 
     Ok(())
 }
+
+
+/// A wrapper around an `Arc<str>`: an immutable shared reference to a string.
+#[derive(Debug)]
+pub struct BStrRef(Arc<str>);
+

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -1041,9 +1041,3 @@ pub fn write_relocation(
 
     Ok(())
 }
-
-
-/// A wrapper around an `Arc<str>`: an immutable shared reference to a string.
-#[derive(Debug)]
-pub struct BStrRef(Arc<str>);
-

--- a/kernel/crate_swap/Cargo.toml
+++ b/kernel/crate_swap/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 
 [dependencies]
 spin = "0.9.0"
-qp-trie = "0.7.3"
+qp-trie = "0.8.0"
 by_address = "1.0.4"
 
 

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 spin = "0.9.0"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 rustc-demangle = "0.1.19"
-qp-trie = "0.7.3"
+qp-trie = "0.8.0"
 cstr_core = "0.2.3"
 rangemap = "0.1.13"
 const_format = "0.2.2"

--- a/libtheseus/Cargo.toml
+++ b/libtheseus/Cargo.toml
@@ -44,8 +44,6 @@ spin = { git = "https://github.com/theseus-os/spin-rs" }
 volatile = { git = "https://github.com/theseus-os/volatile" }
 ### use our own no_std-compatilbe getopts
 getopts = { git = "https://github.com/theseus-os/getopts" }
-### use our own no_std-compatible qp trie
-qp-trie = { git = "https://github.com/theseus-os/qp-trie-rs" }
 ### use the latest version of smoltcp from github; the one on crates.io is out of date
 smoltcp = { git = "https://github.com/m-labs/smoltcp" }
 

--- a/tlibc/Cargo.toml
+++ b/tlibc/Cargo.toml
@@ -54,7 +54,5 @@ spin = { git = "https://github.com/theseus-os/spin-rs" }
 volatile = { git = "https://github.com/theseus-os/volatile" }
 ### use our own no_std-compatilbe getopts
 getopts = { git = "https://github.com/theseus-os/getopts" }
-### use our own no_std-compatible qp trie
-qp-trie = { git = "https://github.com/theseus-os/qp-trie-rs" }
 ### use the latest version of smoltcp from github; the one on crates.io is out of date
 smoltcp = { git = "https://github.com/m-labs/smoltcp" }

--- a/tools/diff_crates/Cargo.toml
+++ b/tools/diff_crates/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 [dependencies]
 getopts = "0.2"
 walkdir = "2.2.7"
-qp-trie = "0.7.3"
+qp-trie = "0.8.0"
 multimap = "0.4.0"
 spin = "0.5.0"
 serde_json = "1.0.39"


### PR DESCRIPTION
Our fork is no longer needed.