### PR TITLE
Fix most clippy::perf items in root workspace

### DIFF
--- a/applications/less/src/lib.rs
+++ b/applications/less/src/lib.rs
@@ -68,14 +68,14 @@ fn get_content_string(file_path: String) -> Result<String, String> {
                         Ok(num) => num,
                         Err(e) => {
                             return Err(format!("Failed to read {:?}, error {:?}",
-                                               file_locked.get_name(), e).to_string())
+                                               file_locked.get_name(), e))
                         }
                     };
                     let read_string = match str::from_utf8(&string_slice_as_bytes) {
                         Ok(string_slice) => string_slice,
                         Err(utf8_err) => {
                             return Err(format!("File {:?} was not a printable UTF-8 text file: {}",
-                                               file_locked.get_name(), utf8_err).to_string())
+                                               file_locked.get_name(), utf8_err))
                         }
                     };
                     Ok(read_string.to_string())
@@ -83,7 +83,7 @@ fn get_content_string(file_path: String) -> Result<String, String> {
             }
         },
         _ => {
-            Err(format!("Couldn't find file at path {}", path).to_string())
+            Err(format!("Couldn't find file at path {}", path))
         }
     }
 }

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -545,7 +545,7 @@ impl Shell {
                 return Ok(());
             } else { // start a new job
                 self.terminal.lock().print_to_terminal("\n".to_string());
-                self.command_history.push(cmdline.clone());
+                self.command_history.push(cmdline);
                 self.command_history.dedup(); // Removes any duplicates
                 self.history_index = 0;
 
@@ -561,7 +561,6 @@ impl Shell {
                         if last == "&" {
                             self.terminal.lock().print_to_terminal(
                                 format!("[{}] [running] {}\n", new_job_num, self.cmdline)
-                                .to_string()
                             );
                             self.fg_job_num = None;
                             self.clear_cmdline(false)?;
@@ -694,7 +693,7 @@ impl Shell {
         let cmdline = self.cmdline.clone();
         let mut task_refs = Vec::new();
 
-        for single_task_cmd in cmdline.split("|") {
+        for single_task_cmd in cmdline.split('|') {
             let mut args: Vec<String> = single_task_cmd.split_whitespace().map(|s| s.to_string()).collect();
             let command = args.remove(0);
 
@@ -758,7 +757,7 @@ impl Shell {
 
                     // Insert print event producer to `terminal_print` to support legacy output.
                     if let Err(msg) = terminal_print::add_child(*task_id, self.print_producer.obtain_producer()) {
-                        self.terminal.lock().print_to_terminal(format!("{}\n", msg).to_string());
+                        self.terminal.lock().print_to_terminal(format!("{}\n", msg));
                         return Err(msg);
                     }
                 }
@@ -807,7 +806,7 @@ impl Shell {
                 };
                 self.terminal.lock().print_to_terminal(err_msg);
                 if let Err(msg) = self.clear_cmdline(false) {
-                    self.terminal.lock().print_to_terminal(format!("{}\n", msg).to_string());
+                    self.terminal.lock().print_to_terminal(format!("{}\n", msg));
                 }
                 self.redisplay_prompt();
                 Err("Failed to evaluate command line.")
@@ -844,7 +843,7 @@ impl Shell {
         // Drop the extension name and hash value.
         let mut clean_name = String::new();
         for name in names.iter_mut() {
-            if let Some(prefix) = name.split("-").next() {
+            if let Some(prefix) = name.split('-').next() {
                 clean_name = prefix.to_string();
             }
             if !clean_name.is_empty() {
@@ -880,7 +879,7 @@ impl Shell {
         };
 
         // Split the path by slash and filter out consecutive slashes.
-        let mut nodes: Vec<_> = incomplete_cmd.split("/").filter(|node| { node.len() > 0 }).collect();
+        let mut nodes: Vec<_> = incomplete_cmd.split('/').filter(|node| { node.len() > 0 }).collect();
 
         // Get the last node in the path, which is to be completed.
         let incomplete_node = {
@@ -1005,13 +1004,13 @@ impl Shell {
 
         // Get the last string slice in the pipe chain.
         let cmdline = self.cmdline[0..self.cmdline.len()-self.terminal.lock().get_cursor_offset_from_end()].to_string();
-        let last_cmd_in_pipe = match cmdline.split("|").last() {
+        let last_cmd_in_pipe = match cmdline.split('|').last() {
             Some(cmd) => cmd,
             None => return Ok(())
         };
 
         // Get the last word in the args (or maybe the command name itself).
-        let last_word_in_cmd = match last_cmd_in_pipe.split(" ").last() {
+        let last_word_in_cmd = match last_cmd_in_pipe.split(' ').last() {
             Some(word) => word.to_string(),
             None => return Ok(())
         };
@@ -1438,7 +1437,7 @@ impl Shell {
                     self.redisplay_prompt();
                     return Ok(());
                 }
-                self.terminal.lock().print_to_terminal(format!("No job number {} found!\n", job_num).to_string());
+                self.terminal.lock().print_to_terminal(format!("No job number {} found!\n", job_num));
                 return Ok(());
             }
         }
@@ -1469,7 +1468,7 @@ impl Shell {
                     }
                     return Ok(());
                 }
-                self.terminal.lock().print_to_terminal(format!("No job number {} found!\n", job_num).to_string());
+                self.terminal.lock().print_to_terminal(format!("No job number {} found!\n", job_num));
                 return Ok(());
             }
         }

--- a/kernel/acpi/src/lib.rs
+++ b/kernel/acpi/src/lib.rs
@@ -73,7 +73,7 @@ pub fn init(page_table: &mut PageTable) -> Result<(), &'static str> {
     // The RSDT/XSDT tells us where all of the rest of the ACPI tables exist.
     {
         let mut acpi_tables = ACPI_TABLES.lock();
-        for sdt_paddr in sdt_addresses.clone() {
+        for sdt_paddr in sdt_addresses {
             // debug!("RXSDT entry: {:#X}", sdt_paddr);
             let (sdt_signature, sdt_total_length) = acpi_tables.map_new_table(sdt_paddr, page_table)?;
             acpi_table_handler(&mut acpi_tables, sdt_signature, sdt_total_length, sdt_paddr)?;

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -59,7 +59,7 @@ pub fn kstart_ap(processor_id: u8, apic_id: u8,
 
     // get the stack that was allocated for us (this AP) by the BSP.
     let this_ap_stack = AP_STACKS.lock().remove(&apic_id)
-        .expect(&format!("BUG: kstart_ap(): couldn't get stack created for AP with apic_id: {}", apic_id));
+        .unwrap_or_else(|| panic!("BUG: kstart_ap(): couldn't get stack created for AP with apic_id: {}", apic_id));
 
     // initialize interrupts (including TSS/GDT) for this AP
     let kernel_mmi_ref = get_kernel_mmi_ref().expect("kstart_ap(): kernel_mmi ref was None");

--- a/kernel/fault_crate_swap/src/lib.rs
+++ b/kernel/fault_crate_swap/src/lib.rs
@@ -318,9 +318,7 @@ pub fn self_swap_handler(crate_name: &str) -> Result<SwapRanges, String> {
     let verbose = false;
     let state_transfer_functions: Vec<String> = Vec::new();
 
-    let mut tuples: Vec<(&str, &str, bool)> = Vec::new();
-
-    tuples.push((crate_name, crate_name , false));
+    let tuples: Vec<(&str, &str, bool)> = vec![(crate_name, crate_name , false)];
 
     #[cfg(not(downtime_eval))]
     debug!("tuples: {:?}", tuples);
@@ -344,7 +342,7 @@ pub fn self_swap_handler(crate_name: &str) -> Result<SwapRanges, String> {
         }
         Err(e) => {
             debug!("SWAP FAILED at do_self_swap");
-            return Err(e.to_string())
+            return Err(e)
         }
     };
 

--- a/kernel/fault_log/src/lib.rs
+++ b/kernel/fault_log/src/lib.rs
@@ -204,7 +204,7 @@ pub fn log_panic_entry(panic_info: &PanicInfo) {
     if let Some(location) = panic_info.location() {
         // debug!("panic occurred in file '{}' at line {}", location.file(), location.line());
         let panic_file = location.file();
-        let mut error_crate_iter = panic_file.split("/");
+        let mut error_crate_iter = panic_file.split('/');
         error_crate_iter.next();
         let error_crate_name_simple = error_crate_iter.next().unwrap_or_else(|| panic_file);
         debug!("panic file {}",error_crate_name_simple);
@@ -259,7 +259,7 @@ pub fn get_the_most_recent_match(error_crate : &str) -> Option<FaultEntry> {
     for fault_entry in FAULT_LIST.lock().iter() {
         if let Some(crate_error_occured) = &fault_entry.crate_error_occured {
             let error_crate_name = crate_error_occured.clone();
-            let error_crate_name_simple = error_crate_name.split("-").next().unwrap_or_else(|| &error_crate_name);
+            let error_crate_name_simple = error_crate_name.split('-').next().unwrap_or_else(|| &error_crate_name);
             if error_crate_name_simple == error_crate {
                 let item = fault_entry.clone();
                 fe = Some(item);

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -1156,7 +1156,7 @@ impl CrateNamespace {
         }
 
         let new_crate = CowArc::new(LoadedCrate {
-            crate_name:              crate_name.clone(),
+            crate_name:              crate_name,
             debug_symbols_file:      Arc::downgrade(&crate_object_file),
             object_file:             crate_object_file, 
             sections:                HashMap::new(),

--- a/kernel/mod_mgmt/src/serde.rs
+++ b/kernel/mod_mgmt/src/serde.rs
@@ -104,7 +104,7 @@ impl SerializedCrate {
         namespace
             .crate_tree
             .lock()
-            .insert(crate_name.clone(), loaded_crate.clone_shallow());
+            .insert(crate_name, loaded_crate.clone_shallow());
         info!(
             "Finished parsing nano_core crate, {} new symbols.",
             num_new_syms

--- a/kernel/ota_update_client/src/lib.rs
+++ b/kernel/ota_update_client/src/lib.rs
@@ -192,14 +192,14 @@ pub fn parse_diff_lines(diffs: &Vec<String>) -> Result<Diff, &'static str> {
     let mut state_transfer_functions: Vec<String> = Vec::new();
     for diff in diffs {
         // addition of new crate
-        if diff.starts_with("+") {
+        if diff.starts_with('+') {
             pairs.push((
                 String::new(), 
                 diff.get(1..).ok_or("error parsing (+) diff line")?.trim().to_string(),
             ));
         } 
         // removal of old crate
-        else if diff.starts_with("-") {
+        else if diff.starts_with('-') {
             pairs.push((
                 diff.get(1..).ok_or("error parsing (-) diff line")?.trim().to_string(), 
                 String::new()
@@ -210,7 +210,7 @@ pub fn parse_diff_lines(diffs: &Vec<String>) -> Result<Diff, &'static str> {
             pairs.push((old.trim().to_string(), new.trim().to_string()));
         }
         // state transfer function
-        else if diff.starts_with("@") {
+        else if diff.starts_with('@') {
             state_transfer_functions.push(
                 diff.get(1..).ok_or("error parsing (@state_transfer) diff line")?.trim().to_string(),
             )

--- a/kernel/page_allocator/src/lib.rs
+++ b/kernel/page_allocator/src/lib.rs
@@ -323,8 +323,8 @@ impl<'list> DeferredAllocAction<'list> {
 			  F2: Into<Option<Chunk>>,
 	{
 		let free_list = &FREE_PAGE_LIST;
-		let free1 = free1.into().unwrap_or(Chunk::empty());
-		let free2 = free2.into().unwrap_or(Chunk::empty());
+		let free1 = free1.into().unwrap_or_else(Chunk::empty);
+		let free2 = free2.into().unwrap_or_else(Chunk::empty);
 		DeferredAllocAction { free_list, free1, free2 }
 	}
 }

--- a/kernel/path/src/lib.rs
+++ b/kernel/path/src/lib.rs
@@ -119,9 +119,9 @@ impl Path {
         new_components.extend(current_path.components());
         // Push components of the path to the components of the new path
         for component in self.components() {
-            if component == String::from(".") {
+            if component == "." {
                 continue;
-            } else if component == String::from("..") {
+            } else if component == ".." {
                 new_components.pop();
             } else {
                 new_components.push(component);

--- a/kernel/root/src/lib.rs
+++ b/kernel/root/src/lib.rs
@@ -85,7 +85,7 @@ impl Directory for RootDirectory {
 impl FsNode for RootDirectory {
     /// Recursively gets the absolute pathname as a String
     fn get_absolute_path(&self) -> String {
-        format!("{}/", ROOT_DIRECTORY_NAME.to_string()).to_string()
+        format!("{}/", ROOT_DIRECTORY_NAME)
     }
 
     fn get_name(&self) -> String {

--- a/kernel/task_fs/src/lib.rs
+++ b/kernel/task_fs/src/lib.rs
@@ -82,7 +82,7 @@ impl TaskFs {
         let parent_dir = self.get_self_pointer().ok_or("BUG: tasks directory wasn't in root")?;
         let dir_name = task_ref.id.to_string(); 
         // lazily compute a new TaskDir everytime the caller wants to get a TaskDir
-        let task_dir = TaskDir::new(dir_name, &parent_dir, task_ref.clone())?;        
+        let task_dir = TaskDir::new(dir_name, &parent_dir, task_ref)?;        
         let boxed_task_dir = Arc::new(Mutex::new(task_dir)) as DirRef;
         Ok(FileOrDir::Dir(boxed_task_dir))
     }
@@ -187,9 +187,7 @@ impl Directory for TaskDir {
 
     /// Returns a string listing all the children in the directory
     fn list(&self) -> Vec<String> {
-        let mut children = Vec::new();
-        children.push("mmi".to_string());
-        children.push("taskInfo".to_string());
+        let children = vec!["mmi".to_string(), "taskInfo".to_string()];
         children
     }
 
@@ -239,8 +237,8 @@ impl TaskFile {
     /// Generates the task info string.
     fn generate(&self) -> String {
         // Print all tasks
-        let cpu = self.taskref.running_on_cpu().map(|cpu| format!("{}", cpu)).unwrap_or(String::from("-"));
-        let pinned = &self.taskref.pinned_core().map(|pin| format!("{}", pin)).unwrap_or(String::from("-"));
+        let cpu = self.taskref.running_on_cpu().map(|cpu| format!("{}", cpu)).unwrap_or_else(|| String::from("-"));
+        let pinned = &self.taskref.pinned_core().map(|pin| format!("{}", pin)).unwrap_or_else(|| String::from("-"));
         let task_type = if self.taskref.is_an_idle_task {
             "I"
         } else if self.taskref.is_application() {
@@ -355,8 +353,7 @@ impl Directory for MmiDir {
 
     /// Returns a string listing all the children in the directory
     fn list(&self) -> Vec<String> {
-        let mut children = Vec::new();
-        children.push("MmiInfo".to_string());
+        let children = vec!["MmiInfo".to_string()];
         children
     }
 

--- a/kernel/wasi_interpreter/src/lib.rs
+++ b/kernel/wasi_interpreter/src/lib.rs
@@ -91,7 +91,7 @@ pub fn execute_binary(wasm_binary: Vec<u8>, args: Vec<String>, preopen_dirs: Vec
             // Currently supports `wasi_snapshot_preview1`.
             if wasm_interface.eq("wasi_snapshot_preview1") {
                 let system_call = SystemCall::from_str(fn_name)
-                    .expect(&format!("Unknown WASI function {}", fn_name));
+                    .unwrap_or_else(|_| panic!("Unknown WASI function {}", fn_name));
                 // Verify that signature of system call matches expected signature.
                 if fn_signature.eq(&system_call.into()) {
                     return Ok(system_call.into());

--- a/kernel/window_manager/src/lib.rs
+++ b/kernel/window_manager/src/lib.rs
@@ -263,9 +263,9 @@ impl WindowManager {
                 src_framebuffer: window.framebuffer(),
                 coordinate_in_dest_framebuffer: window.get_position(),
             }
-        }).collect::<Vec<_>>();
+        });
         
-        let buffer_iter = Some(bottom_fb_area).into_iter().chain(window_bufferlist.into_iter());
+        let buffer_iter = Some(bottom_fb_area).into_iter().chain(window_bufferlist);
         FRAME_COMPOSITOR.lock().composite(buffer_iter, &mut self.final_fb, bounding_box)?;
         
         Ok(())
@@ -314,9 +314,9 @@ impl WindowManager {
                 src_framebuffer: window.framebuffer(),
                 coordinate_in_dest_framebuffer: window.get_position(),
             }
-        }).collect::<Vec<_>>();
+        });
 
-        FRAME_COMPOSITOR.lock().composite(bufferlist.into_iter(), &mut self.final_fb, bounding_box)
+        FRAME_COMPOSITOR.lock().composite(bufferlist, &mut self.final_fb, bounding_box)
     }
 
 


### PR DESCRIPTION
Addresses #526 

The below items suggested by Clippy from clippy::perf were changed in the root workspace:

redundant-clone
or-fun-call
to-string-in-format-args
cmp-owned
single-char-pattern
vec-init-then-push
expect-fun-call

I noticed that calling Clippy from the root workspace will not reach some other crates in the codebase (like `./kernel/wasi_interpreter`, this doesn't seem to be excluded in the root Cargo.toml so I thought it should be included like most of the other kernel crates) but I wasn't able to immediately understand how some were not being included in the workspace compilation, so I didn't go on to call Clippy in other individual workspaces and just made the root workspace changes for now.