### PR TITLE
Deduplicate crate name strings

### DIFF
--- a/applications/deps/src/lib.rs
+++ b/applications/deps/src/lib.rs
@@ -20,7 +20,7 @@ extern crate spin;
 
 use alloc::{
     collections::BTreeSet,
-    string::{String},
+    string::String,
     vec::Vec,
     sync::Arc,
 };
@@ -30,7 +30,7 @@ use getopts::{Matches, Options};
 use mod_mgmt::{
     StrongCrateRef,
     StrongSectionRef,
-    CrateNamespace,
+    CrateNamespace, StrRef,
 };
 use crate_name_utils::get_containing_crate_name;
 
@@ -372,7 +372,7 @@ fn sections_in_crate(crate_name: &str, all_sections: bool) -> Result<(), String>
 /// 
 /// If there are multiple matches, this returns an Error containing 
 /// all of the matching section names separated by the newline character `'\n'`.
-fn find_crate(crate_name: &str) -> Result<(String, StrongCrateRef), String> {
+fn find_crate(crate_name: &str) -> Result<(StrRef, StrongCrateRef), String> {
     let namespace = get_my_current_namespace();
     let mut matching_crates = CrateNamespace::get_crates_starting_with(&namespace, crate_name);
     match matching_crates.len() {
@@ -381,7 +381,7 @@ fn find_crate(crate_name: &str) -> Result<(String, StrongCrateRef), String> {
             let mc = matching_crates.swap_remove(0);
             Ok((mc.0, mc.1)) 
         }
-        _ => Err(matching_crates.into_iter().map(|(crate_name, _crate_ref, _ns)| crate_name).collect::<Vec<String>>().join("\n")),
+        _ => Err(matching_crates.into_iter().map(|(crate_name, _crate_ref, _ns)| crate_name).collect::<Vec<_>>().join("\n")),
     }
 }
 

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -185,7 +185,7 @@ impl CrateType {
 /// loaded and linked into at least one `CrateNamespace`.
 pub struct LoadedCrate {
     /// The name of this crate.
-    pub crate_name: String,
+    pub crate_name: StrRef,
     /// The object file that this crate was loaded from.
     pub object_file: FileRef,
     /// The file that contains debug symbols for this crate. 

--- a/kernel/fault_log/src/lib.rs
+++ b/kernel/fault_log/src/lib.rs
@@ -166,14 +166,14 @@ fn update_and_insert_fault_entry_internal(
 
     // If task is from an application add application crate name. `None` if not 
     fe.running_app_crate = {
-        curr_task.app_crate.as_ref().map(|x| x.lock_as_ref().crate_name.clone())
+        curr_task.app_crate.as_ref().map(|x| x.lock_as_ref().crate_name.to_string())
     };
 
     if let Some(instruction_pointer) = instruction_pointer {
         let instruction_pointer = VirtualAddress::new_canonical(instruction_pointer);
         fe.instruction_pointer = Some(instruction_pointer);
         fe.crate_error_occured = namespace.get_crate_containing_address(instruction_pointer.clone(), false)
-                                        .map(|x| x.lock_as_ref().crate_name.clone());
+                                        .map(|x| x.lock_as_ref().crate_name.to_string());
     };
 
     // Push the fault entry.

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -831,7 +831,7 @@ impl CrateNamespace {
             
         #[cfg(not(loscd_eval))]
         info!("loaded new crate {:?}, num sections: {}, added {} new symbols.", new_crate_name, _num_sections, new_syms);
-        self.crate_tree.lock().insert(new_crate_name.into(), new_crate_ref.clone_shallow());
+        self.crate_tree.lock().insert(new_crate_name, new_crate_ref.clone_shallow());
         Ok((new_crate_ref, new_syms))
     }
 
@@ -1254,7 +1254,7 @@ impl CrateNamespace {
                 } else {
                     name
                 };
-                let demangled = demangle(name).to_string().into();
+                let demangled = demangle(name).to_string().as_str().into();
 
                 // We already copied the content of all .text sections above, 
                 // so here we just record the metadata into a new `LoadedSection` object.
@@ -1293,7 +1293,7 @@ impl CrateNamespace {
                 } else {
                     try_get_symbol_name_after_prefix!(sec_name, TLS_DATA_PREFIX)
                 };
-                let demangled = demangle(name).to_string().into();
+                let demangled = demangle(name).to_string().as_str().into();
 
                 if let Some((ref rp_ref, ref mut rp)) = read_only_pages_locked {
                     let (mapped_pages_offset, sec_typ) = if is_bss {
@@ -1362,7 +1362,7 @@ impl CrateNamespace {
                         //     }
                         // })
                 };
-                let demangled = demangle(name).to_string().into();
+                let demangled = demangle(name).to_string().as_str().into();
                 
                 if let Some((ref dp_ref, ref mut dp)) = read_write_pages_locked {
                     // here: we're ready to copy the data/bss section to the proper address
@@ -1403,7 +1403,7 @@ impl CrateNamespace {
             // Fourth, if neither executable nor TLS nor writable, handle .rodata sections.
             else if sec_name.starts_with(RODATA_PREFIX) {
                 let name = try_get_symbol_name_after_prefix!(sec_name, RODATA_PREFIX);
-                let demangled = demangle(name).to_string().into();
+                let demangled = demangle(name).to_string().as_str().into();
 
                 if let Some((ref rp_ref, ref mut rp)) = read_only_pages_locked {
                     // here: we're ready to copy the rodata section to the proper address

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -402,7 +402,7 @@ impl Drop for AppCrateRef {
             for sec_to_remove in crate_locked.global_sections_iter() {
                 match symbol_map.remove(&sec_to_remove.name) {
                     Some(_removed) => {
-                        trace!("Removed symbol {}: {:?}", sec_to_remove.name, _removed.upgrade());
+                        // trace!("Removed symbol {}: {:?}", sec_to_remove.name, _removed.upgrade());
                     }
                     None => {
                         error!("NOTE: couldn't find old symbol {:?} in the old crate {:?} to remove from namespace {:?}.", sec_to_remove.name, crate_locked.crate_name, self.namespace.name());
@@ -545,9 +545,9 @@ impl CrateNamespace {
 
     /// Returns a list of all of the crate names currently loaded into this `CrateNamespace`,
     /// including all crates in any recursive namespaces as well if `recursive` is `true`.
-    /// This is a slow method mostly for debugging, since it allocates new Strings for each crate name.
-    pub fn crate_names(&self, recursive: bool) -> Vec<String> {
-        let mut crates: Vec<String> = self.crate_tree.lock().keys().map(|n| String::from(n.as_str())).collect();
+    /// This is a slow method mostly for debugging, since it allocates a new vector of crate names.
+    pub fn crate_names(&self, recursive: bool) -> Vec<StrRef> {
+        let mut crates: Vec<StrRef> = self.crate_tree.lock().keys().map(|n| n.clone()).collect();
 
         if recursive {
             if let Some(mut crates_recursive) = self.recursive_namespace.as_ref().map(|r_ns| r_ns.crate_names(recursive)) {

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -575,7 +575,7 @@ fn parse_nano_core_binary(
                         &new_crate_weak_ref,
                         &mut section_counter,
                         entry.shndx() as usize,
-                        demangled.into(),
+                        demangled.as_str().into(),
                         sec_size,
                         sec_vaddr_value,
                         global

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -78,7 +78,7 @@ pub fn parse_nano_core(
     let nano_core_file_path = Path::new(nano_core_file.lock().get_absolute_path());
     debug!("parse_nano_core: trying to load and parse the nano_core file: {:?}", nano_core_file_path);
 
-    let crate_name = String::from(NANO_CORE_CRATE_NAME);
+    let crate_name = StrRef::from(NANO_CORE_CRATE_NAME);
 
     // Create the LoadedCrate instance to represent the nano_core. 
     // It will be properly populated in one of the parse_nano_core_* functions below
@@ -124,7 +124,7 @@ pub fn parse_nano_core(
     }
 
     // Add the newly-parsed nano_core crate to the kernel namespace.
-    real_namespace.crate_tree.lock().insert(crate_name.into(), nano_core_crate_ref.clone_shallow());
+    real_namespace.crate_tree.lock().insert(crate_name, nano_core_crate_ref.clone_shallow());
     info!("Finished parsing nano_core crate, {} new symbols.", new_syms);
     // trace!("TlsInitializer after parse_nano_core(): {:#?}", &*real_namespace.tls_initializer.lock());
     // trace!("TlsInitializer data after parse_nano_core(): {:02X?}", real_namespace.tls_initializer.lock().get_data());

--- a/kernel/mod_mgmt/src/replace_nano_core_crates.rs
+++ b/kernel/mod_mgmt/src/replace_nano_core_crates.rs
@@ -107,7 +107,7 @@ fn load_crate_using_nano_core_data_sections(
     // (1) Load the crate's sections. We won't end up using the newly-loaded .data/.bss sections, but that's fine.
     let (new_crate_ref, elf_file) = namespace.load_crate_sections(&*cf, kernel_mmi_ref, verbose_log)?;
 
-    let new_crate_name: String; 
+    let new_crate_name; 
     let _num_new_syms: usize;
     let _num_new_sections: usize;
 
@@ -156,6 +156,6 @@ fn load_crate_using_nano_core_data_sections(
         new_crate_name, _num_new_sections, _num_new_syms
     );
     // (6) Add the newly-loaded crate to the namespace.
-    namespace.crate_tree.lock().insert(new_crate_name.into(), new_crate_ref.clone_shallow());
+    namespace.crate_tree.lock().insert(new_crate_name, new_crate_ref.clone_shallow());
     Ok(new_crate_ref)
 }

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -35,7 +35,7 @@ extern crate thread_local_macro;
 use core::{marker::PhantomData, mem, ops::Deref};
 use alloc::{
     vec::Vec,
-    string::String,
+    string::{String, ToString},
     sync::Arc,
     boxed::Box,
 };
@@ -165,7 +165,7 @@ pub fn new_application_task_builder(
     // Create the underlying task builder. 
     // Give it a default name based on the app crate's name, but that can be changed later. 
     let mut tb = TaskBuilder::new(*main_func, MainFuncArg::default())
-        .name(app_crate_ref.lock_as_ref().crate_name.clone()); 
+        .name(app_crate_ref.lock_as_ref().crate_name.to_string()); 
 
     // Once the new application task is created (but before its scheduled in),
     // ensure it has the relevant app-specific fields set properly.

--- a/libs/str_ref/src/lib.rs
+++ b/libs/str_ref/src/lib.rs
@@ -35,7 +35,7 @@ impl Clone for StrRef {
 
 impl fmt::Debug for StrRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
+        write!(f, "{:?}", self.as_str())
     }
 }
 

--- a/libs/str_ref/src/lib.rs
+++ b/libs/str_ref/src/lib.rs
@@ -11,16 +11,13 @@ use core::{
     ops::Deref,
     str,
 };
-use alloc::{
-    sync::Arc,
-    string::String,
-};
+use alloc::sync::Arc;
 
-/// A wrapper around an `Arc<str>`: an immutable shared reference to a string.
+/// A wrapper around an `Arc<str>`: an immutable shared reference to a string slice.
 /// 
 /// This can be borrowed and hashed as a slice of bytes because it implements `Borrow<[u8]>`, 
 /// which is useful for compatibility with crates like `qp_trie`.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct StrRef(Arc<str>);
 
 impl Deref for StrRef {
@@ -36,15 +33,15 @@ impl Clone for StrRef {
     }
 }
 
-impl core::fmt::Display for StrRef {
+impl fmt::Debug for StrRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
-impl From<String> for StrRef {
-    fn from(s: String) -> Self {
-        StrRef(s.into())
+impl fmt::Display for StrRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 


### PR DESCRIPTION
This is effectively the same as #549 but applies to `LoadedCrate::crate_name` instead of `LoadedSection::name`.

Basically, each `CrateNamespace`'s `crate_tree` map has a duplicate allocated String of every crate's full name. We deduplicate them using the `StrRef` type, effectively an Arc<str>.