### PR TITLE
Add `Environment::chdir()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 name = "cd"
 version = "0.1.0"
 dependencies = [
+ "environment",
  "fs_node",
  "getopts",
  "log",
@@ -900,6 +901,7 @@ version = "0.1.0"
 dependencies = [
  "fs_node",
  "hashbrown",
+ "path",
  "root",
 ]
 

--- a/applications/cd/Cargo.toml
+++ b/applications/cd/Cargo.toml
@@ -5,9 +5,7 @@ authors = ["Christine Wang <chrissywang54@gmail.com>"]
 
 [dependencies]
 getopts = "0.2.21"
-
-[dependencies.log]
-version = "0.4.8"
+log = "0.4.8"
 
 [dependencies.terminal_print]
 path = "../../kernel/terminal_print"
@@ -23,6 +21,9 @@ path = "../../kernel/fs_node"
 
 [dependencies.root]
 path = "../../kernel/root"
+
+[dependencies.environment]
+path = "../../kernel/environment"
 
 # [dependencies.application_main_fn]
 # path = "../../compiler_plugins"

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -3,31 +3,29 @@
 // #[macro_use] extern crate log;
 
 extern crate alloc;
-extern crate task;
+extern crate fs_node;
 extern crate getopts;
 extern crate path;
-extern crate fs_node;
 extern crate root;
+extern crate task;
 
-use alloc::vec::Vec;
 use alloc::string::String;
-use alloc::sync::Arc;
 use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
 use getopts::Options;
 use path::Path;
-use fs_node::FileOrDir;
-
 
 pub fn main(args: Vec<String>) -> isize {
     let mut opts = Options::new();
     opts.optflag("h", "help", "print this help menu");
-    
+
     let matches = match opts.parse(&args) {
         Ok(m) => m,
         Err(_f) => {
             println!("{}", _f);
             print_usage(opts);
-            return -1; 
+            return -1;
         }
     };
 
@@ -39,41 +37,30 @@ pub fn main(args: Vec<String>) -> isize {
         }
     };
     let curr_env = taskref.get_env();
-    let curr_wr = Arc::clone(&curr_env.lock().working_dir);
 
-    // go to root directory 
+    // go to root directory
     if matches.free.is_empty() {
         curr_env.lock().working_dir = Arc::clone(root::get_root());
-        return 0;
-    }
-
-    let path = Path::new(matches.free[0].to_string());
-    
-    // navigate to the filepath specified by first argument
-    match path.get(&curr_wr) {
-        Some(file_dir_enum) => {
-            match file_dir_enum {
-                FileOrDir::Dir(dir) => {
-                    curr_env.lock().working_dir = dir;
-                },
-                FileOrDir::File(file) => {
-                    println!("{:?} is not a directory.", file.lock().get_name());
-                    return -1;
-                }
+    } else {
+        let path = Path::new(matches.free[0].to_string());
+        match curr_env.lock().chdir(&path) {
+            Err(environment::Error::NotADirectory) => {
+                println!("not a directory: {}", path);
+                return -1;
             }
-        },
-        _ => {
-            println!("Couldn't find directory {}", path); 
-            return -1;
+            Err(environment::Error::NotFound) => {
+                println!("couldn't find directory: {}", path);
+                return -1;
+            }
+            _ => {}
         }
-    };
-    return 0;
+    }
+    0
 }
 
 fn print_usage(opts: Options) {
     println!("{}", opts.usage(USAGE));
 }
-
 
 const USAGE: &'static str = "Usage: cd [PATH]
 Change directory";

--- a/kernel/environment/Cargo.toml
+++ b/kernel/environment/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 [dependencies]
 fs_node = { path = "../fs_node" }
 hashbrown = "0.11.2"
+path = { path = "../path" }
 root = { path = "../root" }

--- a/kernel/environment/src/lib.rs
+++ b/kernel/environment/src/lib.rs
@@ -2,21 +2,21 @@
 
 extern crate alloc;
 
-use alloc::{
-    string::String,
-    sync::Arc,
-};
-use fs_node::DirRef;
+use alloc::{string::String, sync::Arc};
+use core::fmt;
+use fs_node::{DirRef, FileOrDir};
 use hashbrown::HashMap;
+use path::Path;
 
-/// A structure that contains environment state for a given `Task` or group of `Task`s.
-/// 
+/// A structure that contains environment state for a given `Task` or group of
+/// `Task`s.
+///
 /// A default environment can be created with the following state:
 /// * The working directory is the `root` directory.
 pub struct Environment {
-    /// The "current working directory", i.e., 
+    /// The "current working directory", i.e.,
     /// where a task's relative path begins upon first execution.
-    pub working_dir: DirRef, 
+    pub working_dir: DirRef,
     pub variables: HashMap<String, String>,
 }
 
@@ -26,6 +26,19 @@ impl Environment {
     pub fn cwd(&self) -> String {
         let wd = self.working_dir.lock();
         wd.get_absolute_path()
+    }
+
+    /// Changes the current working directory.
+    #[doc(alias("change"))]
+    pub fn chdir(&mut self, path: &Path) -> Result<()> {
+        match path.get(&self.working_dir) {
+            Some(FileOrDir::Dir(dir_ref)) => {
+                self.working_dir = dir_ref;
+                Ok(())
+            }
+            Some(FileOrDir::File(_)) => Err(Error::NotADirectory),
+            None => Err(Error::NotFound),
+        }
     }
 
     /// Returns the value of the environment variable with the given `key`.
@@ -53,5 +66,27 @@ impl Default for Environment {
             working_dir: Arc::clone(root::get_root()),
             variables: HashMap::new(),
         }
+    }
+}
+
+/// A specialized [`Result`] type for environment operations.
+///
+/// [`Result`]: core::result::Result
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// The error type for environment operations.
+pub enum Error {
+    /// A filesystem node was, unexpectedly, not a directory.
+    NotADirectory,
+    /// A filesystem node wasn't found.
+    NotFound,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::NotADirectory => "not a directory",
+            Error::NotFound => "entity not found",
+        })
     }
 }

--- a/kernel/path/src/lib.rs
+++ b/kernel/path/src/lib.rs
@@ -49,7 +49,7 @@ impl fmt::Display for Path {
 impl From<String> for Path {
     #[inline]
     fn from(path: String) -> Self {
-        Path {path: path}
+        Path { path }
     }
 }
 


### PR DESCRIPTION
I'm not sure about the error handling. Currently, the usual Theseus
result type is `Result<T, &'static str>'`. However, this limits what
the function caller can do with an error. Pattern matching on strings
is ... less than ideal. So instead, `chdir()` returns an [`Error`] enum,
as is common in Rust. However, both variants are file system errors
rather than environment errors and so ideally, we would define this type
in `fs_node`. But, `fs_node`'s API doesn't expose functions that would
use these error variants, so ...

For reference, `std::env::set_current_dir()` returns an
`std::io::Result`.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>