### PR TITLE
Use shared string references for section names to save heap memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,9 +562,12 @@ dependencies = [
  "fs_node",
  "goblin",
  "hashbrown",
+ "lazy_static",
  "log",
  "memory",
+ "qp-trie",
  "spin 0.9.0",
+ "str_ref",
  "xmas-elf",
 ]
 
@@ -2999,6 +3002,10 @@ dependencies = [
  "spin 0.9.0",
  "storage_device",
 ]
+
+[[package]]
+name = "str_ref"
+version = "0.1.0"
 
 [[package]]
 name = "swap"

--- a/applications/deps/src/lib.rs
+++ b/applications/deps/src/lib.rs
@@ -24,6 +24,7 @@ use alloc::{
     vec::Vec,
     sync::Arc,
 };
+use memory::VirtualAddress;
 use spin::Once;
 use getopts::{Matches, Options};
 use mod_mgmt::{
@@ -57,6 +58,7 @@ pub fn main(args: Vec<String>) -> isize {
     let mut opts = Options::new();
     opts.optflag("h", "help",             "print this help menu");
     opts.optflag("v", "verbose",          "enable verbose output");
+    opts.optopt ("a", "address",          "output the section that contains the given ADDRESS",      "ADDRESS");
     opts.optopt ("s", "sections-in",      "output the sections that depend on the given SECTION (incoming weak dependents)",      "SECTION");
     opts.optopt ("S", "sections-out",     "output the sections that the given SECTION depends on (outgoing strong dependencies)", "SECTION");
     opts.optopt ("c", "crates-in",        "output the crates that depend on the given CRATE (incoming weak dependents)",          "CRATE");
@@ -98,7 +100,10 @@ pub fn main(args: Vec<String>) -> isize {
 fn rmain(matches: Matches) -> Result<(), String> {
     if verbose!() { println!("MATCHES: {:?}", matches.free); }
 
-    if let Some(sec_name) = matches.opt_str("s") {
+    if let Some(addr) = matches.opt_str("a") {
+        section_containing_address(&addr)
+    }
+    else if let Some(sec_name) = matches.opt_str("s") {
         sections_dependent_on_me(&sec_name)
     }
     else if let Some(sec_name) = matches.opt_str("S") {
@@ -130,6 +135,30 @@ fn rmain(matches: Matches) -> Result<(), String> {
     }
     else {
         Err(format!("no supported options/arguments found."))
+    }
+}
+
+
+
+/// Outputs the section containing the given address, i.e., symbolication.
+/// 
+fn section_containing_address(addr: &str) -> Result<(), String> {
+    let addr = if addr.starts_with("0x") || addr.starts_with("0X") {
+        &addr[2..]
+    } else {
+        addr
+    };
+    
+    let virt_addr = VirtualAddress::new(
+        usize::from_str_radix(addr, 16)
+            .map_err(|_| format!("Error: address {:?} is not a valid hexademical usize value", addr))?
+    ).ok_or_else(|| format!("Error: address {:?} is not a valid VirtualAddress", addr))?;
+
+    if let Some((sec, offset)) = get_my_current_namespace().get_section_containing_address(virt_addr, false) {
+        println!("Found {:>#018X} in {} + {:#X}, typ: {:?}", virt_addr, sec.name, offset, sec.typ);
+        Ok(())
+    } else {
+        Err(format!("Couldn't find section containing address {:>#018X}", virt_addr))
     }
 }
 
@@ -396,7 +425,7 @@ fn find_section(section_name: &str) -> Result<StrongSectionRef, String> {
     if matching_sections.len() == 1 { 
         Ok(matching_sections.remove(0))
     } else {
-        Err(matching_sections.into_iter().map(|sec| sec.name.clone()).collect::<Vec<String>>().join("\n"))
+        Err(matching_sections.into_iter().map(|sec| sec.name.clone()).collect::<Vec<_>>().join("\n"))
     }
 }
 

--- a/kernel/crate_metadata/Cargo.toml
+++ b/kernel/crate_metadata/Cargo.toml
@@ -3,15 +3,22 @@ name = "crate_metadata"
 version = "0.1.0"
 description = "Types for tracking loaded crates and their dependency metadata within Theseus's CrateNamespaces"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
-
+edition = "2018"
 
 [dependencies]
 spin = "0.9.0"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
+qp-trie = "0.8.0"
 
+[dependencies.str_ref]
+path = "../../libs/str_ref"
 
 [dependencies.log]
 version = "0.4.8"
+
+[dependencies.lazy_static]
+features = ["spin_no_std"]
+version = "1.4.0"
 
 ### used for linker relocation typedefs
 [dependencies.goblin]

--- a/kernel/memory/src/paging/mapper.rs
+++ b/kernel/memory/src/paging/mapper.rs
@@ -414,47 +414,47 @@ impl MappedPages {
     }
 
     
-    // Removing this function for now since it's unused and untested.
-    // /// Creates a deep copy of this `MappedPages` memory region,
-    // /// by duplicating not only the virtual memory mapping
-    // /// but also the underlying physical memory frames. 
-    // /// 
-    // /// The caller can optionally specify new flags for the duplicated mapping,
-    // /// otherwise, the same flags as the existing `MappedPages` will be used. 
-    // /// This is useful for when you want to modify contents in the new pages,
-    // /// since it avoids extra `remap()` operations.
-    // /// 
-    // /// Returns a new `MappedPages` object with the same in-memory contents
-    // /// as this object, but at a completely new memory region.
-    // pub fn deep_copy(&self, new_flags: Option<EntryFlags>, active_table_mapper: &mut Mapper) -> Result<MappedPages, &'static str> {
-    //     let size_in_pages = self.size_in_pages();
+    /// Creates a deep copy of this `MappedPages` memory region,
+    /// by duplicating not only the virtual memory mapping
+    /// but also the underlying physical memory frames. 
+    /// 
+    /// The caller can optionally specify new flags for the duplicated mapping,
+    /// otherwise, the same flags as the existing `MappedPages` will be used. 
+    /// This is useful for when you want to modify contents in the new pages,
+    /// since it avoids extra `remap()` operations.
+    /// 
+    /// Returns a new `MappedPages` object with the same in-memory contents
+    /// as this object, but at a completely new memory region.
+    pub fn deep_copy(&self, new_flags: Option<EntryFlags>, active_table_mapper: &mut Mapper) -> Result<MappedPages, &'static str> {
+        warn!("MappedPages::deep_copy() has not been adequately tested yet.");
+        let size_in_pages = self.size_in_pages();
 
-    //     use paging::allocate_pages;
-    //     let new_pages = allocate_pages(size_in_pages).ok_or_else(|| "Couldn't allocate_pages()")?;
+        use paging::allocate_pages;
+        let new_pages = allocate_pages(size_in_pages).ok_or_else(|| "Couldn't allocate_pages()")?;
 
-    //     // we must temporarily map the new pages as Writable, since we're about to copy data into them
-    //     let new_flags = new_flags.unwrap_or(self.flags);
-    //     let needs_remapping = new_flags.is_writable(); 
-    //     let mut new_mapped_pages = active_table_mapper.map_allocated_pages(
-    //         new_pages, 
-    //         new_flags | EntryFlags::WRITABLE, // force writable
-    //     )?;
+        // we must temporarily map the new pages as Writable, since we're about to copy data into them
+        let new_flags = new_flags.unwrap_or(self.flags);
+        let needs_remapping = !new_flags.is_writable(); 
+        let mut new_mapped_pages = active_table_mapper.map_allocated_pages(
+            new_pages, 
+            new_flags | EntryFlags::WRITABLE, // force writable
+        )?;
 
-    //     // perform the actual copy of in-memory content
-    //     // TODO: there is probably a better way to do this, e.g., `rep stosq/movsq` or something
-    //     {
-    //         type PageContent = [u8; PAGE_SIZE];
-    //         let source: &[PageContent] = self.as_slice(0, size_in_pages)?;
-    //         let dest: &mut [PageContent] = new_mapped_pages.as_slice_mut(0, size_in_pages)?;
-    //         dest.copy_from_slice(source);
-    //     }
+        // perform the actual copy of in-memory content
+        // TODO: there is probably a better way to do this, e.g., `rep stosq/movsq` or something
+        {
+            type PageContent = [u8; PAGE_SIZE];
+            let source: &[PageContent] = self.as_slice(0, size_in_pages)?;
+            let dest: &mut [PageContent] = new_mapped_pages.as_slice_mut(0, size_in_pages)?;
+            dest.copy_from_slice(source);
+        }
 
-    //     if needs_remapping {
-    //         new_mapped_pages.remap(active_table_mapper, new_flags)?;
-    //     }
+        if needs_remapping {
+            new_mapped_pages.remap(active_table_mapper, new_flags)?;
+        }
         
-    //     Ok(new_mapped_pages)
-    // }
+        Ok(new_mapped_pages)
+    }
 
     
     /// Change the permissions (`new_flags`) of this `MappedPages`'s page table entries.

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -1442,8 +1442,11 @@ impl CrateNamespace {
 
             // Fifth, if neither executable nor TLS nor writable nor .rodata, handle the `.gcc_except_table` sections
             else if sec_name.starts_with(GCC_EXCEPT_TABLE_PREFIX) {
-                let name = try_get_symbol_name_after_prefix!(sec_name, GCC_EXCEPT_TABLE_PREFIX);
-                let demangled = demangle(name).to_string().into();
+                // We don't need to waste space keeping the name of the `.gcc_exept_table` section, 
+                // because that name is irrelevant and will never be used.
+                //
+                // let name = try_get_symbol_name_after_prefix!(sec_name, GCC_EXCEPT_TABLE_PREFIX);
+                // let demangled = demangle(name).to_string().into();
 
                 // gcc_except_table sections are read-only, so we put them in the .rodata pages
                 if let Some((ref rp_ref, ref mut rp)) = read_only_pages_locked {
@@ -1464,12 +1467,12 @@ impl CrateNamespace {
                         shndx, 
                         Arc::new(LoadedSection::new(
                             SectionType::GccExceptTable,
-                            demangled,
+                            GCC_EXCEPT_TABLE_STR_REF.clone(),
                             Arc::clone(rp_ref),
                             rodata_offset,
                             dest_vaddr,
                             sec_size,
-                            false, // .gcc_except_table sections are not globally visible,
+                            false, // .gcc_except_table sections are never globally visible,
                             new_crate_weak_ref.clone(),
                         ))
                     );

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -15,7 +15,7 @@ use xmas_elf::{self, ElfFile, sections::{SHF_ALLOC, SHF_EXECINSTR, SHF_TLS, SHF_
 use rustc_demangle::demangle;
 use cstr_core::CStr;
 use memory::{VirtualAddress, MappedPages};
-use crate_metadata::{LoadedCrate, StrongCrateRef, LoadedSection, StrongSectionRef, SectionType, Shndx};
+use crate_metadata::{LoadedCrate, StrongCrateRef, LoadedSection, StrongSectionRef, SectionType, Shndx, StrRef, EH_FRAME_STR_REF, GCC_EXCEPT_TABLE_STR_REF};
 use hashbrown::HashMap;
 use path::Path;
 use super::CrateNamespace;
@@ -248,7 +248,7 @@ fn parse_nano_core_symbol_file(
                 section_counter,
                 Arc::new(LoadedSection::new(
                     SectionType::EhFrame,
-                    String::from(".eh_frame"),
+                    EH_FRAME_STR_REF.clone(),
                     Arc::clone(&rodata_pages),
                     mapped_pages_offset,
                     sec_vaddr,
@@ -268,7 +268,7 @@ fn parse_nano_core_symbol_file(
                 section_counter,
                 Arc::new(LoadedSection::new(
                     SectionType::GccExceptTable,
-                    String::from(".gcc_except_table"),
+                    GCC_EXCEPT_TABLE_STR_REF.clone(),
                     Arc::clone(&rodata_pages),
                     mapped_pages_offset,
                     sec_vaddr,
@@ -380,7 +380,7 @@ fn parse_nano_core_symbol_file(
                 &new_crate_weak_ref,
                 &mut section_counter,
                 sec_ndx,
-                String::from(name),
+                StrRef::from(name),
                 sec_size,
                 sec_vaddr,
                 global
@@ -500,7 +500,7 @@ fn parse_nano_core_binary(
                     section_counter,
                     Arc::new(LoadedSection::new(
                         SectionType::GccExceptTable,
-                        String::from(".gcc_except_table"),
+                        GCC_EXCEPT_TABLE_STR_REF.clone(),
                         Arc::clone(&rodata_pages),
                         mapped_pages_offset,
                         sec_vaddr,
@@ -520,7 +520,7 @@ fn parse_nano_core_binary(
                     section_counter,
                     Arc::new(LoadedSection::new(
                         SectionType::EhFrame,
-                        String::from(".eh_frame"),
+                        EH_FRAME_STR_REF.clone(),
                         Arc::clone(&rodata_pages),
                         mapped_pages_offset,
                         sec_vaddr,
@@ -575,7 +575,7 @@ fn parse_nano_core_binary(
                         &new_crate_weak_ref,
                         &mut section_counter,
                         entry.shndx() as usize,
-                        demangled,
+                        demangled.into(),
                         sec_size,
                         sec_vaddr_value,
                         global
@@ -640,7 +640,7 @@ fn add_new_section(
     section_counter:     &mut Shndx,
     // crate-wide args above, section-specific stuff below
     sec_ndx: Shndx,
-    sec_name: String,
+    sec_name: StrRef,
     sec_size: usize,
     sec_vaddr: usize,
     global: bool,
@@ -750,7 +750,7 @@ fn add_new_section(
         Some(tls_section)
     }
     else {
-        crate_items.init_symbols.insert(sec_name, sec_vaddr);
+        crate_items.init_symbols.insert(String::from(sec_name.as_str()), sec_vaddr);
         None
     };
 

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -15,7 +15,7 @@ use xmas_elf::{self, ElfFile, sections::{SHF_ALLOC, SHF_EXECINSTR, SHF_TLS, SHF_
 use rustc_demangle::demangle;
 use cstr_core::CStr;
 use memory::{VirtualAddress, MappedPages};
-use crate_metadata::{LoadedCrate, StrongCrateRef, LoadedSection, StrongSectionRef, SectionType, Shndx, StrRef, EH_FRAME_STR_REF, GCC_EXCEPT_TABLE_STR_REF};
+use crate_metadata::*;
 use hashbrown::HashMap;
 use path::Path;
 use super::CrateNamespace;

--- a/kernel/mod_mgmt/src/replace_nano_core_crates.rs
+++ b/kernel/mod_mgmt/src/replace_nano_core_crates.rs
@@ -50,7 +50,7 @@ pub fn replace_nano_core_crates(
 
     let mut constituent_crates = BTreeSet::new();
     for sec in nano_core_crate.global_sections_iter() {
-        for n in super::get_containing_crate_name(&sec.name) {
+        for n in super::get_containing_crate_name(sec.name.as_str()) {
             constituent_crates.insert(String::from(n));
         }
     }

--- a/libs/str_ref/Cargo.toml
+++ b/libs/str_ref/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "str_ref"
+description = "A shared immutable reference to a `str`, essentially `Arc<str>` that is borrowable as a byte slice"
+version = "0.1.0"
+

--- a/libs/str_ref/src/lib.rs
+++ b/libs/str_ref/src/lib.rs
@@ -1,0 +1,91 @@
+//! An immutable shared reference to a string, effectively `Arc<str>`.
+
+#![no_std]
+
+extern crate alloc;
+
+use core::{
+    borrow::Borrow,
+    hash::{Hash, Hasher},
+    fmt,
+    ops::Deref,
+    str,
+};
+use alloc::{
+    sync::Arc,
+    string::String,
+};
+
+/// A wrapper around an `Arc<str>`: an immutable shared reference to a string.
+/// 
+/// This can be borrowed and hashed as a slice of bytes because it implements `Borrow<[u8]>`, 
+/// which is useful for compatibility with crates like `qp_trie`.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StrRef(Arc<str>);
+
+impl Deref for StrRef {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl Clone for StrRef {
+    fn clone(&self) -> Self {
+        StrRef(Arc::clone(&self.0))
+    }
+}
+
+impl core::fmt::Display for StrRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<String> for StrRef {
+    fn from(s: String) -> Self {
+        StrRef(s.into())
+    }
+}
+
+impl From<&str> for StrRef {
+    fn from(s: &str) -> Self {
+        StrRef(Arc::from(s))
+    }
+}
+
+impl Borrow<str> for StrRef {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<[u8]> for StrRef {
+    #[inline]
+    fn borrow(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+#[allow(clippy::derive_hash_xor_eq)]
+impl Hash for StrRef {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_bytes().hash(state);
+    }
+}
+
+impl AsRef<str> for StrRef {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl StrRef {
+    /// Obtain a reference to the inner `str`.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}


### PR DESCRIPTION
Previously, each namespace's symbol map had a duplicate copy of every section's full name, which is quite wasteful.

Now we deduplicate them using the `StrRef` type, effectively an `Arc<str>`, which reduces heap usage by about 20% (or more in `cfg(loadable)` mode).

Adds a frontend interface in the `deps` application to query which section a virtual address corresponds to, e.g., similar to `addr2line` symbolication.

Also fixes small bug around the parsing of `.gcc_exept_table` sections.

