### PR TITLE
Add `local_rust` option to Makefile

### DIFF
--- a/cfg/Config.mk
+++ b/cfg/Config.mk
@@ -49,9 +49,9 @@ endif
 ## Tell cargo to build our own target-specific version of the `core` and `alloc` crates.
 ## Also ensure that core memory functions (e.g., memcpy) are included in the build and not name-mangled.
 ## We keep these flags separate from the regular CARGOFLAGS for purposes of easily creating a sysroot directory.
-# BUILD_STD_CARGOFLAGS += -Z unstable-options
-# BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
-# BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
+BUILD_STD_CARGOFLAGS += -Z unstable-options
+BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
+BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
 
 
 ## Tell rustc to output the native object file for each crate,

--- a/theseus_features/Cargo.toml
+++ b/theseus_features/Cargo.toml
@@ -148,10 +148,14 @@ theseus_tests = [
     "test_realtime",
     "test_restartable",
     "test_serial_echo",
-    "test_std",
     "test_std_fs",
     "test_wait_queue",
     "test_wasmtime",
     "tls_test",
     "unwind_test",
+]
+
+# Includes applications that can only be built with the `local_rust` build.
+std = [
+    "test_std",
 ]


### PR DESCRIPTION
I haven't worked with make much, so this may be a terrible way to do it. It definitely feels terrible.

This way of doing it unnecessarily forces us to rebuild `core` and `alloc`, but I'm not sure if it's possible to clean out just `std` using `x.py`. This is something we can look into in the future.

Running `x.py` from anywhere other than the rust repo directory doesn't work, so we `cd $(local_std)` rather than run `$(local_std)/x.py`.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>