### PR TITLE
Depend on bincode via git repository in kernel/mod_mgmt

### DIFF
--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -75,9 +75,9 @@ default-features = false
 features = ["derive", "alloc"]
 
 [dependencies.bincode]
-version = "2.0.0-rc.1"
 default-features = false
 features = ["serde", "alloc"]
+git = "https://github.com/bincode-org/bincode"
 
 [lib]
 crate-type = ["rlib"]


### PR DESCRIPTION
This would allow us to depend on theseus via git in libstd