### PR TITLE
Mark `LoadedSection::as_func()` as unsafe

### DIFF
--- a/kernel/crate_swap/src/lib.rs
+++ b/kernel/crate_swap/src/lib.rs
@@ -512,7 +512,8 @@ pub fn swap_crates(
             // as a backup, search fuzzily to accommodate state transfer function symbol names without full hashes
             .or_else(|| namespace_of_new_crates.get_symbol_starting_with(&symbol).upgrade())
             .ok_or("couldn't find specified state transfer function in the new CrateNamespace")?;
-        let st_fn = state_transfer_fn_sec.as_func::<StateTransferFunction>()?;
+        // FIXME SAFETY: None. swap_crates should probably be unsafe as there is no guaranteed that the state transfer functions have the correct signature.
+        let st_fn = unsafe { state_transfer_fn_sec.as_func::<StateTransferFunction>() }?;
         #[cfg(not(loscd_eval))]
         debug!("swap_crates(): invoking the state transfer function {:?} with old_ns: {:?}, new_ns: {:?}", symbol, this_namespace.name(), namespace_of_new_crates.name());
         st_fn(this_namespace, &namespace_of_new_crates)?;

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -236,7 +236,7 @@ pub extern "C" fn nano_core_start(
         info!("The nano_core (in loadable mode) is invoking the captain init function: {:?}", section.name);
 
         type CaptainInitFunc = fn(MmiRef, Vec<MappedPages>, stack::Stack, VirtualAddress, VirtualAddress) -> Result<(), &'static str>;
-        let func: &CaptainInitFunc = try_exit!(section.as_func());
+        let func: &CaptainInitFunc = try_exit!(unsafe { section.as_func() });
 
         try_exit!(
             func(kernel_mmi_ref, identity_mapped_pages, stack, ap_realmode_begin, ap_realmode_end)

--- a/kernel/panic_entry/src/lib.rs
+++ b/kernel/panic_entry/src/lib.rs
@@ -46,7 +46,7 @@ fn panic_entry_point(info: &PanicInfo) -> ! {
                         .and_then(|namespace| namespace.get_symbol_starting_with(PANIC_WRAPPER_SYMBOL).upgrade())
                         .ok_or("Couldn't get single symbol matching \"panic_wrapper::panic_wrapper::\"")?
                 };
-                let func: &PanicWrapperFunc = section.as_func()?;
+                let func: &PanicWrapperFunc = unsafe { section.as_func() }?;
                 func(info)
             }
 
@@ -108,7 +108,7 @@ extern "C" fn _Unwind_Resume(arg: usize) -> ! {
                     .and_then(|namespace| namespace.get_symbol_starting_with(UNWIND_RESUME_SYMBOL).upgrade())
                     .ok_or("Couldn't get single symbol matching \"unwind::unwind_resume::\"")?
             };
-            let func: &UnwindResumeFunc = section.as_func()?;
+            let func: &UnwindResumeFunc = unsafe { section.as_func() }?;
             func(arg)
         }
         match invoke_unwind_resume(arg) {

--- a/kernel/simd_personality/src/lib.rs
+++ b/kernel/simd_personality/src/lib.rs
@@ -159,7 +159,7 @@ fn internal_setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str
 	let section_ref1 = simd_app_namespace.get_symbol_starting_with("simd_test::test1::")
 		.upgrade()
 		.ok_or("no single symbol matching \"simd_test::test1\"")?;
-	let func1: &SimdTestFunc = section_ref1.as_func()?;
+	let func1: &SimdTestFunc = unsafe { section_ref1.as_func() }?;
 	let _task1 = spawn::new_task_builder(*func1, ())
 		.name(format!("simd_test_1-{}", simd_app_namespace.name()))
 		.pin_on_core(this_core)
@@ -171,7 +171,7 @@ fn internal_setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str
 	let section_ref2 = simd_app_namespace.get_symbol_starting_with("simd_test::test2::")
 		.upgrade()
 		.ok_or("no single symbol matching \"simd_test::test2\"")?;
-	let func2: &SimdTestFunc = section_ref2.as_func()?;
+	let func2: &SimdTestFunc = unsafe { section_ref2.as_func() }?;
 	let _task2 = spawn::new_task_builder(*func2, ())
 		.name(format!("simd_test_2-{}", simd_app_namespace.name()))
 		.pin_on_core(this_core)
@@ -183,7 +183,7 @@ fn internal_setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str
 	let section_ref3 = simd_app_namespace.get_symbol_starting_with("simd_test::test_short::")
 		.upgrade()
 		.ok_or("no single symbol matching \"simd_test::test_short\"")?;
-	let func3: &SimdTestFunc = section_ref3.as_func()?;
+	let func3: &SimdTestFunc = unsafe { section_ref3.as_func() }?;
 	let _task3 = spawn::new_task_builder(*func3, ())
 		.name(format!("simd_test_short-{}", simd_app_namespace.name()))
 		.pin_on_core(this_core)

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -160,7 +160,8 @@ pub fn new_application_task_builder(
     };
     let main_func_sec = main_func_sec_opt.ok_or("spawn::new_application_task_builder(): couldn't find \"main\" function, expected function name like \"<crate_name>::main::<hash>\"\
         --> Is this an app-level library or kernel crate? (Note: you cannot spawn a library crate with no main function)")?;
-    let main_func = main_func_sec.as_func::<MainFunc>()?;
+    // SAFETY: None. There is a lint in compiler_plugins/application_main_fn.rs, but it's currently disabled.
+    let main_func = unsafe { main_func_sec.as_func::<MainFunc>() }?;
 
     // Create the underlying task builder. 
     // Give it a default name based on the app crate's name, but that can be changed later. 


### PR DESCRIPTION
`LoadedSection::as_func()` is very unsafe. I didn't mark `swap_crates` as unsafe because it's used in a number of different contexts where the user provides a symbol to a function, but ideally, it would be marked unsafe as well.