### PR TITLE
Tasks should only be able to access their kill handler

### DIFF
--- a/applications/test_panic/src/lib.rs
+++ b/applications/test_panic/src/lib.rs
@@ -15,11 +15,11 @@ use alloc::boxed::Box;
 pub fn main(_args: Vec<String>) -> isize {
     info!("test_panic::main(): at top");
 
-    let _res = task::set_my_kill_handler(Box::new(|kill_reason| {
+    let _res = task::set_kill_handler(Box::new(|kill_reason| {
         println!("test_panic: caught a kill action: {}", kill_reason);
     }));
 
-    info!("test_panic::main(): registering kill handler... {:?}.", _res);
+    info!("test_panic::main(): registered kill handler? {:?}.", _res);
 
     match _args.get(0).map(|s| &**s) {
         // indexing test

--- a/applications/unwind_test/src/lib.rs
+++ b/applications/unwind_test/src/lib.rs
@@ -22,7 +22,7 @@ impl Drop for MyStruct {
 
 #[inline(never)]
 fn foo(cause_page_fault: bool) {
-    let _res = task::set_my_kill_handler(Box::new(|kill_reason| {
+    let _res = task::set_kill_handler(Box::new(|kill_reason| {
         info!("unwind_test: caught kill action at {}", kill_reason);
     }));
     

--- a/kernel/exceptions_full/src/lib.rs
+++ b/kernel/exceptions_full/src/lib.rs
@@ -167,19 +167,13 @@ fn kill_and_halt(
     let cause = task::KillReason::Exception(exception_number);
 
     // Call this task's kill handler, if it has one.
-    {
-        let kill_handler = task::get_my_current_task().and_then(|t| t.take_kill_handler());
-        if let Some(ref kh_func) = kill_handler {
-
-            #[cfg(not(downtime_eval))]
-            debug!("Found kill handler callback to invoke in Task {:?}", task::get_my_current_task());
-
-            kh_func(&cause);
-        }
-        else {
-            #[cfg(not(downtime_eval))]
-            debug!("No kill handler callback in Task {:?}", task::get_my_current_task());
-        }
+    if let Some(ref kh_func) = task::take_kill_handler() {
+        #[cfg(not(downtime_eval))]
+        debug!("Found kill handler callback to invoke in Task {:?}", task::get_my_current_task());
+        kh_func(&cause);
+    } else {
+        #[cfg(not(downtime_eval))]
+        debug!("No kill handler callback in Task {:?}", task::get_my_current_task());
     }
 
     // Invoke the proper signal handler registered for this task, if one exists.

--- a/kernel/panic_wrapper/src/lib.rs
+++ b/kernel/panic_wrapper/src/lib.rs
@@ -89,15 +89,11 @@ pub fn panic_wrapper(panic_info: &PanicInfo) -> Result<(), &'static str> {
     error!("------------------------------------------------------------------");
 
     // Call this task's kill handler, if it has one.
-    {
-        let kill_handler = task::get_my_current_task().and_then(|t| t.take_kill_handler());
-        if let Some(ref kh_func) = kill_handler {
-            debug!("Found kill handler callback to invoke in Task {:?}", task::get_my_current_task());
-            kh_func(&KillReason::Panic(PanicInfoOwned::from(panic_info)));
-        }
-        else {
-            debug!("No kill handler callback in Task {:?}", task::get_my_current_task());
-        }
+    if let Some(ref kh_func) = task::take_kill_handler() {
+        debug!("Found kill handler callback to invoke in Task {:?}", task::get_my_current_task());
+        kh_func(&KillReason::Panic(PanicInfoOwned::from(panic_info)));
+    } else {
+        debug!("No kill handler callback in Task {:?}", task::get_my_current_task());
     }
 
     // Start the unwinding process


### PR DESCRIPTION
Kill handlers should not be accessible from other tasks, since we don't want nor have any need for one task to set or unset the kill handler for a different task.