### PR TITLE
Implement `raw_mutex` and `mutex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutex"
+version = "0.1.0"
+dependencies = [
+ "raw_mutex",
+]
+
+[[package]]
 name = "mutex_sleep"
 version = "0.1.0"
 dependencies = [
@@ -2518,6 +2525,15 @@ dependencies = [
  "bitflags",
  "cc",
  "rustc_version",
+]
+
+[[package]]
+name = "raw_mutex"
+version = "0.1.0"
+dependencies = [
+ "irq_safety",
+ "scheduler",
+ "task",
 ]
 
 [[package]]
@@ -3336,12 +3352,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "test_mutex_sleep"
+name = "test_mutex"
 version = "0.1.0"
 dependencies = [
  "apic",
  "log",
- "mutex_sleep",
+ "mutex",
  "scheduler",
  "spawn",
  "task",
@@ -3510,7 +3526,7 @@ dependencies = [
  "test_ixgbe",
  "test_libc",
  "test_mlx5",
- "test_mutex_sleep",
+ "test_mutex",
  "test_panic",
  "test_realtime",
  "test_restartable",

--- a/applications/test_mutex/Cargo.toml
+++ b/applications/test_mutex/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test_mutex_sleep"
+name = "test_mutex"
 version = "0.1.0"
 description = "Tests the blocking sleeping mutex with multiple tasks"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
@@ -19,5 +19,5 @@ path = "../../kernel/apic"
 [dependencies.spawn]
 path = "../../kernel/spawn"
 
-[dependencies.mutex_sleep]
-path = "../../kernel/mutex_sleep"
+[dependencies.mutex]
+path = "../../kernel/mutex"

--- a/kernel/mutex/Cargo.toml
+++ b/kernel/mutex/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "mutex"
+version = "0.1.0"
+authors = ["Klim Tsoutsman <klim@tsoutsman.com>"]
+description = "A mutex implementation"
+edition = "2021"
+
+[dependencies]
+raw_mutex = { path = "../raw_mutex" }

--- a/kernel/mutex/src/lib.rs
+++ b/kernel/mutex/src/lib.rs
@@ -1,0 +1,276 @@
+#![feature(must_not_suspend, negative_impls)]
+#![no_std]
+
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    ops::{Deref, DerefMut},
+};
+// use lockable::{Lockable, LockableSized};
+
+/// A mutual exclusion primitive useful for protecting shared data
+///
+/// This mutex will block threads waiting for the lock to become available. The
+/// mutex can be created via a [`new`] constructor. Each mutex has a type
+/// parameter which represents the data that it is protecting. The data can only
+/// be accessed through the RAII guards returned from [`lock`] and [`try_lock`],
+/// which guarantees that the data is only ever accessed when the mutex is
+/// locked.
+///
+/// [`new`]: Self::new
+/// [`lock`]: Self::lock
+/// [`try_lock`]: Self::try_lock
+pub struct Mutex<T: ?Sized> {
+    inner: raw_mutex::Mutex,
+    data: UnsafeCell<T>,
+}
+
+// SAFETY: Same impl as `std::sync::Mutex`.
+unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
+// SAFETY: Same impl as `std::sync::Mutex`.
+unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
+
+/// An RAII implementation of a "scoped lock" of a mutex. When this structure is
+/// dropped (falls out of scope), the lock will be unlocked.
+///
+/// The data protected by the mutex can be accessed through this guard via its
+/// [`Deref`] and [`DerefMut`] implementations.
+///
+/// This structure is created by the [`lock`] and [`try_lock`] methods on
+/// [`Mutex`].
+///
+/// [`lock`]: Mutex::lock
+/// [`try_lock`]: Mutex::try_lock
+#[must_use = "if unused the Mutex will immediately unlock"]
+#[must_not_suspend = "holding a MutexGuard across suspend \
+                      points can cause deadlocks, delays, \
+                      and cause Futures to not implement `Send`"]
+#[clippy::has_significant_drop]
+pub struct MutexGuard<'a, T: ?Sized + 'a> {
+    lock: &'a Mutex<T>,
+}
+
+impl<T: ?Sized> !Send for MutexGuard<'_, T> {}
+// SAFETY: Same impl as `std::sync::MutexGuard`.
+unsafe impl<T: ?Sized + Sync> Sync for MutexGuard<'_, T> {}
+
+impl<T> Mutex<T> {
+    /// Creates a new mutex in an unlocked state ready for use.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sync::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// ```
+    // NOTE: const fn is currently disabled because the inner mutex contains a
+    // VecDeque which isn't statically initializable. When we switch to a different
+    // type, we can offer this as a const fn again.
+    pub fn new(data: T) -> Self {
+        Self {
+            inner: raw_mutex::Mutex::new(),
+            data: UnsafeCell::new(data),
+        }
+    }
+}
+
+impl<T: ?Sized> Mutex<T> {
+    /// Acquires a mutex, blocking the current thread until it is able to do so.
+    ///
+    /// This function will block the local thread until it is available to
+    /// acquire the mutex. Upon returning, the thread is the only thread
+    /// with the lock held. An RAII guard is returned to allow scoped unlock
+    /// of the lock. When the guard goes out of scope, the mutex will be
+    /// unlocked.
+    ///
+    /// If locking a mutex in the thread which already holds the lock, this
+    /// function will deadlock.
+    pub fn lock(&self) -> MutexGuard<'_, T> {
+        self.inner.lock();
+        // SAFETY: We just locked the mutex.
+        unsafe { MutexGuard::new(self) }
+    }
+
+    /// Attempts to acquire this lock.
+    ///
+    /// If the lock could not be acquired at this time, then [`None`] is
+    /// returned. Otherwise, an RAII guard is returned. The lock will be
+    /// unlocked when the guard is dropped.
+    ///
+    /// This function does not block.
+    pub fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
+        if self.inner.try_lock() {
+            // SAFETY: We just locked the mutex.
+            Some(unsafe { MutexGuard::new(self) })
+        } else {
+            None
+        }
+    }
+
+    /// Consumes this mutex, returning the underlying data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sync::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// assert_eq!(mutex.into_inner(), 0);
+    /// ```
+    pub fn into_inner(self) -> T
+    where
+        T: Sized,
+    {
+        self.data.into_inner()
+    }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// Since this call borrows the [`Mutex`] mutably, and a mutable
+    /// reference is guaranteed to be exclusive in Rust, no actual locking
+    /// needs to take place -- the mutable borrow statically guarantees no locks
+    /// exist. As such, this is a 'zero-cost' operation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sync::Mutex;
+    ///
+    /// let mut lock = Mutex::new(0);
+    /// *lock.get_mut() = 10;
+    /// assert_eq!(*lock.lock(), 10);
+    /// ```
+    #[inline(always)]
+    pub fn get_mut(&mut self) -> &mut T {
+        self.data.get_mut()
+    }
+}
+
+impl<T> From<T> for Mutex<T> {
+    /// Creates a new mutex in an unlocked state ready for use.
+    /// This is equivalent to [`Mutex::new`].
+    fn from(t: T) -> Self {
+        Mutex::new(t)
+    }
+}
+
+impl<T: ?Sized + Default> Default for Mutex<T> {
+    fn default() -> Mutex<T> {
+        Mutex::new(Default::default())
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut d = f.debug_struct("Mutex");
+        match self.try_lock() {
+            Some(guard) => {
+                d.field("data", &&*guard);
+            }
+            None => {
+                struct LockedPlaceholder;
+                impl fmt::Debug for LockedPlaceholder {
+                    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        f.write_str("<locked>")
+                    }
+                }
+                d.field("data", &LockedPlaceholder);
+            }
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl<'mutex, T: ?Sized> MutexGuard<'mutex, T> {
+    /// Create a new `MutexGuard` from a locked [`Mutex`].
+    ///
+    /// # Safety
+    ///
+    /// `lock` must be locked by the current thread.
+    unsafe fn new(lock: &'mutex Mutex<T>) -> MutexGuard<'mutex, T> {
+        MutexGuard { lock }
+    }
+}
+
+impl<T: ?Sized> Deref for MutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // SAFETY: self existing is proof that the mutex is locked by the current
+        // thread.
+        unsafe { &*self.lock.data.get() }
+    }
+}
+
+impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: self existing is proof that the mutex is locked by the current
+        // thread.
+        unsafe { &mut *self.lock.data.get() }
+    }
+}
+
+impl<'a, T: ?Sized> Drop for MutexGuard<'a, T> {
+    fn drop(&mut self) {
+        // SAFETY: self existing is proof that the mutex is locked by the current
+        // thread.
+        unsafe { self.lock.inner.unlock() };
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for MutexGuard<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+/// Acquire the raw mutex of the guard.
+///
+/// This function must only be used by the condition variable implementation.
+#[doc(hidden)]
+pub fn guard_lock<'a, T: ?Sized>(guard: &MutexGuard<'a, T>) -> &'a raw_mutex::Mutex {
+    &guard.lock.inner
+}
+
+// impl<'t, T> Lockable<'t, T> for Mutex<T>
+// where
+//     T: 't + ?Sized,
+// {
+//     type Guard = MutexGuard<'t, T>;
+//     type GuardMut = Self::Guard;
+
+//     fn lock(&'t self) -> Self::Guard {
+//         self.lock()
+//     }
+//     fn try_lock(&'t self) -> Option<Self::Guard> {
+//         self.try_lock()
+//     }
+//     fn lock_mut(&'t self) -> Self::GuardMut {
+//         self.lock()
+//     }
+//     fn try_lock_mut(&'t self) -> Option<Self::GuardMut> {
+//         self.try_lock()
+//     }
+//     fn is_locked(&self) -> bool {
+//         self.is_locked()
+//     }
+//     fn get_mut(&'t mut self) -> &mut T {
+//         self.get_mut()
+//     }
+// }
+// /// Implement `LockableSized` for [`Mutex`].
+// impl<'t, T> LockableSized<'t, T> for Mutex<T>
+// where
+//     T: 't + Sized,
+// {
+//     fn into_inner(self) -> T {
+//         self.into_inner()
+//     }
+// }

