### PR TITLE
Add initial preemption manager crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,6 +2427,14 @@ name = "port_io"
 version = "0.2.1"
 
 [[package]]
+name = "preemption"
+version = "0.1.0"
+dependencies = [
+ "apic",
+ "log",
+]
+
+[[package]]
 name = "print"
 version = "0.1.0"
 dependencies = [

--- a/kernel/apic/Cargo.toml
+++ b/kernel/apic/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "apic"
 description = "APIC (Advanced Programmable Interrupt Controller) support for Theseus (x86 only), including apic/xapic and x2apic"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies]
 spin = "0.9.0"

--- a/kernel/preemption/Cargo.toml
+++ b/kernel/preemption/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>", "Klim Tsoutsman <klim@tsoutsman.com>"]
+name = "preemption"
+description = "Handles enabling and disabling preemption for each CPU core"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+log = "0.4.8"
+
+[dependencies.apic]
+path = "../apic"
+
+[lib]
+crate-type = ["rlib"]

--- a/kernel/preemption/src/lib.rs
+++ b/kernel/preemption/src/lib.rs
@@ -1,0 +1,115 @@
+//! Manages preemption on a per-CPU core basis.
+//! 
+//! Supports enabling and disabling preemption for the purpose of 
+//! safe task state management, e.g., through preemption-safe locks.
+
+#![no_std]
+
+extern crate alloc;
+
+use core::sync::atomic::{AtomicU8, Ordering};
+
+/// Theseus uses a `u8` to hold each CPU core's ID (apic ID),
+/// so the maximum number of cores it supports is `u8::MAX` (256).
+const MAX_CPU_CORES: usize = u8::MAX as usize;
+
+const ATOMIC_U8_ZERO: AtomicU8 = AtomicU8::new(0);
+
+/// The per-core preemption count, indexed by a CPU core's APIC ID.
+/// 
+/// If a CPU's count is `0`, preemption is enabled.
+/// If a CPU's count is greater than `0`, preemption is disabled.
+static PREEMPTION_COUNT: [AtomicU8; MAX_CPU_CORES] = [ATOMIC_U8_ZERO; MAX_CPU_CORES];
+
+
+/// Prevents preemption (preemptive task switching) from occurring
+/// until the returned guard object is dropped.
+pub fn hold_preemption() -> PreemptionGuard {
+    let apic_id = apic::get_my_apic_id();
+    let prev_val = PREEMPTION_COUNT[apic_id as usize].fetch_add(1, Ordering::Relaxed);
+    // If the previous counter value was 0, that indicates we are transitioning
+    // from preemption being enabled to disabled on this CPU.
+    let preemption_was_enabled = prev_val == 0;
+    // Create a guard here immediately after incrementing the counter,
+    // in order to guarantee that a failure below will drop it and decrement the counter.
+    let guard = PreemptionGuard {
+        apic_id,
+        preemption_was_enabled,
+    };
+
+    if preemption_was_enabled {
+        // When transitioning from preemption being enabled to disabled,
+        // we must disable the local APIC timer used for preemptive task switching.
+        apic::get_my_apic()
+            .expect("BUG: hold_preemption() couldn't get local APIC")
+            .write()
+            .enable_lvt_timer(false);
+    } else if prev_val == u8::MAX {
+        // Overflow occurred and the counter value wrapped around, which is a bug.
+        panic!("BUG: Overflow occurred in the preemption counter for CPU {}", apic_id);
+    }
+
+    guard
+}
+
+
+/// A guard type that ensures preemption is disabled as long as it is held.
+/// 
+/// Call [`hold_preemption()`] to obtain a `PreemptionGuard`.
+/// 
+/// Preemption *may* be re-enabled when this guard is dropped,
+/// but not necessarily so, because other tasks on this CPU 
+/// may also have acquired a `PreemptionGuard`.
+pub struct PreemptionGuard {
+    /// The APIC ID of the CPU on which preemption was held.
+    /// This is not necessary, it's just used for sanity checks or debugging.
+    apic_id: u8,
+    /// Whether preemption was enabled when this guard was created.
+    preemption_was_enabled: bool,
+}
+
+impl PreemptionGuard {
+    /// Returns `true` if preemption was originally enabled
+    /// when this guard was created and disabled them.
+    pub fn preemption_was_enabled(&self) -> bool {
+        self.preemption_was_enabled
+    }
+}
+
+impl Drop for PreemptionGuard {
+    fn drop(&mut self) {
+        let apic_id = apic::get_my_apic_id();
+        assert!(
+            self.apic_id == apic_id,
+            "PreemptionGuard::drop(): BUG: APIC IDs did not match! \
+            This indicates an unexpected task migration across CPUs."
+        );
+
+        let prev_val = PREEMPTION_COUNT[apic_id as usize].fetch_sub(1, Ordering::Relaxed);
+        if prev_val == 1 {
+            // If the previous counter value was 1, that means the current value is 1,
+            // which indicates we are transitioning from preemption disabled to enabled on this CPU.
+            // Thus, we re-enable the local APIC timer used for preemptive task switching.
+            apic::get_my_apic()
+                .expect("BUG: PreemptionGuard::drop() couldn't get local APIC")
+                .write()
+                .enable_lvt_timer(true);
+        } else if prev_val == 0 {
+            // Underflow occurred and the counter value wrapped around, which is a bug.
+            panic!("BUG: Underflow occurred in the preemption counter for CPU {}", apic_id);
+        }
+    }
+}
+
+
+/// Returns `true` if preemption is currently enabled on this CPU.
+/// 
+/// Note that this value can't be used as a lock indicator or property,
+/// as it is just a snapshot offers no guarantee that preemption will be enabled
+/// or disabled on the next attempt to enable/disable it
+/// or acquire a preemption-safe lock.
+pub fn preemption_enabled() -> bool {
+    let apic_id = apic::get_my_apic_id();
+    let val = PREEMPTION_COUNT[apic_id as usize].load(Ordering::Relaxed);
+    val == 0
+}


### PR DESCRIPTION
The crate is unused so far, but in the scheduler, we would use it like so:
```rust
pub fn schedule() -> bool {
    let preemption_guard = preemption::hold_preemption();
    // If preemption was not previously enabled (before we disabled it above),
    // then we shouldn't perform a task switch here.
    if !preemption_guard.preemption_was_enabled() {
        return false;
    }

    ...
```

We'd need to do a few other things to avoid disabling interrupts during `schedule()` and only disable preemption:
* remove the call to `hold_interrupts()` 
* move the preemption guard from the curr task's stack to the next task's stack, similar to how we use `drop_after_task_switch`
* potentially remove the unconditional call to `enable_interrupts()` in `spawn::task_wrapper_internal()`.