### PR TITLE
Address more `unaligned_references` warnings / future incompat reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,9 +1939,9 @@ version = "0.1.0"
 
 [[package]]
 name = "multiboot2"
-version = "0.10.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e9fc890ff2ef2ded9084c964b950da1bc9e26d480e446ae721607b899db1fd"
+checksum = "e6170b6f12ea75d8d0f5621e3ed780b041a666c4a5b904c77261fe343d0e798d"
 dependencies = [
  "bitflags",
 ]

--- a/kernel/acpi/src/lib.rs
+++ b/kernel/acpi/src/lib.rs
@@ -2,8 +2,6 @@
 #![no_std]
 
 #![allow(dead_code)] //  to suppress warnings for unused functions/methods
-#![allow(unaligned_references)] // temporary, just to suppress unsafe packed borrows 
-
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate lazy_static;

--- a/kernel/e1000/src/lib.rs
+++ b/kernel/e1000/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 #![allow(dead_code)] //  to suppress warnings for unused functions/methods
-#![allow(unaligned_references)] // temporary, just to suppress unsafe packed borrows 
 #![feature(rustc_private)]
 #![feature(abi_x86_interrupt)]
 

--- a/kernel/entryflags_x86_64/Cargo.toml
+++ b/kernel/entryflags_x86_64/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 [dependencies]
 static_assertions = "1.1.0"
 bitflags = "1.0.4"
-multiboot2 = "0.10.1"
+multiboot2 = "0.14.0"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 
 [lib]

--- a/kernel/ixgbe/src/lib.rs
+++ b/kernel/ixgbe/src/lib.rs
@@ -7,7 +7,6 @@
 
 #![no_std]
 #![allow(dead_code)] //  to suppress warnings for unused functions/methods
-#![allow(unaligned_references)] // temporary, just to suppress unsafe packed borrows 
 #![feature(abi_x86_interrupt)]
 
 #[macro_use] extern crate log;

--- a/kernel/memory/Cargo.toml
+++ b/kernel/memory/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 [dependencies]
 spin = "0.9.0"
 bitflags = "1.1.0"
-multiboot2 = "0.10.1"
+multiboot2 = "0.14.0"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 bit_field = "0.7.0"
 x86_64 = "0.14.8"

--- a/kernel/memory_initialization/Cargo.toml
+++ b/kernel/memory_initialization/Cargo.toml
@@ -5,7 +5,7 @@ description = "Initialization routine for the virtual memory subsystem."
 version = "0.1.0"
 
 [dependencies]
-multiboot2 = "0.10.1"
+multiboot2 = "0.14.0"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/memory_structs/Cargo.toml
+++ b/kernel/memory_structs/Cargo.toml
@@ -5,7 +5,7 @@ description = "Common types used in the memory management subsystem"
 version = "0.1.0"
 
 [dependencies]
-multiboot2 = "0.10.1"
+multiboot2 = "0.14.0"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 bit_field = "0.7.0"
 zerocopy = "0.5.0"

--- a/kernel/memory_x86_64/Cargo.toml
+++ b/kernel/memory_x86_64/Cargo.toml
@@ -5,7 +5,7 @@ description = "The memory subsystem interfaces on x86_64."
 version = "0.1.0"
 
 [dependencies]
-multiboot2 = "0.10.1"
+multiboot2 = "0.14.0"
 x86_64 = "0.14.8"
 
 [dependencies.log]

--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 
 [dependencies]
 spin = "0.9.0"
-multiboot2 = "0.10.1"
+multiboot2 = "0.14.0"
 libm = "0.2.1"
 
 

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -121,8 +121,13 @@ pub extern "C" fn nano_core_start(
     if VirtualAddress::new(multiboot_information_virtual_address).is_none() {
         try_exit!(Err("multiboot info virtual address was invalid! Ensure that nano_core_start() is being invoked properly from boot.asm!"));
     }
-    let boot_info = unsafe { multiboot2::load(multiboot_information_virtual_address) };
-    println_raw!("nano_core_start(): booted via multiboot2 with info at {:#X}.", multiboot_information_virtual_address); 
+    let boot_info = try_exit!(
+        unsafe { multiboot2::load(multiboot_information_virtual_address) }.map_err(|e| {
+            error!("Error loading multiboot2 info: {:?}", e);
+            "Error loading multiboot2 info"
+        })
+    );
+    println_raw!("nano_core_start(): booted via multiboot2 with boot info at {:#X}.", multiboot_information_virtual_address); 
 
     // init memory management: set up stack with guard page, heap, kernel text/data mappings, etc
     let (

--- a/tools/serialize_nano_core/Cargo.lock
+++ b/tools/serialize_nano_core/Cargo.lock
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "multiboot2"
-version = "0.10.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e9fc890ff2ef2ded9084c964b950da1bc9e26d480e446ae721607b899db1fd"
+checksum = "e6170b6f12ea75d8d0f5621e3ed780b041a666c4a5b904c77261fe343d0e798d"
 dependencies = [
  "bitflags",
 ]


### PR DESCRIPTION
This removes all remaining warnings from rustc about future incompatibilities related to `unaligned_references`