### PR TITLE
Use a build script to clone the 'wasmtime' git repo on demand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ target/
 # Build directory
 build/
 
+# Dynamically cloned git repo for wasmtime
+ports/wasmtime/
+
 # Generated documentation, used for GitHub Pages
 github_pages/book/
 github_pages/doc/

--- a/theseus_features/build.rs
+++ b/theseus_features/build.rs
@@ -1,0 +1,48 @@
+#![feature(path_try_exists)]
+
+use core::panic;
+use std::{fs, process::Command};
+
+fn main() {
+    clone_wasmtime_repo();
+}
+
+static REPO_URL: &str = "https://github.com/theseus-os/wasmtime.git";
+static REPO_BRANCH: &str = "theseus";
+
+static ROOT_PORTS_WASMTIME_DIR: &str = "ports/wasmtime";
+
+
+/// Clone the wasmtime repo to the proper location above.
+/// 
+/// Any errors here should be translated to panics to ensure the build process fails.
+fn clone_wasmtime_repo() {
+    let path_to_wasmtime_repo = std::env::current_dir().unwrap()
+        .parent().unwrap()
+        .join(ROOT_PORTS_WASMTIME_DIR);
+
+    if fs::try_exists(&path_to_wasmtime_repo).unwrap() {
+        eprintln!("Note: the path {:?} already exists, not cloning the 'wasmtime' repo.", path_to_wasmtime_repo);
+        return;
+    } else {
+        eprintln!("Note: the path {:?} did not exist, proceeding to clone the 'wasmtime' repo.", path_to_wasmtime_repo);
+    }
+
+    let status = Command::new("git")
+        .arg("clone")
+        .arg("--depth").arg("1")
+        // .arg("--recursive")
+        .arg(REPO_URL)
+        .arg("-b")
+        .arg(REPO_BRANCH)
+        .arg(&path_to_wasmtime_repo)
+        .status()
+        .expect("Failed to execute 'git' command");
+
+    if status.success() {
+        eprintln!("Successfully cloned wasmtime git repo to {:?}", path_to_wasmtime_repo);
+    } else {
+        panic!("git clone of wasmtime repo failed with error code {:?}", status.code());
+    }
+
+}


### PR DESCRIPTION
In the future we should move this into a separate crate instead of having it reside in the `theseus_features` crate. Then `theseus_features` should optionally depend on and thus build that other crate if a "wasmtime"-like feature is enabled.

This is a bit of a hack to get around around two issues:
* cargo not being able to check out a git/registry dependency to a specific location in the project workspace (e.g., `ports/wasmtime`)
* git submodules not being "optional"