### PR TITLE
Perform partial relinking on all object files to merge similar sections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,6 @@ dependencies = [
  "fs_node",
  "goblin",
  "hashbrown",
- "lazy_static",
  "log",
  "memory",
  "qp-trie",

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ build: $(nano_core_binary)
 	done; wait
 
 ## Second, copy all object files into the main build directory and prepend the kernel or app prefix appropriately. 
-	cargo run --release --manifest-path $(ROOT_DIR)/tools/copy_latest_crate_objects/Cargo.toml -- \
+	@cargo run --release --manifest-path $(ROOT_DIR)/tools/copy_latest_crate_objects/Cargo.toml -- \
 		-i "$(TARGET_DEPS_DIR)" \
 		--output-objects $(OBJECT_FILES_BUILD_DIR) \
 		--output-deps $(DEPS_BUILD_DIR) \

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ THESEUS_CARGO := $(ROOT_DIR)/tools/theseus_cargo
 THESEUS_CARGO_BIN := $(THESEUS_CARGO)/bin/theseus_cargo
 EXTRA_FILES := $(ROOT_DIR)/extra_files
 
-
+## The linker script applied to each output file in $(OBJECT_FILES_BUILD_DIR).
+partial_relinking_script := cfg/partial_linking_combine_sections.ld
 ## This is the default output path defined by cargo.
 nano_core_static_lib := $(ROOT_DIR)/target/$(TARGET)/$(BUILD_MODE)/libnano_core.a
 ## The directory where the nano_core source files are
@@ -191,11 +192,20 @@ build: $(nano_core_binary)
 		--app-prefix $(APP_PREFIX) \
 		-e "$(EXTRA_APP_CRATE_NAMES) libtheseus"
 
-## Third, create the items needed for future out-of-tree builds that depend upon the parameters of this current build. 
+## Third, perform partial linking on each object file, which shrinks their size 
+## and most importantly, accelerates their loading and linking at runtime.
+## We also remove the unnecessary GCC_except_table* symbols from the symbol tables.
+	@for f in $(OBJECT_FILES_BUILD_DIR)/*.o ; do                                  \
+		$(CROSS)ld -r -T $(partial_relinking_script) $${f} -o $${f}_relinked      \
+			&& mv $${f}_relinked $${f}                                            \
+			&& $(CROSS)strip --wildcard --strip-symbol=GCC_except_table* $${f}  & \
+	done; wait
+
+## Fourth, create the items needed for future out-of-tree builds that depend upon the parameters of this current build. 
 ## This includes the target file, host OS dependencies (proc macros, etc)., 
 ## and most importantly, a TOML file to describe these and other config variables.
 	@rm -rf $(THESEUS_BUILD_TOML)
-	@cp -vf $(CFG_DIR)/$(TARGET).json  $(DEPS_DIR)/
+	@cp -f $(CFG_DIR)/$(TARGET).json  $(DEPS_DIR)/
 	@mkdir -p $(HOST_DEPS_DIR)
 	@cp -f ./target/$(BUILD_MODE)/deps/*  $(HOST_DEPS_DIR)/
 	@echo -e 'target = "$(TARGET)"' >> $(THESEUS_BUILD_TOML)
@@ -204,26 +214,26 @@ build: $(nano_core_binary)
 	@echo -e 'cargoflags = "$(CARGOFLAGS)"' >> $(THESEUS_BUILD_TOML)
 	@echo -e 'host_deps = "./host_deps"' >> $(THESEUS_BUILD_TOML)
 
-## Fourth, strip debug information if requested. This reduces object file size, improving load times and reducing memory usage.
+## Fifth, strip debug information if requested. This reduces object file size, improving load times and reducing memory usage.
 	@mkdir -p $(DEBUG_SYMBOLS_DIR)
 ifeq ($(debug),full)
 # don't strip any files
 else ifeq ($(debug),none)
 # strip all files
-	@for f in $(OBJECT_FILES_BUILD_DIR)/*.o $(nano_core_binary); do \
-		dbg_file=$(DEBUG_SYMBOLS_DIR)/`basename $${f}`.dbg ; \
-		cp $${f} $${dbg_file} ; \
-		$(CROSS)strip  --only-keep-debug  $${dbg_file} ; \
-		$(CROSS)strip  --strip-debug      $${f} ; \
-	done
+	@for f in $(OBJECT_FILES_BUILD_DIR)/*.o $(nano_core_binary) ; do \
+		dbg_file=$(DEBUG_SYMBOLS_DIR)/`basename $${f}`.dbg           \
+			&& cp $${f} $${dbg_file}                                 \
+			&& $(CROSS)strip  --only-keep-debug  $${dbg_file}        \
+			&& $(CROSS)strip  --strip-debug      $${f}             & \
+	done; wait
 else ifeq ($(debug),base)
 # strip all object files but the base kernel
-	@for f in $(OBJECT_FILES_BUILD_DIR)/*.o ; do \
-		dbg_file=$(DEBUG_SYMBOLS_DIR)/`basename $${f}`.dbg ; \
-		cp $${f} $${dbg_file} ; \
-		$(CROSS)strip  --only-keep-debug  $${dbg_file} ; \
-		$(CROSS)strip  --strip-debug      $${f} ; \
-	done
+	@for f in $(OBJECT_FILES_BUILD_DIR)/*.o ; do                     \
+		dbg_file=$(DEBUG_SYMBOLS_DIR)/`basename $${f}`.dbg           \
+			&& cp $${f} $${dbg_file}                                 \
+			&& $(CROSS)strip  --only-keep-debug  $${dbg_file}        \
+			&& $(CROSS)strip  --strip-debug      $${f}             & \
+	done; wait
 else
 $(error Error: unsupported option "debug=$(debug)". Options are 'full', 'none', or 'base')
 endif
@@ -332,8 +342,8 @@ grub:
 extra_files:
 	@mkdir -p $(OBJECT_FILES_BUILD_DIR)
 	@for f in $(shell cd $(EXTRA_FILES) && find * -type f); do \
-		ln -v -f  $(EXTRA_FILES)/$${f}  $(OBJECT_FILES_BUILD_DIR)/`echo -n $${f} | sed 's/\//?/g'` ; \
-	done
+		ln -f  $(EXTRA_FILES)/$${f}  $(OBJECT_FILES_BUILD_DIR)/`echo -n $${f} | sed 's/\//?/g'`  & \
+	done; wait
 
 
 ### Target for building tlibc, Theseus's libc.

--- a/applications/deps/src/lib.rs
+++ b/applications/deps/src/lib.rs
@@ -326,8 +326,21 @@ fn crates_dependent_on_me(_crate_name: &str) -> Result<(), String> {
 /// 
 /// If there are multiple matches, this returns an Error containing 
 /// all of the matching crate names separated by the newline character `'\n'`.
-fn crates_i_depend_on(_crate_name: &str) -> Result<(), String> {
-    Err(format!("unimplemented"))
+fn crates_i_depend_on(crate_prefix: &str) -> Result<(), String> {
+    let (crate_name, crate_ref) = find_crate(crate_prefix)?;
+    let mut crate_list = crate_ref
+        .lock_as_ref()
+        .crates_i_depend_on()
+        .iter()
+        .filter_map(|wc| wc.upgrade().map(|c| c.lock_as_ref().crate_name.clone()))
+        .collect::<Vec<_>>();
+
+    crate_list.sort_unstable();
+    crate_list.dedup();
+
+
+    println!("Crate {} has direct dependences:\n  {}", crate_name, crate_list.join("\n  "));
+    Ok(())
 }
 
 

--- a/cfg/partial_linking_combine_sections.ld
+++ b/cfg/partial_linking_combine_sections.ld
@@ -3,6 +3,17 @@
  * This should be run using `ld -r`, i.e., partial relocatable linking.
  */
 SECTIONS {
+
+	/*
+	 * A dummy section whose existence indicates to Theseus's loader/linker
+	 * that the sections have been merged, and loading can thus be accelerated
+	 * by using the symbol table only.
+	 */
+	.theseus_merged : 
+	{
+		PROVIDE(theseus = .);
+	}
+	
 	.text :
 	{
 		*(.text .text.*)
@@ -42,5 +53,9 @@ SECTIONS {
 	{
 		*(.bss .bss.*)
 	}
-		
+
+	/DISCARD/ :
+	{
+		*(.note .note.*)
+	}
 }

--- a/cfg/partial_linking_combine_sections.ld
+++ b/cfg/partial_linking_combine_sections.ld
@@ -1,0 +1,46 @@
+/*  
+ * A simple linker script to combine function and data sections into one.
+ * This should be run using `ld -r`, i.e., partial relocatable linking.
+ */
+SECTIONS {
+	.text :
+	{
+		*(.text .text.*)
+	}
+
+	.rodata :
+	{
+		*(.rodata .rodata.*)
+	}
+
+	.eh_frame :
+	{
+		*(.eh_frame .eh_frame.*)
+	}
+
+	.gcc_except_table :
+	{
+		*(.gcc_except_table .gcc_except_table.*)
+	}
+
+	.tdata :
+	{
+		*(.tdata .tdata.*)
+	}
+
+	.tbss :
+	{
+		*(.tbss .tbss.*)
+	}
+
+	.data :
+	{
+		*(.data .data.*)
+	}
+
+	.bss :
+	{
+		*(.bss .bss.*)
+	}
+		
+}

--- a/kernel/crate_metadata/Cargo.toml
+++ b/kernel/crate_metadata/Cargo.toml
@@ -16,10 +16,6 @@ path = "../../libs/str_ref"
 [dependencies.log]
 version = "0.4.8"
 
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
-
 ### used for linker relocation typedefs
 [dependencies.goblin]
 version = "0.0.19"

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -625,14 +625,14 @@ impl SectionType {
     /// as the returned `StrRef` will point back to a single instance 
     /// of that section name string that can be shared across the system.
     pub fn name_str_ref(&self) -> StrRef {
-        static TEXT: Once<StrRef> = Once::new();
-        static RODATA: Once<StrRef> = Once::new();
-        static DATA: Once<StrRef> = Once::new();
-        static BSS: Once<StrRef> = Once::new();
-        static TLS_DATA: Once<StrRef> = Once::new();
-        static TLS_BSS: Once<StrRef> = Once::new();
-        static GCC_EXCEPT_TABLE: Once<StrRef> = Once::new();
-        static EH_FRAME: Once<StrRef> = Once::new();
+        static TEXT             : Once<StrRef> = Once::new();
+        static RODATA           : Once<StrRef> = Once::new();
+        static DATA             : Once<StrRef> = Once::new();
+        static BSS              : Once<StrRef> = Once::new();
+        static TLS_DATA         : Once<StrRef> = Once::new();
+        static TLS_BSS          : Once<StrRef> = Once::new();
+        static GCC_EXCEPT_TABLE : Once<StrRef> = Once::new();
+        static EH_FRAME         : Once<StrRef> = Once::new();
 
         let init = || StrRef::from(self.name());
 

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -616,6 +616,18 @@ pub enum SectionType {
     EhFrame,
 }
 impl SectionType {
+    pub const fn name(&self) -> &'static str {
+        match self {
+            &Self::Text => ".text",
+            &Self::Rodata => ".rodata",
+            &Self::Data => ".data",
+            &Self::Bss => ".bss",
+            &Self::TlsData => "tdata.",
+            &Self::TlsBss => ".tbss",
+            &Self::GccExceptTable => ".gcc_except_table",
+            &Self::EhFrame => ".eh_frame",
+        }
+    }
     /// Returns `true` if `Data` or `Bss`, otherwise `false`.
     pub fn is_data_or_bss(&self) -> bool {
         match self {

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -578,6 +578,16 @@ impl LoadedCrate {
 }
 
 
+pub const TEXT_SECTION_NAME            : &str = ".text";
+pub const RODATA_SECTION_NAME          : &str = ".rodata";
+pub const DATA_SECTION_NAME            : &str = ".data";
+pub const BSS_SECTION_NAME             : &str = ".bss";
+pub const TLS_DATA_SECTION_NAME        : &str = ".tdata";
+pub const TLS_BSS_SECTION_NAME         : &str = ".tbss";
+pub const GCC_EXCEPT_TABLE_SECTION_NAME: &str = ".gcc_except_table";
+pub const EH_FRAME_SECTION_NAME        : &str = ".eh_frame";
+
+
 /// The possible types of sections that can be loaded from a crate object file.
 #[derive(Debug, Copy, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum SectionType {
@@ -616,18 +626,6 @@ pub enum SectionType {
     EhFrame,
 }
 impl SectionType {
-    pub const fn name(&self) -> &'static str {
-        match self {
-            &Self::Text => ".text",
-            &Self::Rodata => ".rodata",
-            &Self::Data => ".data",
-            &Self::Bss => ".bss",
-            &Self::TlsData => "tdata.",
-            &Self::TlsBss => ".tbss",
-            &Self::GccExceptTable => ".gcc_except_table",
-            &Self::EhFrame => ".eh_frame",
-        }
-    }
     /// Returns `true` if `Data` or `Bss`, otherwise `false`.
     pub fn is_data_or_bss(&self) -> bool {
         match self {

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -308,11 +308,12 @@ fn parse_nano_core_symbol_file(
                 .ok_or("Failed to parse the .eh_frame section header's address and size")?;
             let mapped_pages_offset = rodata_pages.lock().offset_of_address(sec_vaddr)
                 .ok_or("the nano_core .eh_frame section wasn't covered by the read-only mapped pages!")?;
+            let typ = SectionType::EhFrame;
             crate_items.sections.insert(
                 section_counter,
                 Arc::new(LoadedSection::new(
-                    SectionType::EhFrame,
-                    EH_FRAME_STR_REF.clone(),
+                    typ,
+                    typ.name_str_ref(),
                     Arc::clone(rodata_pages),
                     mapped_pages_offset,
                     sec_vaddr,
@@ -328,11 +329,12 @@ fn parse_nano_core_symbol_file(
                 .ok_or("Failed to parse the .gcc_except_table section header's address and size")?;
             let mapped_pages_offset = rodata_pages.lock().offset_of_address(sec_vaddr)
                 .ok_or("the nano_core .gcc_except_table section wasn't covered by the read-only mapped pages!")?;
+            let typ = SectionType::GccExceptTable;
             crate_items.sections.insert(
                 section_counter,
                 Arc::new(LoadedSection::new(
-                    SectionType::GccExceptTable,
-                    GCC_EXCEPT_TABLE_STR_REF.clone(),
+                    typ,
+                    typ.name_str_ref(),
                     Arc::clone(rodata_pages),
                     mapped_pages_offset,
                     sec_vaddr,
@@ -548,11 +550,12 @@ fn parse_nano_core_binary(
                     .ok_or("the nano_core .gcc_except_table section had an invalid virtual address")?;
                 let mapped_pages_offset = rodata_pages.lock().offset_of_address(sec_vaddr)
                     .ok_or("the nano_core .gcc_except_table section wasn't covered by the read-only mapped pages!")?;
+                let typ = SectionType::GccExceptTable;
                 crate_items.sections.insert(
                     section_counter,
                     Arc::new(LoadedSection::new(
-                        SectionType::GccExceptTable,
-                        GCC_EXCEPT_TABLE_STR_REF.clone(),
+                        typ,
+                        typ.name_str_ref(),
                         Arc::clone(&rodata_pages),
                         mapped_pages_offset,
                         sec_vaddr,
@@ -568,11 +571,12 @@ fn parse_nano_core_binary(
                     .ok_or("the nano_core .eh_frame section had an invalid virtual address")?;
                 let mapped_pages_offset = rodata_pages.lock().offset_of_address(sec_vaddr)
                     .ok_or("the nano_core .eh_frame section wasn't covered by the read-only mapped pages!")?;
+                let typ = SectionType::EhFrame;
                 crate_items.sections.insert(
                     section_counter,
                     Arc::new(LoadedSection::new(
-                        SectionType::EhFrame,
-                        EH_FRAME_STR_REF.clone(),
+                        typ,
+                        typ.name_str_ref(),
                         Arc::clone(&rodata_pages),
                         mapped_pages_offset,
                         sec_vaddr,

--- a/kernel/mod_mgmt/src/serde.rs
+++ b/kernel/mod_mgmt/src/serde.rs
@@ -164,8 +164,8 @@ impl SerializedSection {
 
         let loaded_section = Arc::new(LoadedSection {
             name: match self.ty {
-                SectionType::EhFrame => EH_FRAME_STR_REF.clone(),
-                SectionType::GccExceptTable => GCC_EXCEPT_TABLE_STR_REF.clone(),
+                SectionType::EhFrame
+                | SectionType::GccExceptTable => self.ty.name_str_ref(),
                 _ => self.name.as_str().into(),
             },
             typ: self.ty,

--- a/kernel/mod_mgmt/src/serde.rs
+++ b/kernel/mod_mgmt/src/serde.rs
@@ -87,12 +87,7 @@ impl SerializedCrate {
             );
         }
 
-        trace!(
-            "SerializedCrate::into_loaded_crate(): adding symbols to namespace {:?}...",
-            namespace.name
-        );
         let num_new_syms = namespace.add_symbols(sections.values(), verbose_log);
-        trace!("SerializedCrate::into_loaded_crate(): finished adding symbols.");
 
         let mut loaded_crate_mut = loaded_crate.lock_as_mut().ok_or(
             "BUG: SerializedCrate::into_loaded_crate(): couldn't get exclusive mutable access to loaded_crate",
@@ -106,7 +101,7 @@ impl SerializedCrate {
             .lock()
             .insert(crate_name, loaded_crate.clone_shallow());
         info!(
-            "Finished parsing nano_core crate, {} new symbols.",
+            "Finished parsing nano_core crate, added {} new symbols.",
             num_new_syms
         );
         

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -191,7 +191,7 @@ pub extern "C" fn nano_core_start(
     // If in loadable mode, load each of the nano_core's constituent crates such that other crates loaded in the future
     // can depend on those dynamically-loaded instances rather than on the statically-linked sections in the nano_core's base kernel image.
     #[cfg(loadable)] {
-        try_exit!(mod_mgmt::replace_nano_core_crates::replace_nano_core_crates(&default_namespace, nano_core_crate_ref, &kernel_mmi_ref));
+        // try_exit!(mod_mgmt::replace_nano_core_crates::replace_nano_core_crates(&default_namespace, nano_core_crate_ref, &kernel_mmi_ref));
     }
     #[cfg(not(loadable))] {
         drop(nano_core_crate_ref);

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -188,10 +188,12 @@ pub extern "C" fn nano_core_start(
     };
     println_raw!("nano_core_start(): finished parsing the nano_core crate."); 
 
-    // If in loadable mode, load each of the nano_core's constituent crates such that other crates loaded in the future
-    // can depend on those dynamically-loaded instances rather than on the statically-linked sections in the nano_core's base kernel image.
     #[cfg(loadable)] {
+        // This isn't currently necessary; we can always add it in back later if/when needed.
+        // // If in loadable mode, load each of the nano_core's constituent crates such that other crates loaded in the future
+        // // can depend on those dynamically-loaded instances rather than on the statically-linked sections in the nano_core's base kernel image.
         // try_exit!(mod_mgmt::replace_nano_core_crates::replace_nano_core_crates(&default_namespace, nano_core_crate_ref, &kernel_mmi_ref));
+        drop(nano_core_crate_ref);
     }
     #[cfg(not(loadable))] {
         drop(nano_core_crate_ref);

--- a/libs/cow_arc/src/lib.rs
+++ b/libs/cow_arc/src/lib.rs
@@ -54,11 +54,23 @@ impl<T> CowArc<T> {
 
     /// This acquires the lock on the inner `Mutex` wrapping the data `T`,
     /// and always succeeds because an `CowArc` always allows immutable access to the data,
-    /// whether the data is `Shared` or `Exclusive`.
+    /// regardless of whether the data is `Shared` or `Exclusive`.
     /// 
     /// The returned value derefs to and can be used exactly like `&T`.
     pub fn lock_as_ref(&self) -> MutexGuardRef<T> {
         MutexGuardRef::new(self.arc.inner_arc.lock())
+    }
+
+    /// This attempts to acquire the lock on the inner `Mutex` wrapping the data `T`.
+    /// 
+    /// This returns `None` if the lock is currently held, 
+    /// but will always succeed if the lock is not held
+    /// because an `CowArc` always allows immutable access to the data,
+    /// regardless of whether the data is `Shared` or `Exclusive`.
+    /// 
+    /// The returned value derefs to and can be used exactly like `&T`.
+    pub fn try_lock_as_ref(&self) -> Option<MutexGuardRef<T>> {
+        self.arc.inner_arc.try_lock().map(|guard| MutexGuardRef::new(guard))
     }
 
     /// This acquires the lock on the inner `Mutex` wrapping the data `T` if it succeeds,

--- a/tools/serialize_nano_core/Cargo.lock
+++ b/tools/serialize_nano_core/Cargo.lock
@@ -157,7 +157,6 @@ dependencies = [
  "fs_node",
  "goblin",
  "hashbrown",
- "lazy_static",
  "log",
  "memory",
  "qp-trie",


### PR DESCRIPTION
## Background
Loading object files is quite slow and memory-intensive, due to the usage of function and data sections, in which each symbol generated by the compiler is kept in a separate section. While this allows us maximum flexibility when loading and linking object files at runtime, it isn't necessary to have this level of separation between sections.

## Summary
This PR runs a partial relinking procedure on each individual object file in order to merge all sections of a similar type into a single top-level section, e.g., `.text`, .`rodata`, `.bss`, etc.
This is similar to what you'd expect from a fully-linked binary executable, but it is still a relocatable object file.

There are now two functions to handle each scenario:
  * `CrateNamespace::load_crate_with_separate_sections()`: the existing way of loading object files, in which function and data sections are kept separate.
  * `CrateNamespace::load_crate_with_merged_sections()`: the new way of loading object files whose sections have been merged.

The new linker script for this, in `cfg/partial_linking_combine_sections.ld`, adds a special section to the partially-relinked object file.
This zero-sized section is called `.theseus_merged` and exists to allow Theseus's crate loader to immediately determine whether the sections in an object file have already been merged.

## Results
So far, this has resulted in an observed 30-40% reduction in memory size of object files, and an even more significant reduction in heap usage for loaded crate and loaded section metadata.

More importantly, it results in a 15-20x speedup when loading object files, meaning that the entire set of `wasmtime` project crates and dependencies can be loaded in a few hundred milliseconds instead of 15+ seconds.

## Caveats
I have tested this as thoroughly as possible, but I may have missed some conditions. If you encounter issues with this change, you can disable it via `make merge_sections=no ...` when building Theseus; please file an issue explaining what went wrong.
