### PR TITLE
Avoid `lazy_static` for TLS init by using const `RangeMap::new()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,7 +1889,6 @@ dependencies = [
  "fs_node",
  "hashbrown",
  "kernel_config",
- "lazy_static",
  "log",
  "lz4_flex",
  "memfs",
@@ -2513,9 +2512,8 @@ checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 
 [[package]]
 name = "rangemap"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cb84161aa5e5eaa263fadf53172fee10b72fa7aad3a37e0a7aa1aefec2423e"
+version = "1.0.3"
+source = "git+https://github.com/theseus-os/rangemap?branch=const_fn_constructor#be8b0ee4cfe51d587d4317f37a2db7c75f2d2647"
 
 [[package]]
 name = "raw-cpuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,9 @@ volatile = { git = "https://github.com/theseus-os/volatile" }
 getopts = { git = "https://github.com/theseus-os/getopts" }
 ### use the latest version of smoltcp from github; the one on crates.io is out of date
 smoltcp = { git = "https://github.com/m-labs/smoltcp" }
+### Use our fork of `rangemap`, which makes constructors const functions.
+### This can be removed once this PR lands: <https://github.com/jeffparsons/rangemap/pull/52>
+rangemap = { git = "https://github.com/theseus-os/rangemap", branch = "const_fn_constructor" }
 
 ### Patch `libc` so we can use libc-specific types when using `cfg(target_os = "theseus")`.
 libc = { git = "https://github.com/theseus-os/libc", branch = "theseus" }

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -11,7 +11,7 @@ xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.gi
 rustc-demangle = "0.1.19"
 qp-trie = "0.8.0"
 cstr_core = "0.2.3"
-rangemap = "0.1.13"
+rangemap = { version = "1.0.3", features = [ "const_fn" ] }
 const_format = "0.2.2"
 lz4_flex = { version = "0.9.3", default-features = false, optional = true }
 cpio_reader = { version = "0.1.0", optional = true }
@@ -21,10 +21,6 @@ cpio_reader = { version = "0.1.0", optional = true }
 # from a compressed "modules.cpio.lz4" module.
 # Currently this is enabled when building for the 'limine' bootloader.
 extract_boot_modules = ["lz4_flex", "cpio_reader"]
-
-[dependencies.lazy_static]
-features = ["spin_no_std"]
-version = "1.4.0"
 
 [dependencies.util]
 path = "../../libs/util"

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -1016,7 +1016,6 @@ dependencies = [
  "fs_node",
  "hashbrown",
  "kernel_config",
- "lazy_static",
  "log",
  "memfs",
  "memory",
@@ -1283,9 +1282,8 @@ dependencies = [
 
 [[package]]
 name = "rangemap"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cb84161aa5e5eaa263fadf53172fee10b72fa7aad3a37e0a7aa1aefec2423e"
+version = "1.0.3"
+source = "git+https://github.com/theseus-os/rangemap?branch=const_fn_constructor#be8b0ee4cfe51d587d4317f37a2db7c75f2d2647"
 
 [[package]]
 name = "raw-cpuid"

--- a/tlibc/Cargo.toml
+++ b/tlibc/Cargo.toml
@@ -51,6 +51,9 @@ volatile = { git = "https://github.com/theseus-os/volatile" }
 getopts = { git = "https://github.com/theseus-os/getopts" }
 ### use the latest version of smoltcp from github; the one on crates.io is out of date
 smoltcp = { git = "https://github.com/m-labs/smoltcp" }
+### Use our fork of `rangemap`, which makes constructors const functions.
+### This can be removed once this PR lands: <https://github.com/jeffparsons/rangemap/pull/52>
+rangemap = { git = "https://github.com/theseus-os/rangemap", branch = "const_fn_constructor" }
 
 ### Patch `libc` so we can use libc-specific types when using `cfg(target_os = "theseus")`.
 libc = { git = "https://github.com/theseus-os/libc", branch = "theseus" }

--- a/tools/serialize_nano_core/Cargo.lock
+++ b/tools/serialize_nano_core/Cargo.lock
@@ -473,7 +473,6 @@ dependencies = [
  "fs_node",
  "hashbrown",
  "kernel_config",
- "lazy_static",
  "log",
  "memfs",
  "memory",
@@ -610,9 +609,8 @@ dependencies = [
 
 [[package]]
 name = "rangemap"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3929836cb64d09ee7deee59635c3d9bffbc1c0373e247efff6272abd62a11baa"
+version = "1.0.3"
+source = "git+https://github.com/theseus-os/rangemap?branch=const_fn_constructor#be8b0ee4cfe51d587d4317f37a2db7c75f2d2647"
 
 [[package]]
 name = "root"

--- a/tools/serialize_nano_core/Cargo.toml
+++ b/tools/serialize_nano_core/Cargo.toml
@@ -16,3 +16,8 @@ serde = { version = "1.0", features = ["derive"] }
 [dependencies.bincode]
 version = "2.0.0-rc.1"
 features = ["serde"]
+
+[patch.crates-io]
+### Use our fork of `rangemap`, which makes constructors const functions.
+### This can be removed once this PR lands: <https://github.com/jeffparsons/rangemap/pull/52>
+rangemap = { git = "https://github.com/theseus-os/rangemap", branch = "const_fn_constructor" }


### PR DESCRIPTION
* Added our own fork of `rangemap`, waiting on PR acceptance.