### PR TITLE
Use shallow cloning for all git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	path = libs/object
 	url = https://github.com/theseus-os/object.git
 	shallow = true
-[submodule "libs/libc"]
+[submodule "ports/libc"]
 	path = ports/libc
 	url = https://github.com/theseus-os/libc.git
 	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,25 +1,32 @@
 [submodule "libs/dfqueue"]
 	path = libs/dfqueue
 	url = https://github.com/theseus-os/DFQueue
-	ignore = dirty
+	shallow = true
 [submodule "libs/object"]
 	path = libs/object
 	url = https://github.com/theseus-os/object.git
+	shallow = true
 [submodule "libs/libc"]
 	path = ports/libc
 	url = https://github.com/theseus-os/libc.git
+	shallow = true
 [submodule "libs/indexmap"]
 	path = libs/indexmap
 	url = https://github.com/theseus-os/indexmap
+	shallow = true
 [submodule "ports/region"]
 	path = ports/region
 	url = https://github.com/theseus-os/region-rs
+	shallow = true
 [submodule "ports/backtrace"]
 	path = ports/backtrace
 	url = https://github.com/theseus-os/backtrace-rs.git
+	shallow = true
 [submodule "libs/thiserror-core2"]
 	path = libs/thiserror-core2
 	url = https://github.com/theseus-os/thiserror-core2.git
+	shallow = true
 [submodule "libs/core2"]
 	path = libs/core2
 	url = https://github.com/theseus-os/core2.git
+	shallow = true


### PR DESCRIPTION
Speeds up the `git clone` process when downloading all the submodules.