### PR TITLE
Use const fn wherever possible; avoid lazy_static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,26 +8,16 @@ version = "0.1.0"
 dependencies = [
  "acpi_table",
  "acpi_table_handler",
- "ap_start",
- "apic",
  "dmar",
  "fadt",
  "hpet",
- "ioapic",
  "iommu",
- "irq_safety",
- "kernel_config",
- "lazy_static",
  "log",
  "madt",
  "memory",
- "pause",
- "pic",
- "pit_clock",
  "rsdp",
  "rsdt",
  "spin 0.9.0",
- "volatile 0.2.7",
 ]
 
 [[package]]
@@ -94,12 +84,10 @@ dependencies = [
  "interrupts",
  "irq_safety",
  "kernel_config",
- "lazy_static",
  "log",
  "memory",
  "scheduler",
  "spawn",
- "spin 0.9.0",
  "stack",
  "tlb_shootdown",
 ]
@@ -113,7 +101,6 @@ dependencies = [
  "crossbeam-utils",
  "irq_safety",
  "kernel_config",
- "lazy_static",
  "log",
  "memory",
  "msr",
@@ -134,7 +121,6 @@ dependencies = [
  "core2",
  "event_types",
  "keycodes_ascii",
- "lazy_static",
  "libterm",
  "log",
  "logger",
@@ -978,7 +964,6 @@ dependencies = [
 name = "external_unwind_info"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "log",
  "memory",
  "spin 0.9.0",
@@ -1029,7 +1014,6 @@ version = "0.1.0"
 dependencies = [
  "apic",
  "irq_safety",
- "lazy_static",
  "log",
  "memory",
  "print",
@@ -1088,7 +1072,6 @@ dependencies = [
  "compositor",
  "framebuffer",
  "hashbrown",
- "lazy_static",
  "shapes",
  "spin 0.9.0",
 ]
@@ -1128,7 +1111,6 @@ dependencies = [
  "atomic_linked_list",
  "bit_field 0.7.0",
  "bitflags",
- "lazy_static",
  "log",
  "memory",
  "spin 0.9.0",
@@ -1369,7 +1351,6 @@ name = "ioapic"
 version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
- "lazy_static",
  "log",
  "memory",
  "owning_ref",
@@ -2071,7 +2052,6 @@ name = "network_manager"
 version = "0.1.0"
 dependencies = [
  "e1000",
- "lazy_static",
  "log",
  "owning_ref",
  "smoltcp",
@@ -2674,7 +2654,6 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "irq_safety",
- "lazy_static",
  "log",
  "single_simd_task_optimization",
  "task",
@@ -2686,7 +2665,6 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "irq_safety",
- "lazy_static",
  "log",
  "task",
 ]
@@ -2697,7 +2675,6 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "irq_safety",
- "lazy_static",
  "log",
  "single_simd_task_optimization",
  "task",
@@ -3155,7 +3132,6 @@ name = "storage_manager"
 version = "0.1.0"
 dependencies = [
  "ata",
- "lazy_static",
  "log",
  "owning_ref",
  "pci",
@@ -3221,7 +3197,6 @@ dependencies = [
  "environment",
  "irq_safety",
  "kernel_config",
- "lazy_static",
  "log",
  "memory",
  "mod_mgmt",
@@ -3253,7 +3228,6 @@ version = "0.1.0"
 dependencies = [
  "dfqueue",
  "event_types",
- "lazy_static",
  "logger",
  "spin 0.9.0",
  "task",
@@ -3309,7 +3283,6 @@ dependencies = [
  "framebuffer_drawer",
  "getopts",
  "hpet",
- "lazy_static",
  "log",
  "rendezvous",
  "runqueue",
@@ -3401,7 +3374,6 @@ name = "test_restartable"
 version = "0.1.0"
 dependencies = [
  "getopts",
- "lazy_static",
  "log",
  "spawn",
  "spin 0.9.0",
@@ -3630,7 +3602,6 @@ version = "0.1.0"
 dependencies = [
  "apic",
  "atomic_linked_list",
- "lazy_static",
  "log",
  "memory",
  "spin 0.9.0",

--- a/applications/test_downtime/Cargo.toml
+++ b/applications/test_downtime/Cargo.toml
@@ -32,10 +32,6 @@ path = "../../kernel/rendezvous"
 [dependencies.async_channel]
 path = "../../kernel/async_channel"
 
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
-
 # for WM
 
 [dependencies.window]

--- a/applications/test_downtime/src/lib.rs
+++ b/applications/test_downtime/src/lib.rs
@@ -2,7 +2,6 @@
 
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate log;
-#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate terminal_print;
 extern crate getopts;
 extern crate spin;
@@ -49,12 +48,9 @@ macro_rules! CPU_ID {
 
 // ------------------------- Window fault injection section -------------------------------------------
 
-lazy_static! {
-
-    /// The structure to hold the list of all faults so far occured in the system
-    pub static ref DOWNTIME_SEND_LOCK: Mutex<PassStruct> = Mutex::new(PassStruct{count : 0, user : 0});
-    pub static ref DOWNTIME_RECEIVE_LOCK: Mutex<PassStruct> = Mutex::new(PassStruct{count : 0, user : 0});
-}
+/// The structure to hold the list of all faults so far occured in the system
+pub static DOWNTIME_SEND_LOCK: Mutex<PassStruct> = Mutex::new(PassStruct{count : 0, user : 0});
+pub static DOWNTIME_RECEIVE_LOCK: Mutex<PassStruct> = Mutex::new(PassStruct{count : 0, user : 0});
 
 /// Setup two tasks to send cordinates and receive a response
 pub fn set_graphics_measuring_task() -> (){

--- a/applications/test_restartable/Cargo.toml
+++ b/applications/test_restartable/Cargo.toml
@@ -11,10 +11,6 @@ spin = "0.9.0"
 default-features = false
 version = "0.4.8"
 
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
-
 [dependencies.spawn]
 path = "../../kernel/spawn"
 

--- a/applications/test_restartable/src/lib.rs
+++ b/applications/test_restartable/src/lib.rs
@@ -5,7 +5,6 @@
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate terminal_print;
-#[macro_use] extern crate lazy_static;
 extern crate getopts;
 extern crate alloc;
 extern crate spawn;
@@ -30,10 +29,8 @@ impl Drop for DropStruct {
     }
 }
 
-lazy_static! {
-    /// A lock to check and verify releasing of locks
-    static ref STATIC_LOCK: Mutex<Vec<usize>> = Mutex::new(Vec::new());
-}
+/// A lock to check and verify releasing of locks
+static STATIC_LOCK: Mutex<Vec<usize>> = Mutex::new(Vec::new());
 
 /// An enum to hold the methods we plan to exit a task
 #[derive(Clone)]

--- a/kernel/acpi/Cargo.toml
+++ b/kernel/acpi/Cargo.toml
@@ -6,42 +6,10 @@ version = "0.1.0"
 
 [dependencies]
 spin = "0.9.0"
-volatile = "0.2.7"
-
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
-
-[dependencies.irq_safety]
-git = "https://github.com/theseus-os/irq_safety"
+log = "0.4.8"
 
 [dependencies.memory]
 path = "../memory"
-
-[dependencies.kernel_config]
-path = "../kernel_config"
-
-[dependencies.ioapic]
-path = "../ioapic"
-
-[dependencies.apic]
-path = "../apic"
-
-[dependencies.pit_clock]
-path = "../pit_clock"
-
-[dependencies.pic]
-path = "../pic"
-
-[dependencies.ap_start]
-path = "../ap_start"
-
-[dependencies.pause]
-path = "../pause"
 
 [dependencies.acpi_table]
 path = "acpi_table"

--- a/kernel/acpi/acpi_table/src/lib.rs
+++ b/kernel/acpi/acpi_table/src/lib.rs
@@ -6,6 +6,7 @@
 //! to point to other ACPI SDTs, while the RSDT uses 32-bit physical addresses.
 
 #![no_std]
+#![feature(const_btree_new)]
 
 extern crate alloc;
 #[macro_use] extern crate log;
@@ -53,6 +54,15 @@ pub struct AcpiTables {
 }
 
 impl AcpiTables {
+    /// Returns a new empty `AcpiTables` object.
+    pub const fn empty() -> AcpiTables {
+        AcpiTables {
+            mapped_pages: MappedPages::empty(),
+            frames: FrameRange::empty(),
+            tables: BTreeMap::new(),
+        }
+    }
+
     /// Map the ACPI table that exists at the given PhysicalAddress, where an `SDT` header must exist.
     /// Ensures that the entire ACPI table is mapped, including extra length that may be specified within the SDT.
     /// 
@@ -240,14 +250,3 @@ impl AcpiTables {
         &self.mapped_pages
     }
 }
-
-impl Default for AcpiTables {
-    fn default() -> AcpiTables {
-        AcpiTables {
-            mapped_pages: MappedPages::empty(),
-            frames: FrameRange::empty(),
-            tables: BTreeMap::new(),
-        }
-    }
-}
-

--- a/kernel/acpi/src/lib.rs
+++ b/kernel/acpi/src/lib.rs
@@ -4,20 +4,10 @@
 #![allow(dead_code)] //  to suppress warnings for unused functions/methods
 
 #[macro_use] extern crate log;
-#[macro_use] extern crate lazy_static;
 extern crate alloc;
-extern crate volatile;
-extern crate irq_safety; 
 extern crate spin;
 extern crate memory;
-extern crate kernel_config;
-extern crate ioapic;
-extern crate pit_clock;
-extern crate ap_start;
-extern crate pic; 
-extern crate apic;
 extern crate hpet;
-extern crate pause;
 extern crate acpi_table;
 extern crate acpi_table_handler;
 extern crate rsdp;
@@ -36,11 +26,9 @@ use acpi_table::AcpiTables;
 use acpi_table_handler::acpi_table_handler;
 
 
-lazy_static! {
-    /// The singleton instance of the `AcpiTables` struct,
-    /// which contains the MappedPages and location of all discovered ACPI tables.
-    static ref ACPI_TABLES: Mutex<AcpiTables> = Mutex::new(AcpiTables::default());
-}
+/// The singleton instance of the `AcpiTables` struct,
+/// which contains the MappedPages and location of all discovered ACPI tables.
+static ACPI_TABLES: Mutex<AcpiTables> = Mutex::new(AcpiTables::empty());
 
 /// Returns a reference to the singleton instance of all ACPI tables 
 /// that have been discovered, mapped, and parsed so far.

--- a/kernel/ap_start/Cargo.toml
+++ b/kernel/ap_start/Cargo.toml
@@ -5,14 +5,7 @@ description = "High-level initialization code that runs on each AP (core) after 
 version = "0.1.0"
 
 [dependencies]
-spin = "0.9.0"
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
-
-[dependencies.log]
-version = "0.4.8"
+log = "0.4.8"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -3,11 +3,10 @@
 //! 
 
 #![no_std]
+#![feature(const_btree_new)]
 
 extern crate alloc;
 #[macro_use] extern crate log;
-#[macro_use] extern crate lazy_static;
-extern crate spin;
 extern crate irq_safety;
 extern crate memory;
 extern crate stack;
@@ -32,11 +31,9 @@ use apic::{LocalApic, get_lapics};
 /// False means the AP hasn't started or hasn't yet finished booting.
 pub static AP_READY_FLAG: AtomicBool = AtomicBool::new(false);
 
-lazy_static! {
-    /// Temporary storage for transferring allocated `Stack`s from 
-    /// the main bootstrap processor (BSP) to the AP processor being booted in `kstart_ap()` below.
-    static ref AP_STACKS: MutexIrqSafe<BTreeMap<u8, Stack>> = MutexIrqSafe::new(BTreeMap::new());
-}
+/// Temporary storage for transferring allocated `Stack`s from 
+/// the main bootstrap processor (BSP) to the AP processor being booted in `kstart_ap()` below.
+static AP_STACKS: MutexIrqSafe<BTreeMap<u8, Stack>> = MutexIrqSafe::new(BTreeMap::new());
 
 /// Insert a new stack that was allocated for the AP with the given `apic_id`.
 pub fn insert_ap_stack(apic_id: u8, stack: Stack) {

--- a/kernel/apic/Cargo.toml
+++ b/kernel/apic/Cargo.toml
@@ -14,13 +14,7 @@ owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 bit_field = "0.7.0"
 zerocopy = "0.5.0"
 static_assertions = "1.1.0"
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
+log = "0.4.8"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -18,7 +18,6 @@ use crossbeam_utils::atomic::AtomicCell;
 use pit_clock::pit_wait;
 use bit_field::BitField;
 use static_assertions::{const_assert, const_assert_eq};
-use lazy_static::lazy_static;
 use log::{error, info, debug, trace};
 
 /// The IRQ vector number defined by the IDT for Local APIC timer interrupts.
@@ -44,10 +43,8 @@ pub enum InterruptChip {
 // Ensure that `AtomicCell<InterruptChip>` is actually a lock-free atomic.
 const_assert!(AtomicCell::<InterruptChip>::is_lock_free());
 
-
-lazy_static! {
-    static ref LOCAL_APICS: AtomicMap<u8, RwLockIrqSafe<LocalApic>> = AtomicMap::new();
-}
+/// The set of system-wide `LocalApic`s, one per CPU core.
+static LOCAL_APICS: AtomicMap<u8, RwLockIrqSafe<LocalApic>> = AtomicMap::new();
 
 /// The processor id (from the ACPI MADT table) of the bootstrap processor
 static BSP_PROCESSOR_ID: Once<u8> = Once::new(); 

--- a/kernel/app_io/Cargo.toml
+++ b/kernel/app_io/Cargo.toml
@@ -8,9 +8,7 @@ description = "Offers applications the ability to read from or print to the term
 [dependencies]
 spin = "0.9.0"
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
-
-[dependencies.log]
-version = "0.4.8"
+log = "0.4.8"
 
 [dependencies.keycodes_ascii]
 path = "../../libs/keycodes_ascii"
@@ -29,10 +27,6 @@ path = "../../kernel/window_manager"
 
 [dependencies.libterm]
 path = "../../kernel/libterm"
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
 
 [dependencies.stdio]
 path = "../../libs/stdio"

--- a/kernel/entryflags_x86_64/src/lib.rs
+++ b/kernel/entryflags_x86_64/src/lib.rs
@@ -18,7 +18,6 @@ bitflags! {
     /// * Bits `[52:62]` (inclusive) are available for custom OS usage.
     /// * Bit  `63` is reserved by hardware for access flags (noexec).
     /// 
-    #[derive(Default)]
     pub struct EntryFlags: u64 {
         /// If set, this page is currently "present" in memory. 
         /// If not set, this page is not in memory, e.g., not mapped, paged to disk, etc.
@@ -67,6 +66,13 @@ bitflags! {
 const_assert_eq!(EntryFlags::all().bits() & 0x000_FFFFFFFFFF_000, 0);
 
 impl EntryFlags {
+    /// Returns a new, all-zero `EntryFlags` with no bits enabled.
+    /// 
+    /// This is a `const` version of `Default::default`.
+    pub const fn zero() -> EntryFlags {
+        EntryFlags::from_bits_truncate(0)
+    }
+
     /// Returns `true` if the page the entry points to is a huge page.
     pub const fn is_huge(&self) -> bool {
         self.intersects(EntryFlags::HUGE_PAGE)
@@ -176,5 +182,11 @@ impl EntryFlags {
         }
 
         flags
+    }
+}
+
+impl Default for EntryFlags {
+    fn default() -> Self {
+        Self::zero()
     }
 }

--- a/kernel/external_unwind_info/Cargo.toml
+++ b/kernel/external_unwind_info/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.8"
-lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 spin = "0.9.0"
 
 [dependencies.memory]

--- a/kernel/external_unwind_info/src/lib.rs
+++ b/kernel/external_unwind_info/src/lib.rs
@@ -33,22 +33,20 @@
 
 #![no_std]
 #![feature(map_try_insert)]
+#![feature(const_btree_new)]
 
 extern crate alloc;
 
 use core::ops::{Range, Bound::{Included, Unbounded}};
 use alloc::collections::BTreeMap;
-use lazy_static::lazy_static;
 use memory::VirtualAddress;
 use spin::Mutex;
 use log::*;
 
-lazy_static! {
-    /// The system-wide set of unwind information registered by external components.
-    /// 
-    /// The map key is the text section's base `VirtualAddress`.
-    static ref EXTERNAL_UNWIND_INFO: Mutex<BTreeMap<VirtualAddress, ExternalUnwindInfo>> = Mutex::new(BTreeMap::new());
-}
+/// The system-wide set of unwind information registered by external components.
+/// 
+/// The map key is the text section's base `VirtualAddress`.
+static EXTERNAL_UNWIND_INFO: Mutex<BTreeMap<VirtualAddress, ExternalUnwindInfo>> = Mutex::new(BTreeMap::new());
 
 /// Unwinding information for an external (non-Theseus) component.
 #[derive(Debug, Clone)]

--- a/kernel/fault_log/Cargo.toml
+++ b/kernel/fault_log/Cargo.toml
@@ -5,10 +5,6 @@ description = "Logs all exceptions occuring in Theseus"
 authors = ["Namitha Liyanage <namithaliyanage@gmail.com>"]
 
 
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
-
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"
 

--- a/kernel/fault_log/src/lib.rs
+++ b/kernel/fault_log/src/lib.rs
@@ -6,7 +6,6 @@
 #![no_std]
 #![feature(drain_filter)]
 
-#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate vga_buffer; // for println_raw!()
 #[macro_use] extern crate print; // for regular println!()
 #[macro_use] extern crate log;
@@ -127,10 +126,8 @@ impl FaultEntry {
 }
 
 
-lazy_static! {    
-    /// The structure to hold the list of all faults so far occured in the system
-    static ref FAULT_LIST: MutexIrqSafe<Vec<FaultEntry>> = MutexIrqSafe::new(Vec::new());
-}
+/// The structure to hold the list of all faults so far occured in the system
+static FAULT_LIST: MutexIrqSafe<Vec<FaultEntry>> = MutexIrqSafe::new(Vec::new());
 
 /// Clears the log of faults so far occured in the system 
 pub fn clear_fault_log() {

--- a/kernel/framebuffer_compositor/Cargo.toml
+++ b/kernel/framebuffer_compositor/Cargo.toml
@@ -16,10 +16,6 @@ path = "../shapes"
 [dependencies.compositor]
 path = "../compositor"
 
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
-
 [dependencies.hashbrown]
 version = "0.11.2"
 features = ["nightly"]

--- a/kernel/framebuffer_compositor/src/lib.rs
+++ b/kernel/framebuffer_compositor/src/lib.rs
@@ -19,13 +19,12 @@
 //! The cache is basically a rectangular region in the destination framebuffer, and we define the structure `CacheBlock` to represent that cached region.
 
 #![no_std]
+#![feature(const_btree_new)]
 
 extern crate alloc;
 extern crate compositor;
 extern crate framebuffer;
 extern crate spin;
-#[macro_use]
-extern crate lazy_static;
 extern crate hashbrown;
 extern crate shapes;
 
@@ -42,14 +41,12 @@ use core::ops::Range;
 /// The height of a cache block. In every iteration the compositor will deal with groups of 16 rows and cache them.
 pub const CACHE_BLOCK_HEIGHT: usize = 16;
 
-lazy_static! {
-    /// The instance of the framebuffer compositor.
-    pub static ref FRAME_COMPOSITOR: Mutex<FrameCompositor> = Mutex::new(
-        FrameCompositor{
-            caches: BTreeMap::new()
-        }
-    );
-}
+/// The instance of the framebuffer compositor.
+pub static FRAME_COMPOSITOR: Mutex<FrameCompositor> = Mutex::new(
+    FrameCompositor{
+        caches: BTreeMap::new()
+    }
+);
 
 /// A `CacheBlock` represents the cached (previously-composited) content of a range of rows in the source framebuffer. 
 /// It specifies the rectangular region in the destination framebuffer and the hash.

--- a/kernel/gdt/Cargo.toml
+++ b/kernel/gdt/Cargo.toml
@@ -9,13 +9,7 @@ spin = "0.9.0"
 x86_64 = "0.14.8"
 bit_field = "0.7.0"
 bitflags = "1.1.0"
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
+log = "0.4.8"
 
 [dependencies.atomic_linked_list]
 path = "../../libs/atomic_linked_list"

--- a/kernel/gdt/src/lib.rs
+++ b/kernel/gdt/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 
-#[macro_use] extern crate lazy_static;
 // #[macro_use] extern crate log;
 #[macro_use] extern crate bitflags;
 extern crate bit_field;
@@ -28,10 +27,8 @@ use spin::Once;
 use memory::VirtualAddress;
 
 
-lazy_static! {
-    /// The GDT list, one per core, indexed by a key of apic_id
-    static ref GDT: AtomicMap<u8, Gdt> = AtomicMap::new();
-}
+/// The GDT list, one per core, indexed by a key of apic_id
+static GDT: AtomicMap<u8, Gdt> = AtomicMap::new();
 
 
 static KERNEL_CODE_SELECTOR:  Once<SegmentSelector> = Once::new();

--- a/kernel/ioapic/Cargo.toml
+++ b/kernel/ioapic/Cargo.toml
@@ -5,20 +5,14 @@ description = "IOAPIC (I/O Advanced Programmable Interrupt Controller) support (
 version = "0.1.0"
 
 [dependencies]
+log = "0.4.8"
 spin = "0.9.0"
 volatile = "0.2.7"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
 zerocopy = "0.5.0"
 
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
-
 [dependencies.atomic_linked_list]
 path = "../../libs/atomic_linked_list"
-
-[dependencies.log]
-version = "0.4.8"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/ioapic/src/lib.rs
+++ b/kernel/ioapic/src/lib.rs
@@ -3,7 +3,6 @@
 
 extern crate alloc;
 #[macro_use] extern crate log;
-#[macro_use] extern crate lazy_static;
 extern crate spin;
 extern crate memory;
 extern crate volatile;
@@ -21,11 +20,9 @@ use atomic_linked_list::atomic_map::AtomicMap;
 use owning_ref::BoxRefMut;
 
 
-lazy_static! {
-    /// The system-wide list of all `IoApic`s, of which there is usually one, 
-    /// but larger systems can have multiple IoApic chips.
-    static ref IOAPICS: AtomicMap<u8, Mutex<IoApic>> = AtomicMap::new();
-}
+/// The system-wide list of all `IoApic`s, of which there is usually one, 
+/// but larger systems can have multiple IoApic chips.
+static IOAPICS: AtomicMap<u8, Mutex<IoApic>> = AtomicMap::new();
 
 
 /// Returns a reference to the list of IoApics.

--- a/kernel/memory/src/paging/mapper.rs
+++ b/kernel/memory/src/paging/mapper.rs
@@ -314,11 +314,11 @@ impl Deref for MappedPages {
 impl MappedPages {
     /// Returns an empty MappedPages object that performs no allocation or mapping actions. 
     /// Can be used as a placeholder, but will not permit any real usage. 
-    pub fn empty() -> MappedPages {
+    pub const fn empty() -> MappedPages {
         MappedPages {
-            page_table_p4: get_current_p4(),
+            page_table_p4: Frame::containing_address(PhysicalAddress::zero()),
             pages: AllocatedPages::empty(),
-            flags: Default::default(),
+            flags: EntryFlags::zero(),
         }
     }
 

--- a/kernel/network_manager/Cargo.toml
+++ b/kernel/network_manager/Cargo.toml
@@ -7,14 +7,7 @@ version = "0.1.0"
 [dependencies]
 spin = "0.9.0"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
-
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
+log = "0.4.8"
 
 [dependencies.e1000]
 path = "../e1000"

--- a/kernel/network_manager/src/lib.rs
+++ b/kernel/network_manager/src/lib.rs
@@ -2,7 +2,6 @@
 
 extern crate alloc;
 // #[macro_use] extern crate log;
-#[macro_use] extern crate lazy_static;
 extern crate spin;
 extern crate owning_ref;
 extern crate smoltcp;
@@ -19,10 +18,8 @@ use smoltcp::{
 
 
 
-lazy_static! {
-    /// A list of all of the available and initialized network interfaces that exist on this system.
-    pub static ref NETWORK_INTERFACES: Mutex<Vec<NetworkInterfaceRef>> = Mutex::new(Vec::new());
-}
+/// A list of all of the available and initialized network interfaces that exist on this system.
+pub static NETWORK_INTERFACES: Mutex<Vec<NetworkInterfaceRef>> = Mutex::new(Vec::new());
 
 /// A trait that represents a Network Interface within Theseus. 
 /// Currently this is a thin wrapper around what `smoltcp` offers. 

--- a/kernel/runqueue_priority/Cargo.toml
+++ b/kernel/runqueue_priority/Cargo.toml
@@ -5,13 +5,7 @@ description = "Functions and types for handling runqueues when priority schedule
 version = "0.1.0"
 
 [dependencies]
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
+log = "0.4.8"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"

--- a/kernel/runqueue_priority/src/lib.rs
+++ b/kernel/runqueue_priority/src/lib.rs
@@ -6,7 +6,6 @@
 #![no_std]
 
 extern crate alloc;
-#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 extern crate irq_safety;
 extern crate atomic_linked_list;
@@ -82,12 +81,9 @@ impl PriorityTaskRef {
 }
 
 
-lazy_static! {
-    /// There is one runqueue per core, each core only accesses its own private runqueue
-    /// and allows the scheduler to select a task from that runqueue to schedule in.
-    static ref RUNQUEUES: AtomicMap<u8, RwLockIrqSafe<RunQueue>> = AtomicMap::new();
-}
-
+/// There is one runqueue per core, each core only accesses its own private runqueue
+/// and allows the scheduler to select a task from that runqueue to schedule in.
+static RUNQUEUES: AtomicMap<u8, RwLockIrqSafe<RunQueue>> = AtomicMap::new();
 
 /// A list of references to `Task`s (`PriorityTaskRef`s) 
 /// that is used to store the `Task`s (and associated scheduler related data) 

--- a/kernel/runqueue_realtime/Cargo.toml
+++ b/kernel/runqueue_realtime/Cargo.toml
@@ -13,10 +13,6 @@ git = "https://github.com/theseus-os/irq_safety"
 [dependencies.log]
 version = "0.4.8"
 
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.2.0"
-
 [dependencies.atomic_linked_list]
 path = "../../libs/atomic_linked_list"
 

--- a/kernel/runqueue_realtime/src/lib.rs
+++ b/kernel/runqueue_realtime/src/lib.rs
@@ -22,7 +22,6 @@ extern crate task;
 extern crate irq_safety;
 extern crate alloc;
 #[macro_use] extern crate log;
-#[macro_use] extern crate lazy_static;
 extern crate atomic_linked_list;
 
 use task::TaskRef;
@@ -94,11 +93,9 @@ impl RealtimeTaskRef {
     }
 }
 
-lazy_static! {
-    /// There is one runqueue per core, each core only accesses its own private runqueue
-    /// and allows the scheduler to select a task from that runqueue to schedule in
-    static ref RUNQUEUES: AtomicMap<u8, RwLockIrqSafe<RunQueue>> = AtomicMap::new();
-}
+/// There is one runqueue per core, each core only accesses its own private runqueue
+/// and allows the scheduler to select a task from that runqueue to schedule in
+static RUNQUEUES: AtomicMap<u8, RwLockIrqSafe<RunQueue>> = AtomicMap::new();
 
 /// A list of `Task`s and their associated realtime scheduler data that may be run on a given CPU core.
 ///

--- a/kernel/runqueue_round_robin/Cargo.toml
+++ b/kernel/runqueue_round_robin/Cargo.toml
@@ -5,13 +5,7 @@ description = "Functions and types for handling runqueues, i.e., lists of tasks 
 version = "0.1.0"
 
 [dependencies]
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
+log = "0.4.8"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"

--- a/kernel/runqueue_round_robin/src/lib.rs
+++ b/kernel/runqueue_round_robin/src/lib.rs
@@ -6,7 +6,6 @@
 #![no_std]
 
 extern crate alloc;
-#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 extern crate irq_safety;
 extern crate atomic_linked_list;
@@ -76,11 +75,9 @@ impl RoundRobinTaskRef {
     }
 }
 
-lazy_static! {
-    /// There is one runqueue per core, each core only accesses its own private runqueue
-    /// and allows the scheduler to select a task from that runqueue to schedule in.
-    pub static ref RUNQUEUES: AtomicMap<u8, RwLockIrqSafe<RunQueue>> = AtomicMap::new();
-}
+/// There is one runqueue per core, each core only accesses its own private runqueue
+/// and allows the scheduler to select a task from that runqueue to schedule in.
+pub static RUNQUEUES: AtomicMap<u8, RwLockIrqSafe<RunQueue>> = AtomicMap::new();
 
 /// A list of references to `Task`s (`RoundRobinTaskRef`s). 
 /// This is used to store the `Task`s (and associated scheduler related data) 

--- a/kernel/state_transfer/src/lib.rs
+++ b/kernel/state_transfer/src/lib.rs
@@ -50,7 +50,7 @@ pub fn prio_sched(_old_namespace: &Arc<CrateNamespace>, _new_namespace: &CrateNa
 
     // __lazy_static_create!(RQEMPTY, AtomicMap<u8, RwLockIrqSafe<runqueue_round_robin::RunQueue>>);
     // lazy_static! { static ref RQEMPTY: AtomicMap<u8, RwLockIrqSafe<runqueue_round_robin::RunQueue>> = AtomicMap::new(); }
-    let rq_ptr = runqueue_round_robin::RUNQUEUES.deref() as *const _ as usize;
+    let rq_ptr = &runqueue_round_robin::RUNQUEUES as *const _ as usize;
     let once_rq = core::mem::replace(
         unsafe { &mut *(rq_ptr as *mut AtomicMap<u8, RwLockIrqSafe<runqueue_round_robin::RunQueue>>) }, 
         AtomicMap::new()

--- a/kernel/storage_manager/Cargo.toml
+++ b/kernel/storage_manager/Cargo.toml
@@ -7,14 +7,7 @@ version = "0.1.0"
 [dependencies]
 spin = "0.9.0"
 owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
-
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
+log = "0.4.8"
 
 [dependencies.storage_device]
 path = "../storage_device"

--- a/kernel/storage_manager/src/lib.rs
+++ b/kernel/storage_manager/src/lib.rs
@@ -5,7 +5,6 @@
 
 extern crate alloc;
 #[macro_use] extern crate log;
-#[macro_use] extern crate lazy_static;
 extern crate spin;
 extern crate owning_ref;
 extern crate pci;
@@ -22,11 +21,8 @@ use storage_device::StorageControllerRef;
 
 pub use storage_device::*;
 
-
-lazy_static! {
-    /// A list of all of the available and initialized storage controllers that exist on this system.
-    static ref STORAGE_CONTROLLERS: Mutex<Vec<StorageControllerRef>> = Mutex::new(Vec::new());
-}
+/// A list of all of the available and initialized storage controllers that exist on this system.
+static STORAGE_CONTROLLERS: Mutex<Vec<StorageControllerRef>> = Mutex::new(Vec::new());
 
 /// Returns an iterator over all initialized storage controllers on this system.
 /// 

--- a/kernel/task/Cargo.toml
+++ b/kernel/task/Cargo.toml
@@ -9,13 +9,7 @@ spin = "0.9.0"
 x86_64 = "0.14.8"
 static_assertions = "1.1.0"
 crossbeam-utils = { version = "0.8.5", default-features = false }
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
+log = "0.4.8"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -27,9 +27,9 @@
 
 #![no_std]
 #![feature(panic_info_message)]
+#![feature(const_btree_new)]
 
 #[macro_use] extern crate alloc;
-#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 #[macro_use] extern crate static_assertions;
 extern crate irq_safety;
@@ -115,10 +115,8 @@ impl PanicInfoOwned {
 }
 
 
-lazy_static! {
-    /// The list of all Tasks in the system.
-    pub static ref TASKLIST: MutexIrqSafe<BTreeMap<usize, TaskRef>> = MutexIrqSafe::new(BTreeMap::new());
-}
+/// The list of all Tasks in the system.
+pub static TASKLIST: MutexIrqSafe<BTreeMap<usize, TaskRef>> = MutexIrqSafe::new(BTreeMap::new());
 
 
 /// returns a shared reference to the `Task` specified by the given `task_id`

--- a/kernel/terminal_print/Cargo.toml
+++ b/kernel/terminal_print/Cargo.toml
@@ -17,10 +17,5 @@ path = "../../kernel/task"
 [dependencies.logger]
 path = "../../kernel/logger"
 
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
-
 [dependencies.event_types]
 path = "../../kernel/event_types"

--- a/kernel/terminal_print/src/lib.rs
+++ b/kernel/terminal_print/src/lib.rs
@@ -13,9 +13,9 @@
 //! If an application itself spawns child tasks, those will not be able to properly print through these interfaces.
 
 #![no_std]
+#![feature(const_btree_new)]
 
 #[macro_use] extern crate alloc;
-#[macro_use] extern crate lazy_static;
 extern crate logger;
 extern crate task;
 extern crate dfqueue;
@@ -44,11 +44,9 @@ macro_rules! print {
     });
 }
 
-lazy_static! {
-    /// Maps the child application's task ID to its parent terminal print_producer to track parent-child relationships between
-    /// applications so that applications can print to the correct terminal
-    static ref TERMINAL_PRINT_PRODUCERS: Mutex<BTreeMap<usize, DFQueueProducer<Event>>> = Mutex::new(BTreeMap::new());
-}
+/// Maps the child application's task ID to its parent terminal print_producer to track parent-child relationships between
+/// applications so that applications can print to the correct terminal
+static TERMINAL_PRINT_PRODUCERS: Mutex<BTreeMap<usize, DFQueueProducer<Event>>> = Mutex::new(BTreeMap::new());
 
 /// Adds the (child application's task ID, parent terminal print_producer) key-val pair to the map 
 /// Simulates connecting an output stream to the application

--- a/kernel/tss/Cargo.toml
+++ b/kernel/tss/Cargo.toml
@@ -5,16 +5,9 @@ description = "TSS (Task State Segment support (x86 only) for Theseus"
 version = "0.1.0"
 
 [dependencies]
+log = "0.4.8"
 spin = "0.9.0"
 x86_64 = "0.14.8"
-
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
 
 [dependencies.atomic_linked_list]
 path = "../../libs/atomic_linked_list"

--- a/kernel/tss/src/lib.rs
+++ b/kernel/tss/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 
-#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 extern crate atomic_linked_list;
 extern crate memory;
@@ -17,11 +16,8 @@ use memory::VirtualAddress;
 /// The index of the double fault stack in a TaskStateSegment (TSS)
 pub const DOUBLE_FAULT_IST_INDEX: usize = 0;
 
-
-lazy_static! {
-    /// The TSS list, one per core, indexed by a key of apic_id.
-    static ref TSS: AtomicMap<u8, Mutex<TaskStateSegment>> = AtomicMap::new();
-}
+/// The TSS list, one per core, indexed by a key of apic_id.
+static TSS: AtomicMap<u8, Mutex<TaskStateSegment>> = AtomicMap::new();
 
 
 /// Sets the current core's TSS privilege stack 0 (RSP0) entry, which points to the stack that 

--- a/libs/atomic_linked_list/src/atomic_linked_list.rs
+++ b/libs/atomic_linked_list/src/atomic_linked_list.rs
@@ -34,10 +34,12 @@ pub struct AtomicLinkedList<T> {
 }
 
 impl<T> AtomicLinkedList<T> {
-    /// create a new empty AtomicLinkedList.
-    pub fn new() -> AtomicLinkedList<T> {
+    /// Create a new empty AtomicLinkedList.
+    /// 
+    /// Does not perform any allocation until a new node is created.
+    pub const fn new() -> AtomicLinkedList<T> {
         AtomicLinkedList {
-            head: AtomicPtr::default(), // null ptr
+            head: AtomicPtr::new(core::ptr::null_mut()), // null ptr
         }
     }
 

--- a/libs/atomic_linked_list/src/atomic_map.rs
+++ b/libs/atomic_linked_list/src/atomic_map.rs
@@ -38,10 +38,12 @@ pub struct AtomicMap<K, V> where K: PartialEq {
 }
 
 impl<K, V> AtomicMap<K, V> where K: PartialEq {
-    /// create a new empty AtomicMap.
-    pub fn new() -> AtomicMap<K, V> {
+    /// Create a new empty AtomicMap.
+    /// 
+    /// Does not perform any allocation until a new node is created.
+    pub const fn new() -> AtomicMap<K, V> {
         AtomicMap {
-            head: AtomicPtr::default(), // null ptr
+            head: AtomicPtr::new(core::ptr::null_mut()), // null ptr
         }
     }
 

--- a/libs/atomic_linked_list/src/lib.rs
+++ b/libs/atomic_linked_list/src/lib.rs
@@ -6,7 +6,6 @@
 
 extern crate alloc;
 
-
 /// A basic atomic linked list. 
 pub mod atomic_linked_list;
 

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -8,26 +8,16 @@ version = "0.1.0"
 dependencies = [
  "acpi_table",
  "acpi_table_handler",
- "ap_start",
- "apic",
  "dmar",
  "fadt",
  "hpet",
- "ioapic",
  "iommu",
- "irq_safety",
- "kernel_config",
- "lazy_static",
  "log",
  "madt",
  "memory",
- "pause",
- "pic",
- "pit_clock",
  "rsdp",
  "rsdt",
  "spin 0.9.0",
- "volatile 0.2.7",
 ]
 
 [[package]]
@@ -73,12 +63,10 @@ dependencies = [
  "interrupts",
  "irq_safety",
  "kernel_config",
- "lazy_static",
  "log",
  "memory",
  "scheduler",
  "spawn",
- "spin 0.9.0",
  "stack",
  "tlb_shootdown",
 ]
@@ -92,7 +80,6 @@ dependencies = [
  "crossbeam-utils",
  "irq_safety",
  "kernel_config",
- "lazy_static",
  "log",
  "memory",
  "msr",
@@ -113,7 +100,6 @@ dependencies = [
  "core2",
  "event_types",
  "keycodes_ascii",
- "lazy_static",
  "libterm",
  "log",
  "logger",
@@ -519,7 +505,6 @@ dependencies = [
 name = "external_unwind_info"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "log",
  "memory",
  "spin 0.9.0",
@@ -561,7 +546,6 @@ version = "0.1.0"
 dependencies = [
  "apic",
  "irq_safety",
- "lazy_static",
  "log",
  "memory",
  "print",
@@ -609,7 +593,6 @@ dependencies = [
  "compositor",
  "framebuffer",
  "hashbrown",
- "lazy_static",
  "shapes",
  "spin 0.9.0",
 ]
@@ -649,7 +632,6 @@ dependencies = [
  "atomic_linked_list",
  "bit_field 0.7.0",
  "bitflags",
- "lazy_static",
  "log",
  "memory",
  "spin 0.9.0",
@@ -776,7 +758,6 @@ name = "ioapic"
 version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
- "lazy_static",
  "log",
  "memory",
  "owning_ref",
@@ -1367,7 +1348,6 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "irq_safety",
- "lazy_static",
  "log",
  "single_simd_task_optimization",
  "task",
@@ -1379,7 +1359,6 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "irq_safety",
- "lazy_static",
  "log",
  "task",
 ]
@@ -1390,7 +1369,6 @@ version = "0.1.0"
 dependencies = [
  "atomic_linked_list",
  "irq_safety",
- "lazy_static",
  "log",
  "single_simd_task_optimization",
  "task",
@@ -1684,7 +1662,6 @@ dependencies = [
  "environment",
  "irq_safety",
  "kernel_config",
- "lazy_static",
  "log",
  "memory",
  "mod_mgmt",
@@ -1738,7 +1715,6 @@ dependencies = [
  "core2",
  "cstr_core",
  "heap",
- "lazy_static",
  "libc",
  "log",
  "memchr",
@@ -1762,7 +1738,6 @@ version = "0.1.0"
 dependencies = [
  "apic",
  "atomic_linked_list",
- "lazy_static",
  "log",
  "memory",
  "spin 0.9.0",

--- a/tlibc/Cargo.toml
+++ b/tlibc/Cargo.toml
@@ -14,10 +14,6 @@ core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nig
 memchr = { version = "2.2.0", default-features = false }
 cbitset = "0.2.0"
 
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
-
 [dependencies.memory]
 path = "../kernel/memory"
 

--- a/tlibc/src/lib.rs
+++ b/tlibc/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(core_intrinsics)]
 #![feature(linkage)]
 #![feature(thread_local)]
+#![feature(const_btree_new)]
 
 // Allowances for C-style syntax.
 #![allow(non_upper_case_globals)]
@@ -18,7 +19,6 @@ extern crate heap;
 
 extern crate alloc;
 #[macro_use] extern crate log;
-#[macro_use] extern crate lazy_static;
 extern crate libc; // for C types
 extern crate spin;
 extern crate memchr;

--- a/tlibc/src/stdlib.rs
+++ b/tlibc/src/stdlib.rs
@@ -8,10 +8,8 @@ use alloc::{
 use spin::Mutex;
 
 
-lazy_static! {
-    /// A map from the set of pointers that have been malloc-ed to the layouts they were malloc-ed with.
-    static ref POINTER_LAYOUTS: Mutex<BTreeMap<usize, Layout>> = Mutex::new(BTreeMap::new());
-}
+/// A map from the set of pointers that have been malloc-ed to the layouts they were malloc-ed with.
+static POINTER_LAYOUTS: Mutex<BTreeMap<usize, Layout>> = Mutex::new(BTreeMap::new());
 
 
 #[no_mangle]


### PR DESCRIPTION
With recent Rust improvements, more things like constructors are `const fn`, e.g., `BTreeMap`. Thus, we no longer need to use `lazy_static` everywhere, which has mild overhead.