### PR TITLE
Implement preemption disabling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,6 +3357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_preemption_disable"
+version = "0.1.0"
+dependencies = [
+ "scheduler",
+ "sleep",
+ "terminal_print",
+]
+
+[[package]]
 name = "test_realtime"
 version = "0.1.0"
 dependencies = [
@@ -3512,6 +3521,7 @@ dependencies = [
  "test_mlx5",
  "test_mutex_sleep",
  "test_panic",
+ "test_preemption_disable",
  "test_realtime",
  "test_restartable",
  "test_serial_echo",

--- a/applications/test_preemption_disable/Cargo.toml
+++ b/applications/test_preemption_disable/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test_preemption_disable"
+version = "0.1.0"
+authors = ["Klim Tsoutsman <klim@tsoutsman.com>"]
+edition = "2021"
+
+[dependencies.scheduler]
+path = "../../kernel/scheduler"
+
+[dependencies.sleep]
+path = "../../kernel/sleep"
+
+[dependencies.terminal_print]
+path = "../../kernel/terminal_print"
+

--- a/applications/test_preemption_disable/src/lib.rs
+++ b/applications/test_preemption_disable/src/lib.rs
@@ -1,0 +1,30 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
+use terminal_print::{print, println};
+
+pub fn main(_: Vec<String>) -> isize {
+    println!("starting sleep 1");
+    sleep::sleep(1);
+    println!("sleep 1 complete");
+
+    let guard = scheduler::disable_preemption();
+    drop(guard);
+
+    println!("starting sleep 2");
+    sleep::sleep(1);
+    println!("sleep 2 complete");
+
+    let guard = scheduler::disable_preemption();
+    println!("starting sleep 3 (this sleep should not end)");
+    println!(
+        "you should restart Theseus now, as preemption won't be reenabled when this task is killed"
+    );
+    sleep::sleep(1);
+    println!("sleep 3 complete");
+    drop(guard);
+
+    -1
+}

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -503,6 +503,25 @@ impl LocalApic {
         }
     }
 
+    pub fn enable_timer(&mut self) {
+        if has_x2apic() {
+            unsafe { wrmsr(IA32_X2APIC_LVT_TIMER, 0x22 | APIC_TIMER_PERIODIC as u64) };
+        } else {
+            if let Some(ref mut regs) = self.regs {
+                regs.lvt_timer.write(0x22 | APIC_TIMER_PERIODIC);
+            }
+        }
+    }
+
+    pub fn disable_timer(&mut self) {
+        if has_x2apic() {
+            unsafe { wrmsr(IA32_X2APIC_LVT_TIMER, APIC_DISABLE as u64) };
+        } else {
+            if let Some(ref mut regs) = self.regs {
+                regs.lvt_timer.write(APIC_DISABLE);
+            }
+        }
+    }
     
     pub fn id(&self) -> u8 {
         let id: u8 = if has_x2apic() {

--- a/theseus_features/Cargo.toml
+++ b/theseus_features/Cargo.toml
@@ -66,6 +66,7 @@ test_libc = { path = "../applications/test_libc", optional = true }
 test_mlx5 = { path = "../applications/test_mlx5", optional = true }
 test_mutex_sleep = { path = "../applications/test_mutex_sleep", optional = true }
 test_panic = { path = "../applications/test_panic", optional = true }
+test_preemption_disable = { path = "../applications/test_preemption_disable", optional = true }
 test_realtime = { path = "../applications/test_realtime", optional = true }
 test_restartable = { path = "../applications/test_restartable", optional = true }
 test_serial_echo = { path = "../applications/test_serial_echo", optional = true }
@@ -151,6 +152,7 @@ theseus_tests = [
     "test_mlx5",
     "test_mutex_sleep",
     "test_panic",
+    "test_preemption_disable",
     "test_realtime",
     "test_restartable",
     "test_serial_echo",


### PR DESCRIPTION
This commit is the first step towards closing #578.

The implementation uses a counter over a boolean to keep track of
recursive preemption disabling.

The test application isn't great, but I can't think of a more ergonomic
or thorough way of testing the change.

As a next step (and after #576 lands), we can create a new mutex similar
to `spin::Mutex` and `irq_safety::MutexIrqSafe` that disables preemption
when locked.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>