### PR TITLE
Pre-calculate section offsets when serializing `nano_core`

### DIFF
--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -193,10 +193,10 @@ fn parse_nano_core_symbol_file_or_binary(
     new_crate_mut.global_sections = parsed_crate_items.global_sections;
     new_crate_mut.data_sections   = parsed_crate_items.data_sections;
     
-    // Dump loaded sections for verification. See pull request #559 for more details:
-    for (_, section) in new_crate_mut.sections.iter() {
-        trace!("{:016x} {} {}", section.address_range.start.value(), section.name, section.mapped_pages_offset);
-    }
+    // // Dump loaded sections for verification. See pull request #559 for more details:
+    // for (_, section) in new_crate_mut.sections.iter() {
+    //     trace!("{:016x} {} {}", section.address_range.start.value(), section.name, section.mapped_pages_offset);
+    // }
 
     drop(new_crate_mut);
 

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -192,6 +192,12 @@ fn parse_nano_core_symbol_file_or_binary(
     new_crate_mut.sections        = parsed_crate_items.sections;
     new_crate_mut.global_sections = parsed_crate_items.global_sections;
     new_crate_mut.data_sections   = parsed_crate_items.data_sections;
+    
+    // Dump loaded sections for verification. See pull request #559 for more details:
+    for (_, section) in new_crate_mut.sections.iter() {
+        trace!("{:016x} {} {}", section.address_range.start.value(), section.name, section.mapped_pages_offset);
+    }
+
     drop(new_crate_mut);
 
     // Add the newly-parsed nano_core crate to the kernel namespace.

--- a/kernel/mod_mgmt/src/serde.rs
+++ b/kernel/mod_mgmt/src/serde.rs
@@ -110,12 +110,12 @@ impl SerializedCrate {
             num_new_syms
         );
         
-        // Dump loaded sections for verification. See pull request #542/#559 for more details:
-        let loaded_crate_ref = loaded_crate.lock_as_ref();
-        for (_, section) in loaded_crate_ref.sections.iter() {
-            trace!("{:016x} {} {}", section.address_range.start.value(), section.name, section.mapped_pages_offset);
-        }
-        drop(loaded_crate_ref);
+        // // Dump loaded sections for verification. See pull request #542/#559 for more details:
+        // let loaded_crate_ref = loaded_crate.lock_as_ref();
+        // for (_, section) in loaded_crate_ref.sections.iter() {
+        //     trace!("{:016x} {} {}", section.address_range.start.value(), section.name, section.mapped_pages_offset);
+        // }
+        // drop(loaded_crate_ref);
 
         Ok((loaded_crate, self.init_symbols, num_new_syms))
     }

--- a/kernel/mod_mgmt/src/serde.rs
+++ b/kernel/mod_mgmt/src/serde.rs
@@ -110,12 +110,12 @@ impl SerializedCrate {
             num_new_syms
         );
         
-        // Dump loaded sections for verification. See pull request #542 for more details:
-        // let loaded_crate_ref = loaded_crate.lock_as_ref();
-        // for (_, section) in loaded_crate_ref.sections.iter() {
-        //     trace!("{:016x} {}", section.address_range.start.value(), section.name);
-        // }
-        // drop(loaded_crate_ref);
+        // Dump loaded sections for verification. See pull request #542/#559 for more details:
+        let loaded_crate_ref = loaded_crate.lock_as_ref();
+        for (_, section) in loaded_crate_ref.sections.iter() {
+            trace!("{:016x} {} {}", section.address_range.start.value(), section.name, section.mapped_pages_offset);
+        }
+        drop(loaded_crate_ref);
 
         Ok((loaded_crate, self.init_symbols, num_new_syms))
     }
@@ -134,7 +134,7 @@ pub struct SerializedSection {
     pub global: bool,
     /// The starting [`VirtualAddress`] of the range covered by this section.
     pub virtual_address: usize,
-    /// This field is identical to `self.virtual_address` unless this is a thread local section.
+    /// The offset into the [`MappedPages`] where this section starts.
     pub offset: usize,
     /// The size of the section.
     pub size: usize,
@@ -170,20 +170,7 @@ impl SerializedSection {
             },
             typ: self.ty,
             global: self.global,
-            // TLS BSS sections (.tbss) do not have any real loaded data in the ELF file,
-            // since they are read-only initializer sections that would hold all zeroes.
-            // Thus, we just use a max-value mapped pages offset as a canary value here,
-            // as that value should never be used anyway.
-            mapped_pages_offset: match self.ty {
-                SectionType::TlsBss => usize::MAX,
-                _ => mapped_pages
-                    .lock()
-                    .offset_of_address(
-                        VirtualAddress::new(self.offset)
-                            .ok_or("SerializedSection::into_loaded_section(): invalid offset")?,
-                    )
-                    .ok_or("nano_core section wasn't covered by its mapped pages")?,
-            },
+            mapped_pages_offset: self.offset,
             mapped_pages,
             address_range: virtual_address..(virtual_address + self.size),
             parent_crate,

--- a/tools/serialize_nano_core/Cargo.lock
+++ b/tools/serialize_nano_core/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "bincode",
  "crate_metadata",
  "hashbrown",
+ "kernel_config",
  "memory",
  "mod_mgmt",
  "serde",

--- a/tools/serialize_nano_core/Cargo.toml
+++ b/tools/serialize_nano_core/Cargo.toml
@@ -9,6 +9,7 @@ description = "Creates a serialized representation of the symbols in the `nano_c
 crate_metadata = { path = "../../kernel/crate_metadata" }
 mod_mgmt = { path = "../../kernel/mod_mgmt" }
 memory = { path = "../../kernel/memory" }
+kernel_config = { path = "../../kernel/kernel_config" }
 hashbrown = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/tools/serialize_nano_core/src/parse.rs
+++ b/tools/serialize_nano_core/src/parse.rs
@@ -100,8 +100,6 @@ pub fn parse_nano_core_symbol_file(symbol_str: String) -> Result<ParsedCrateItem
                     ty: SectionType::EhFrame,
                     global: false, // .eh_frame is not global
                     virtual_address,
-                    // .eh_frame is contained in .rodata and so its .symtab entry is guaranteed to be
-                    // after.
                     offset: virtual_address - rodata.expect(".eh_frame parsed before .rodata").1,
                     size,
                 },
@@ -120,8 +118,6 @@ pub fn parse_nano_core_symbol_file(symbol_str: String) -> Result<ParsedCrateItem
                     ty: SectionType::GccExceptTable,
                     global: false, // .gcc_except_table is not global
                     virtual_address,
-                    // .gcc_except_table is contained in .rodata and so its .symtab entry is guaranteed to be
-                    // after.
                     offset: virtual_address - rodata.expect(".gcc_except_table parsed before .rodata").1,
                     size,
                 },
@@ -281,10 +277,7 @@ pub struct ParsedCrateItems {
 }
 
 /// The section header indices (shndx) and starting virtual addresses for the main sections:
-/// .text, .rodata, .data, and .bss.
-///
-/// If TLS sections are present, e.g., .tdata or .tbss, their `shndx`s and starting virtual
-/// addresses are also included.
+/// .text, .rodata, .data, .bss, .tdata, and .tbss, if they exist
 struct MainSections {
     text: (Shndx, usize),
     rodata: (Shndx, usize),


### PR DESCRIPTION
`serialize_nano_core` now parses the section header addresses and uses them
to pre-calculate the offsets of `.symtab` entries.

Closes #546.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>