### PR TITLE
Update `libc`; use git dependency instead of git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,6 @@
 	path = ports/wasmtime
 	url = https://github.com/theseus-os/wasmtime.git
 	shallow = true
-[submodule "ports/libc"]
-	path = ports/libc
-	url = https://github.com/theseus-os/libc.git
-	shallow = true
 [submodule "libs/indexmap"]
 	path = libs/indexmap
 	url = https://github.com/theseus-os/indexmap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,7 +1528,8 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.127"
+source = "git+https://github.com/theseus-os/libc?branch=theseus#32f6c23ac80c9ea9b93c4377f15f407964d16c44"
 
 [[package]]
 name = "libm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ getopts = { git = "https://github.com/theseus-os/getopts" }
 smoltcp = { git = "https://github.com/m-labs/smoltcp" }
 
 ### Patch `libc` so we can use libc-specific types when using `cfg(target_os = "theseus")`.
-libc = { path = "ports/libc" }
+libc = { git = "https://github.com/theseus-os/libc", branch = "theseus" }
 ### Patch `core2` with newer functions from `std::io`, e.g., additional `Seek` trait functions
 core2 = { path = "libs/core2" }
 ### Patch `bincode` because the version on crates.io doesn't handle no_std features correctly.

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -664,7 +664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.127",
+ "libc",
  "wasi",
 ]
 
@@ -854,13 +854,8 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.107"
-
-[[package]]
-name = "libc"
 version = "0.2.127"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+source = "git+https://github.com/theseus-os/libc?branch=theseus#32f6c23ac80c9ea9b93c4377f15f407964d16c44"
 
 [[package]]
 name = "libterm"
@@ -1743,7 +1738,7 @@ dependencies = [
  "cstr_core",
  "heap",
  "lazy_static",
- "libc 0.2.107",
+ "libc",
  "log",
  "memchr",
  "memory",

--- a/tlibc/Cargo.toml
+++ b/tlibc/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 [dependencies]
 spin = "0.9.0"
 log = "0.4.8"
-libc = { path = "../ports/libc", default-features = false }
+libc = { version = "0.2", default-features = false }
 cstr_core = "0.2.3"
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 memchr = { version = "2.2.0", default-features = false }
@@ -57,7 +57,7 @@ getopts = { git = "https://github.com/theseus-os/getopts" }
 smoltcp = { git = "https://github.com/m-labs/smoltcp" }
 
 ### Patch `libc` so we can use libc-specific types when using `cfg(target_os = "theseus")`.
-libc = { path = "../ports/libc" }
+libc = { git = "https://github.com/theseus-os/libc", branch = "theseus" }
 ### Patch `core2` with newer functions from `std::io`, e.g., additional `Seek` trait functions
 core2 = { path = "../libs/core2" }
 ### Patch `bincode` because the version on crates.io doesn't handle no_std features correctly.


### PR DESCRIPTION
* Specifying `libc` dependencies as a local path dependency on a git submodule means that all crates can only use the current version checked out by that local submodule.

* Instead, we now specify `libc` as a git dependency: `libc = { git = "https://github.com/theseus-os/libc", branch = "theseus" }`
   * This allows other crates to use older versions, e.g., 0.2.120 instead of the current most recent version 0.2.127.

* Remove the `ports/libc` git submodule.