--- a/kernel/raw_mutex/Cargo.toml
+++ b/kernel/raw_mutex/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "raw_mutex"
+version = "0.1.0"
+authors = ["Klim Tsoutsman <klim@tsoutsman.com>"]
+description = "A raw mutex implementation"
+edition = "2021"
+
+[dependencies]
+scheduler = { path = "../scheduler" }
+irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
+task = { path = "../task" }

--- a/kernel/raw_mutex/src/lib.rs
+++ b/kernel/raw_mutex/src/lib.rs
@@ -1,0 +1,101 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::collections::VecDeque;
+use task::TaskRef;
+
+/// A mutex.
+///
+/// The implementation is based on [a Princeton University lecture][lecture].
+///
+/// [lecture]: https://www.cs.princeton.edu/courses/archive/fall16/cos318/lectures/6.MutexImplementation.pdf
+#[derive(Debug, Default)]
+pub struct Mutex {
+    /// The inner state of a mutex.
+    ///
+    /// Using an IRQ safe mutex ensures even low priority tasks are able to
+    /// complete their critical section. If preemption was enabled and a low
+    /// priority task was preempted while holding onto the state, deadlock will
+    /// occur if there are enough high priority tasks to not reschedule the
+    /// low priority task, and one of the high priority task also tries to
+    /// acquire the state.
+    state: irq_safety::MutexIrqSafe<State>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct State {
+    is_locked: bool,
+    queue: VecDeque<&'static TaskRef>,
+}
+
+impl State {
+    // TODO: Make const.
+    pub fn new() -> Self {
+        Self {
+            is_locked: false,
+            queue: VecDeque::new(),
+        }
+    }
+}
+
+impl Mutex {
+    // TODO: Make const.
+    pub fn new() -> Self {
+        Self {
+            state: irq_safety::MutexIrqSafe::new(State::new()),
+        }
+    }
+
+    /// Locks the mutex, blocking the current thread until it is available.
+    pub fn lock(&self) {
+        let mut state = self.state.lock();
+
+        if !state.is_locked {
+            state.is_locked = true;
+            return;
+        }
+
+        let current_task = task::get_my_current_task()
+            .expect("raw_mutex::Mutex::lock(): couldn't get current task");
+        state.queue.push_back(current_task);
+        current_task.block();
+
+        drop(state);
+        scheduler::schedule();
+
+        // NOTE: We only reach here after the thread has been unblocked by
+        // another thread.
+    }
+
+    /// Unlocks the mutex.
+    ///
+    /// # Safety
+    ///
+    /// Behavior is undefined if the current thread does not actually hold the
+    /// mutex.
+    pub unsafe fn unlock(&self) {
+        let mut state = self.state.lock();
+        debug_assert!(
+            state.is_locked,
+            "attempted to unlock an already unlocked mutex"
+        );
+        if let Some(task) = state.queue.pop_front() {
+            task.unblock();
+        } else {
+            state.is_locked = false;
+        }
+    }
+
+    /// Attempts to lock the mutex without blocking, returning whether it was
+    /// successfully acquired or not.
+    pub fn try_lock(&self) -> bool {
+        let mut state = self.state.lock();
+        if state.is_locked {
+            false
+        } else {
+            state.is_locked = true;
+            true
+        }
+    }
+}

--- a/theseus_features/Cargo.toml
+++ b/theseus_features/Cargo.toml
@@ -64,7 +64,7 @@ test_filerw = { path = "../applications/test_filerw", optional = true }
 test_ixgbe = { path = "../applications/test_ixgbe", optional = true }
 test_libc = { path = "../applications/test_libc", optional = true }
 test_mlx5 = { path = "../applications/test_mlx5", optional = true }
-test_mutex_sleep = { path = "../applications/test_mutex_sleep", optional = true }
+test_mutex = { path = "../applications/test_mutex", optional = true }
 test_panic = { path = "../applications/test_panic", optional = true }
 test_realtime = { path = "../applications/test_realtime", optional = true }
 test_restartable = { path = "../applications/test_restartable", optional = true }
@@ -149,7 +149,7 @@ theseus_tests = [
     "test_ixgbe",
     "test_libc",
     "test_mlx5",
-    "test_mutex_sleep",
+    "test_mutex",
     "test_panic",
     "test_realtime",
     "test_restartable",


### PR DESCRIPTION
The current implementation isn't particularly performant, but it is
correct. Improving the performance of the mutex is something we could do
in a later PR.

Unlike `mutex_sleep`, `raw_mutex` lock operations panic rather than
return an error if `task::get_my_current_task()` fails. This conforms to
the `std::sys` mutex API where operations mustn't fail.

`mutex::Mutex` is a copy-paste of `std::sync::Mutex` except it doesn't
keep track of poisoning. As a result, it's lock and unlock operations
are also guaranteed to suceed.

I haven't removed `mutex_sleep` yet because it also implements `RwLock`
which I'll add in a later PR.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>