### PR TITLE
Separate cargo flags from cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ members = [
 
 ## Default members are the crates built by default if no specific packages (crates)
 ## are specified when invoking `cargo build`.
-## Currently, this is only relevant when overriding the Makefile's default `CARGOFLAGS`,
-## which has the default value of `--workspace`, ensuring that all `members` above are built
-## `CARGOFLAGS` are explicitly set when invoking `make`.
+## Currently, this is only relevant when overriding the Makefile's default `FEATURES`,
+## which has the default value of `--workspace`, ensuring that all `members` above 
+## are built even when `FEATURES` is explicitly set when invoking `make`.
 ##
 ## So far, this includes only the minimum crates required to allow Theseus to boot.
 default-members = [

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ export override RUSTFLAGS += $(patsubst %,--cfg %, $(THESEUS_CONFIG))
 
 ### Convenience targets for building the entire Theseus workspace
 ### with all optional features enabled. 
-### See `theseus_cargo/Cargo.toml` for more details about what this includes.
+### See `theseus_features/src/lib.rs` for more details on what this includes.
 all: full
 full : export override FEATURES += --workspace --all-features
 full: iso

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ $(error Error: could not find 'grub-mkrescue' or 'grub2-mkrescue', please instal
 else ifeq ($(bootloader),limine)
 	## Check if the limine directory exists. 
 	ifneq (,$(wildcard $(LIMINE_DIR)/.))
-		export override CARGOFLAGS += --features extract_boot_modules
+		export override FEATURES += --features extract_boot_modules
 	else
 $(error Error: missing '$(LIMINE_DIR)' directory! Please follow the limine instructions in the README)
 	endif
@@ -166,9 +166,11 @@ endif
 export override RUSTFLAGS += $(patsubst %,--cfg %, $(THESEUS_CONFIG))
 
 
-### Convenience targets for building Theseus with all features enabled.
+### Convenience targets for building the entire Theseus workspace
+### with all optional features enabled. 
+### See `theseus_cargo/Cargo.toml` for more details about what this includes.
 all: full
-full : export override CARGOFLAGS += --all-features
+full : export override FEATURES += --workspace --all-features
 full: iso
 
 
@@ -248,6 +250,7 @@ endif
 	@echo -e 'sysroot = "./sysroot"' >> $(THESEUS_BUILD_TOML)
 	@echo -e 'rustflags = "$(RUSTFLAGS)"' >> $(THESEUS_BUILD_TOML)
 	@echo -e 'cargoflags = "$(CARGOFLAGS)"' >> $(THESEUS_BUILD_TOML)
+	@echo -e 'features = "$(FEATURES)"' >> $(THESEUS_BUILD_TOML)
 	@echo -e 'host_deps = "./host_deps"' >> $(THESEUS_BUILD_TOML)
 
 ## Fifth, strip debug information if requested. This reduces object file size, improving load times and reducing memory usage.
@@ -287,7 +290,7 @@ cargo: check-rustc
 	@echo -e "\t KERNEL_PREFIX: \"$(KERNEL_PREFIX)\""
 	@echo -e "\t APP_PREFIX: \"$(APP_PREFIX)\""
 	@echo -e "\t THESEUS_CONFIG (before build.rs script): \"$(THESEUS_CONFIG)\""
-	RUST_TARGET_PATH='$(CFG_DIR)' RUSTFLAGS='$(RUSTFLAGS)' cargo build $(CARGOFLAGS) $(BUILD_STD_CARGOFLAGS) $(RUST_FEATURES) --target $(TARGET)
+	RUST_TARGET_PATH='$(CFG_DIR)' RUSTFLAGS='$(RUSTFLAGS)' cargo build $(CARGOFLAGS) $(FEATURES) $(BUILD_STD_CARGOFLAGS) --target $(TARGET)
 
 ## We tried using the "cargo rustc" command here instead of "cargo build" to avoid cargo unnecessarily rebuilding core/alloc crates,
 ## But it doesn't really seem to work (it's not the cause of cargo rebuilding everything).
@@ -887,7 +890,7 @@ loadable: run
 
 
 ### builds and runs Theseus with wasmtime enabled.
-wasmtime : export override CARGOFLAGS += --features wasmtime
+wasmtime : export override FEATURES += --features wasmtime
 wasmtime: run
 
 

--- a/cfg/Config.mk
+++ b/cfg/Config.mk
@@ -22,9 +22,11 @@ KERNEL_PREFIX       ?= k\#
 APP_PREFIX          ?= a\#
 EXECUTABLE_PREFIX   ?= e\#
 
-## By default, the Makefile will build the entire Theseus workspace.
-## However, one can override which crates are built by setting `CARGOFLAGS`.
-CARGOFLAGS ?= --workspace
+## By default, the Makefile will build the entire Theseus workspace
+## as specified by the `members` set in the top-level `Cargo.toml` file
+## (excluding the crates that are part of the `exclude` set).
+## However, one can override which crates are built by setting `FEATURES`.
+FEATURES ?= --workspace
 
 ## Build modes: debug is development mode, release is with full optimizations.
 ## We build using release mode by default, because running in debug mode is quite slow.

--- a/theseus_features/Cargo.toml
+++ b/theseus_features/Cargo.toml
@@ -5,15 +5,8 @@ description = "Set of global features used for configuration and conditional com
 version = "0.1.0"
 edition = "2021"
 
-## Note: to make a crate (or folder of crates) optional, do the following:
-## 1. Add it to the top-level Theseus `Cargo.toml` "exclude" list.
-## 2. Add it as an optional dependency below, ensuring `optional = true`.
-## 3. [Optional] Add it as a feature below, in order to give it a specific name.
-##    Technically this isn't required, but it can offer a clearer/different name.
-##
-## You can optionally add it to the `default` set of features,
-## or create a new group of features that includes it, 
-## or even add it to an existing set of features.
+## Note: see this crate's top-level documentation (or its `lib.rs` file)
+##       for more information on how this crate works and how Theseus handles features.
 
 [dependencies]
 theseus_std = { path = "../ports/theseus_std", optional = true }

--- a/theseus_features/src/lib.rs
+++ b/theseus_features/src/lib.rs
@@ -1,8 +1,51 @@
-//! See this crate's `Cargo.toml` file for more details.
-//! 
 //! This crate exists solely to hold a centralized list of features 
 //! used across all Theseus crates for conditional compilation and configuration.
 //!  
 //! It has no code, logic, or data.
+//! 
+//! ## How to specify optional crates/features in Theseus
+//! 
+//! To make a crate (or folder of crates) optional, do the following:
+//! 1. Add it to the set of `exclude`s in the top-level Theseus `Cargo.toml` file.
+//! 2. Add it as an optional dependency in this crate's `Cargo.toml` file, ensuring `optional = true`.
+//! 3. [Optional] Add it as a feature below, in order to give it a specific name.
+//!    * Technically this isn't required, but it can offer a clearer/different name.
+//!    * You can optionally add it to the `default` set of features,
+//!      or create a new group of features that includes it, 
+//!      or even add it to an existing set of features.
+//!
+//! 
+//! ## How to customize what is included in a Theseus build
+//! 
+//! When building Theseus using `make`, you can choose which of the features 
+//! specified in this crate's `Cargo.toml` file are enabled.
+//! Simply set the `FEATURES` environment variable, which has the default value of `--workspace`.
+//! 
+//! The `FEATURES` variable is passed directly into `cargo build`, meaning that is must
+//! follow the formatting expected by `cargo build.
+//! > Run `cargo build --help` to see more details about what arguments cargo expects.
+//! 
+//! ```sh
+//! # Build the bare minimum `default-members` of the Theseus workspace, 
+//! # excluding those specified by the `default` feature in this crate's `Cargo.toml`.
+//! make FEATURES=--no-default-features
+//! 
+//! # Build the bare minimum `default-members` of the Theseus workspace, plus all optional crates.
+//! make FEATURES=--all-features
+//! 
+//! # Build the standard Theseus workspace plus all optional crates. 
+//! # This is what `make full` or `make all` does.
+//! make FEATURES="--workspace --all-features"
+//! 
+//! # Build the bare minimum `default-members` of the Theseus workspace, plus the `ps` crate.
+//! make FEATURES="--features ps"
+//! 
+//! # Build the standard Theseus workspace plus the crates needed for the below `wasmtime` feature
+//! # and the `test_panic` crate.
+//! make FEATURES="--workspace --features wasmtime --features test_panic" 
+//! ```
+
 
 #![no_std]
+
+// Intentionally left blank.


### PR DESCRIPTION
This commit introduces a new `Makefile` variable called `FEATURES`,
which is passed directly into Theseus's `cargo build` invocation.
It has a default value of `--workspace`, just as `CARGOFLAGS` used to.

This is necessary because `CARGOFLAGS` is reused for correctly
configuring out-of-tree builds against a prebuilt instance of Theseus,
so we cannot overload it with cargo features.

For more info, see the crate-level documentation for `theseus_features`.

At this point, `CARGOFLAGS` is only really used to specify `--release`,
while `FEATURES` is used for controlling which features/crates
are included in a build of Theseus.