### PR TITLE
Fix lint subset of clippy::complexity

### DIFF
--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -889,10 +889,7 @@ impl Shell {
             if slash_ending {
                 ""
             } else {
-                match nodes.pop() {
-                    Some(node) => node,
-                    None => ""
-                }
+                nodes.pop().unwrap_or("")
             }
         };
 
@@ -1378,7 +1375,7 @@ impl Shell {
     fn is_internal_command(&self) -> bool {
         let mut iter = self.cmdline.split_whitespace();
         if let Some(cmd) = iter.next() {
-            match cmd.as_ref() {
+            match cmd {
                 "jobs" => return true,
                 "fg" => return true,
                 "bg" => return true,
@@ -1395,7 +1392,7 @@ impl Shell {
         let cmdline_copy = self.cmdline.clone();
         let mut iter = cmdline_copy.split_whitespace();
         if let Some(cmd) = iter.next() {
-            match cmd.as_ref() {
+            match cmd {
                 "jobs" => self.execute_internal_jobs(),
                 "fg" => self.execute_internal_fg(),
                 "bg" => self.execute_internal_bg(),

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -305,8 +305,7 @@ impl LoadedCrate {
         where F: Fn(&LoadedSection) -> bool
     {
         self.sections.values()
-            .filter(|&sec| predicate(sec))
-            .next()
+            .find(|&sec| predicate(sec))
     }
 
     /// Returns the substring of this crate's name that excludes the trailing hash. 

--- a/kernel/libterm/src/lib.rs
+++ b/kernel/libterm/src/lib.rs
@@ -286,7 +286,7 @@ impl Terminal {
         let buffer_width = self.get_text_dimensions().0;
         let prev_start_idx;
         // Prevents the user from scrolling down if already at the bottom of the page
-        if self.is_scroll_end == true {
+        if self.is_scroll_end {
             return;} 
         prev_start_idx = self.scroll_start_idx;
         let result = self.calc_end_idx(prev_start_idx);

--- a/kernel/libterm/src/lib.rs
+++ b/kernel/libterm/src/lib.rs
@@ -287,7 +287,8 @@ impl Terminal {
         let prev_start_idx;
         // Prevents the user from scrolling down if already at the bottom of the page
         if self.is_scroll_end {
-            return;} 
+            return;
+        } 
         prev_start_idx = self.scroll_start_idx;
         let result = self.calc_end_idx(prev_start_idx);
         let mut end_idx = match result {

--- a/kernel/mlx_ethernet/src/command_queue.rs
+++ b/kernel/mlx_ethernet/src/command_queue.rs
@@ -730,7 +730,7 @@ impl CommandQueue {
 
     /// Find an command queue entry that is not in use
     fn find_free_command_entry(&self) -> Option<usize> {
-        self.available_entries.iter().position(|&x| x == true)
+        self.available_entries.iter().position(|&x| x)
     }
 
     /// Find an command queue entry that is not in use
@@ -746,7 +746,7 @@ impl CommandQueue {
     fn create_command(&mut self, parameters: CommandBuilder) -> Result<Command<{CmdState::Initialized}>, CommandQueueError> 
     {
         let entry_num = self.find_free_command_entry().ok_or(CommandQueueError::NoCommandEntryAvailable)?; 
-        let num_pages = parameters.allocated_pages.as_ref().and_then(|pages| Some(pages.len())); 
+        let num_pages = parameters.allocated_pages.as_ref().map(|pages| pages.len()); 
 
         #[cfg(mlx_verbose_log)]
         {

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -2461,8 +2461,7 @@ pub fn find_symbol_table<'e>(elf_file: &'e ElfFile)
     {
     use xmas_elf::sections::SectionData::SymbolTable64;
     let symtab_data = elf_file.section_iter()
-        .filter(|sec| sec.get_type() == Ok(ShType::SymTab))
-        .next()
+        .find(|sec| sec.get_type() == Ok(ShType::SymTab))
         .ok_or("no symtab section")
         .and_then(|s| s.get_data(&elf_file));
 

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -473,7 +473,7 @@ fn parse_nano_core_binary(
 
     // For us to properly load the ELF file, it must NOT have been stripped,
     // meaning that it must still have its symbol table section. Otherwise, relocations will not work.
-    let sssec = elf_file.section_iter().filter(|sec| sec.get_type() == Ok(ShType::SymTab)).next();
+    let sssec = elf_file.section_iter().find(|sec| sec.get_type() == Ok(ShType::SymTab));
     let symtab = match sssec.ok_or("no symtab section").and_then(|s| s.get_data(&elf_file)) {
         Ok(SectionData::SymbolTable64(symtab)) => symtab,
         _ => {
@@ -504,31 +504,31 @@ fn parse_nano_core_binary(
                
         match sec.get_name(&elf_file) {
             Ok(".text") => {
-                if !(sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR) == (SHF_ALLOC | SHF_EXECINSTR)) {
+                if sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR) != (SHF_ALLOC | SHF_EXECINSTR) {
                     return Err(".text section had wrong flags!");
                 }
                 text_shndx = Some(shndx);
             }
             Ok(".rodata") => {
-                if !(sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR) == (SHF_ALLOC)) {
+                if sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR) != (SHF_ALLOC) {
                     return Err(".rodata section had wrong flags!");
                 }
                 rodata_shndx = Some(shndx);
             }
             Ok(".data") => {
-                if !(sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR) == (SHF_ALLOC | SHF_WRITE)) {
+                if sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR) != (SHF_ALLOC | SHF_WRITE) {
                     return Err(".data section had wrong flags!");
                 }
                 data_shndx = Some(shndx);
             }
             Ok(".bss") => {
-                if !(sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR) == (SHF_ALLOC | SHF_WRITE)) {
+                if sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR) != (SHF_ALLOC | SHF_WRITE) {
                     return Err(".bss section had wrong flags!");
                 }
                 bss_shndx = Some(shndx);
             }
             Ok(".tdata") => {
-                if !(sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR | SHF_TLS) == (SHF_ALLOC | SHF_WRITE | SHF_TLS)) {
+                if sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR | SHF_TLS) != (SHF_ALLOC | SHF_WRITE | SHF_TLS) {
                     return Err(".tdata section had wrong flags!");
                 }
                 let sec_vaddr = VirtualAddress::new(sec.address() as usize)
@@ -536,7 +536,7 @@ fn parse_nano_core_binary(
                 tls_data_shndx = Some((shndx, sec_vaddr));
             }
             Ok(".tbss") => {
-                if !(sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR | SHF_TLS) == (SHF_ALLOC | SHF_WRITE | SHF_TLS)) {
+                if sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR | SHF_TLS) != (SHF_ALLOC | SHF_WRITE | SHF_TLS) {
                     return Err(".tbss section had wrong flags!");
                 }
                 let sec_vaddr = VirtualAddress::new(sec.address() as usize)

--- a/kernel/path/src/lib.rs
+++ b/kernel/path/src/lib.rs
@@ -95,8 +95,7 @@ impl Path {
     pub fn file_stem<'a>(&'a self) -> &'a str {
         self.basename()
             .split(EXTENSION_DELIMITER)
-            .filter(|&x| x != "")
-            .next()
+            .find(|&x| x != "")
             .unwrap_or_else(|| &self.path)
     }
 
@@ -106,8 +105,7 @@ impl Path {
     pub fn extension<'a>(&'a self) -> Option<&'a str> {
         self.basename()
             .rsplit(EXTENSION_DELIMITER)
-            .filter(|&x| x != "")
-            .next()
+            .find(|&x| x != "")
     }
 
     /// Returns a canonical and absolute form of the current path (i.e. the path of the working directory)

--- a/kernel/pmu_x86/src/lib.rs
+++ b/kernel/pmu_x86/src/lib.rs
@@ -128,11 +128,11 @@ static RESULTS_READY: [AtomicU64; WORDS_IN_BITMAP] = [AtomicU64::new(0), AtomicU
 
 lazy_static!{
     /// PMU version supported by the current hardware. The default is zero since the performance monitoring information would not be retrieved only if there was no PMU available.
-    static ref PMU_VERSION: u8 = CpuId::new().get_performance_monitoring_info().and_then(|pmi| Some(pmi.version_id())).unwrap_or(0);
+    static ref PMU_VERSION: u8 = CpuId::new().get_performance_monitoring_info().map(|pmi| pmi.version_id()).unwrap_or(0);
     /// The number of general purpose PMCs that can be used. The default is zero since the performance monitoring information would not be retrieved only if there was no PMU available.
-    static ref NUM_PMC: u8 = CpuId::new().get_performance_monitoring_info().and_then(|pmi| Some(pmi.number_of_counters())).unwrap_or(0);
+    static ref NUM_PMC: u8 = CpuId::new().get_performance_monitoring_info().map(|pmi| pmi.number_of_counters()).unwrap_or(0);
     /// The number of fixed function counters. The default is zero since the performance monitoring information would not be retrieved only if there was no PMU available.
-    static ref NUM_FIXED_FUNC_COUNTERS: u8 = CpuId::new().get_performance_monitoring_info().and_then(|pmi| Some(pmi.fixed_function_counters())).unwrap_or(0);
+    static ref NUM_FIXED_FUNC_COUNTERS: u8 = CpuId::new().get_performance_monitoring_info().map(|pmi| pmi.fixed_function_counters()).unwrap_or(0);
     /// Set to store the cores that the PMU has already been initialized on
     static ref CORES_INITIALIZED: MutexIrqSafe<BTreeSet<u8>> = MutexIrqSafe::new(BTreeSet::new());
     /// The sampling information for each core

--- a/kernel/scheduler_priority/src/lib.rs
+++ b/kernel/scheduler_priority/src/lib.rs
@@ -46,7 +46,7 @@ pub fn select_next_task(apic_id: u8) -> Option<TaskRef>  {
         // A task has been selected
         Some(task) => {
             // If the selected task is idle task we begin a new scheduling epoch
-            if task.idle_task == true {
+            if task.idle_task {
                 assign_tokens(apic_id);
                 select_next_task_priority(apic_id).and_then(|m| m.taskref)
             }

--- a/kernel/slabmalloc_safe/src/sc.rs
+++ b/kernel/slabmalloc_safe/src/sc.rs
@@ -114,7 +114,7 @@ impl SCAllocator {
     }
 
     fn remove_empty(&mut self) -> Option<MappedPages8k> {
-        self.empty_slabs.pop().and_then(|mp| {self.empty_count -= 1; Some(mp)} )
+        self.empty_slabs.pop().map(|mp| {self.empty_count -= 1; mp} )
     }
 
     fn remove_partial(&mut self, id: usize) -> MappedPages8k {
@@ -210,7 +210,7 @@ impl SCAllocator {
 
     /// Returns an empty page from the allocator if available.
     pub fn retrieve_empty_page(&mut self) -> Option<MappedPages8k> {
-        self.remove_empty().and_then(|mp| {self.page_count -= 1; Some(mp)} )
+        self.remove_empty().map(|mp| {self.page_count -= 1; mp} )
     }
 
     /// Allocates a block of memory descriped by `layout`.

--- a/kernel/unwind/src/lib.rs
+++ b/kernel/unwind/src/lib.rs
@@ -707,8 +707,7 @@ fn get_eh_frame_info(crate_ref: &StrongCrateRef) -> Option<(StrongSectionRef, Ba
     let krate = crate_ref.lock_as_ref();
 
     let eh_frame_sec = krate.sections.values()
-        .filter(|s| s.typ == SectionType::EhFrame)
-        .next()?;
+        .find(|s| s.typ == SectionType::EhFrame)?;
     
     let eh_frame_vaddr = eh_frame_sec.start_address().value();
     let text_pages_vaddr = krate.text_pages.as_ref()?.1.start.value();

--- a/kernel/window/src/lib.rs
+++ b/kernel/window/src/lib.rs
@@ -199,12 +199,8 @@ impl Window {
         // we simply return that event from this function such that the application can handle it. 
         let mut unhandled_event: Option<Event> = None;
 
-        loop {
-            let event = match self.event_consumer.pop() {
-                Some(ev) => ev,
-                None => break,
-            };
-            
+        
+        while let Some(event) = self.event_consumer.pop() {
             // TODO FIXME: for a performant design, the goal is to AVOID holding the lock on `inner` as much as possible. 
             //             That means that most of the drawing logic should be moved into the `window_inner` crate itself.
             let mut inner = self.inner.lock();

--- a/kernel/window_manager/src/lib.rs
+++ b/kernel/window_manager/src/lib.rs
@@ -689,13 +689,8 @@ fn window_manager_loop(
                     let mut x = (mouse_displacement.x as i8) as isize;
                     let mut y = (mouse_displacement.y as i8) as isize;
                     // need to combine mouse events if there pending a lot
-                    loop {
-                        let next_event = match mouse_consumer.pop() {
-                            Some(ev) => ev,
-                            _ => {
-                                break;
-                            }
-                        };
+
+                    while let Some(next_event) = mouse_consumer.pop() {
                         match next_event {
                             Event::MouseMovementEvent(ref next_mouse_event) => {
                                 if next_mouse_event.mousemove.scrolling_up


### PR DESCRIPTION
Addresses #526.

Fixes all Clippy suggestions yielded from the command
```
cargo clippy -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target cfg/x86_64-theseus.json --workspace --all-features -- -A clippy::all -W clippy::while-let-loop -W clippy::bool-comparison -W clippy::manual-unwrap-or -W clippy::useless-asref -W clippy::filter_next -W clippy::nonminimal-bool -W clippy::bind-instead-of-map
```

including the lints from clippy::complexity below:
while-let-loop
bool-comparison
manual-unwrap-or
useless-asref
filter_next
nonminimal-bool
bind-instead-of-map