### PR TITLE
Break `pit_clock` into two crates to alleviate cyclic dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
  "memory",
  "msr",
  "owning_ref",
- "pit_clock",
+ "pit_clock_basic",
  "raw-cpuid",
  "spin 0.9.0",
  "static_assertions",
@@ -1304,7 +1304,6 @@ dependencies = [
  "exceptions_early",
  "gdt",
  "irq_safety",
- "kernel_config",
  "keyboard",
  "lazy_static",
  "locked_idt",
@@ -1312,7 +1311,6 @@ dependencies = [
  "memory",
  "mouse",
  "pic",
- "pit_clock",
  "port_io",
  "ps2",
  "scheduler",
@@ -1419,7 +1417,7 @@ dependencies = [
  "pci",
  "physical_nic",
  "pic",
- "pit_clock",
+ "pit_clock_basic",
  "rand",
  "runqueue",
  "spin 0.9.0",
@@ -1960,7 +1958,7 @@ dependencies = [
  "memory",
  "mod_mgmt",
  "pause",
- "pit_clock",
+ "pit_clock_basic",
  "spin 0.9.0",
  "stack",
  "volatile 0.2.7",
@@ -2349,6 +2347,17 @@ dependencies = [
 
 [[package]]
 name = "pit_clock"
+version = "0.1.0"
+dependencies = [
+ "interrupts",
+ "log",
+ "pit_clock_basic",
+ "port_io",
+ "x86_64",
+]
+
+[[package]]
+name = "pit_clock_basic"
 version = "0.1.0"
 dependencies = [
  "log",
@@ -2919,7 +2928,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "core_simd",
  "log",
- "pit_clock",
 ]
 
 [[package]]
@@ -3591,7 +3599,7 @@ name = "tsc"
 version = "0.1.0"
 dependencies = [
  "log",
- "pit_clock",
+ "pit_clock_basic",
 ]
 
 [[package]]

--- a/kernel/apic/Cargo.toml
+++ b/kernel/apic/Cargo.toml
@@ -25,8 +25,8 @@ path = "../../libs/atomic_linked_list"
 [dependencies.msr]
 path = "../../libs/msr"
 
-[dependencies.pit_clock]
-path = "../pit_clock"
+[dependencies.pit_clock_basic]
+path = "../pit_clock_basic"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -15,17 +15,15 @@ use memory::{PageTable, PhysicalAddress, EntryFlags, MappedPages, allocate_pages
 use kernel_config::time::CONFIG_TIMESLICE_PERIOD_MICROSECONDS;
 use atomic_linked_list::atomic_map::AtomicMap;
 use crossbeam_utils::atomic::AtomicCell;
-use pit_clock::pit_wait;
+use pit_clock_basic::pit_wait;
 use bit_field::BitField;
 use static_assertions::{const_assert, const_assert_eq};
 use log::{error, info, debug, trace};
 
-/// The IRQ vector number defined by the IDT for Local APIC timer interrupts.
-/// 
-/// TODO: once we invert the dependency relationship between `interrupts`
-///       and all other crates, we should be able to define this in `interrupts`
-///       and then use that definition here.
-const LOCAL_APIC_LVT_IRQ: u8 = 0x22;
+/// The IRQ number reserved for Local APIC timer interrupts in the IDT.
+pub const LOCAL_APIC_LVT_IRQ: u8 = 0x22;
+/// The IRQ number reserved for spurios interrupts (as recommended by OS dev wiki).
+pub const APIC_SPURIOUS_INTERRUPT_IRQ: u8 = 0xFF;
 
 /// The interrupt chip that is currently configured on this machine. 
 /// The default is `InterruptChip::PIC`, but the typical case is `APIC` or `X2APIC`,
@@ -167,7 +165,6 @@ fn map_apic(page_table: &mut PageTable) -> Result<MappedPages, &'static str> {
 
 
 
-pub const APIC_SPURIOUS_INTERRUPT_VECTOR: u32 = 0xFF; // as recommended by everyone on os dev wiki
 const IA32_APIC_XAPIC_ENABLE: u64 = 1 << 11; // 0x800
 const IA32_APIC_X2APIC_ENABLE: u64 = 1 << 10; // 0x400
 const IA32_APIC_BASE_MSR_IS_BSP: u64 = 1 << 8; // 0x100
@@ -340,6 +337,8 @@ impl LocalApic {
         nmi_flags: u16
     ) -> Result<LocalApic, &'static str> {
 
+        trace!("size of LocalApic: {}", core::mem::size_of::<LocalApic>());
+
         let nmi_lint = match nmi_lint {
             0 => LvtLint::Pin0,
             1 => LvtLint::Pin1,
@@ -444,7 +443,7 @@ impl LocalApic {
                     wrmsr(IA32_X2APIC_TPR,        0);
                     
                     // set bit 8 to start receiving interrupts (still need to "sti")
-                    wrmsr(IA32_X2APIC_SIVR, (APIC_SPURIOUS_INTERRUPT_VECTOR | APIC_SW_ENABLE) as u64); 
+                    wrmsr(IA32_X2APIC_SIVR, (APIC_SPURIOUS_INTERRUPT_IRQ as u32 | APIC_SW_ENABLE) as u64); 
                 }
             }
             LapicType::XApic(regs) => {
@@ -466,7 +465,7 @@ impl LocalApic {
                 regs.task_priority.write(0);
 
                 // set bit 8 to allow receiving interrupts (still need to "sti")
-                regs.spurious_interrupt_vector.write(APIC_SPURIOUS_INTERRUPT_VECTOR | APIC_SW_ENABLE);   
+                regs.spurious_interrupt_vector.write(APIC_SPURIOUS_INTERRUPT_IRQ as u32 | APIC_SW_ENABLE);   
             }
         }
     }

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -26,9 +26,6 @@ path = "../../libs/port_io"
 [dependencies.memory]
 path = "../memory"
 
-[dependencies.kernel_config]
-path = "../kernel_config"
-
 [dependencies.apic]
 path = "../apic"
 
@@ -49,9 +46,6 @@ path = "../exceptions_early"
 
 [dependencies.task]
 path = "../task"
-
-[dependencies.pit_clock]
-path = "../pit_clock"
 
 [dependencies.keyboard]
 path = "../keyboard"

--- a/kernel/ixgbe/Cargo.toml
+++ b/kernel/ixgbe/Cargo.toml
@@ -47,8 +47,8 @@ path = "../pci"
 [dependencies.acpi]
 path = "../acpi"
 
-[dependencies.pit_clock]
-path = "../pit_clock"
+[dependencies.pit_clock_basic]
+path = "../pit_clock_basic"
 
 [dependencies.interrupts]
 path = "../interrupts"

--- a/kernel/ixgbe/src/lib.rs
+++ b/kernel/ixgbe/src/lib.rs
@@ -18,7 +18,7 @@ extern crate irq_safety;
 extern crate kernel_config;
 extern crate memory;
 extern crate pci; 
-extern crate pit_clock;
+extern crate pit_clock_basic;
 extern crate bit_field;
 extern crate interrupts;
 extern crate x86_64;
@@ -681,7 +681,7 @@ impl IxgbeNic {
 
         //wait 10 ms
         let wait_time = 10_000;
-        let _ =pit_clock::pit_wait(wait_time);
+        pit_clock_basic::pit_wait(wait_time)?;
 
         //disable flow control.. write 0 TO FCTTV, FCRTL, FCRTH, FCRTV and FCCFG
         for fcttv in regs2.fcttv.iter_mut() {
@@ -718,7 +718,7 @@ impl IxgbeNic {
 
         while Self::acquire_semaphore(regs3)? {
             //wait 10 ms
-            let _ =pit_clock::pit_wait(wait_time);
+            pit_clock_basic::pit_wait(wait_time)?;
         }
 
         // setup PHY and the link 
@@ -756,7 +756,7 @@ impl IxgbeNic {
         let mut tries = 0;
 
         while (regs2.links.read() & LINKS_SPEED_MASK == 0) && (tries < total_tries) {
-            let _ = pit_clock::pit_wait(wait_time);
+            let _ = pit_clock_basic::pit_wait(wait_time); // wait, or try again regardless
             tries += 1;
         }
     }

--- a/kernel/multicore_bringup/Cargo.toml
+++ b/kernel/multicore_bringup/Cargo.toml
@@ -24,8 +24,8 @@ path = "../stack"
 [dependencies.kernel_config]
 path = "../kernel_config"
 
-[dependencies.pit_clock]
-path = "../pit_clock"
+[dependencies.pit_clock_basic]
+path = "../pit_clock_basic"
 
 [dependencies.mod_mgmt]
 path = "../mod_mgmt"

--- a/kernel/multicore_bringup/src/lib.rs
+++ b/kernel/multicore_bringup/src/lib.rs
@@ -12,7 +12,7 @@ extern crate volatile;
 extern crate zerocopy;
 extern crate irq_safety;
 extern crate memory;
-extern crate pit_clock;
+extern crate pit_clock_basic;
 extern crate stack;
 extern crate kernel_config;
 extern crate apic;
@@ -310,7 +310,7 @@ fn bring_up_ap(
     }
 
     debug!("waiting 10 ms...");
-    pit_clock::pit_wait(10000).unwrap_or_else(|_e| { error!("bring_up_ap(): failed to pit_wait 10 ms. Error: {:?}", _e); });
+    pit_clock_basic::pit_wait(10000).unwrap_or_else(|_e| { error!("bring_up_ap(): failed to pit_wait 10 ms. Error: {:?}", _e); });
     debug!("done waiting.");
 
     // // Send DEASSERT INIT IPI
@@ -347,8 +347,8 @@ fn bring_up_ap(
         bsp_lapic.set_icr(icr);
     }
 
-    pit_clock::pit_wait(300).unwrap_or_else(|_e| { error!("bring_up_ap(): failed to pit_wait 300 us. Error {:?}", _e); });
-    pit_clock::pit_wait(200).unwrap_or_else(|_e| { error!("bring_up_ap(): failed to pit_wait 200 us. Error {:?}", _e); });
+    pit_clock_basic::pit_wait(300).unwrap_or_else(|_e| { error!("bring_up_ap(): failed to pit_wait 300 us. Error {:?}", _e); });
+    pit_clock_basic::pit_wait(200).unwrap_or_else(|_e| { error!("bring_up_ap(): failed to pit_wait 200 us. Error {:?}", _e); });
 
     bsp_lapic.clear_error();
     let esr = bsp_lapic.error();

--- a/kernel/pit_clock/Cargo.toml
+++ b/kernel/pit_clock/Cargo.toml
@@ -5,10 +5,14 @@ description = "PIT (Programmable Interval Timer) support for Theseus, x86 only."
 version = "0.1.0"
 
 [dependencies]
-spin = "0.9.0"
+log = "0.4.8"
+x86_64 = "0.14.8"
 
-[dependencies.log]
-version = "0.4.8"
+[dependencies.pit_clock_basic]
+path = "../pit_clock_basic"
+
+[dependencies.interrupts]
+path = "../interrupts"
 
 [dependencies.port_io]
 path = "../../libs/port_io"

--- a/kernel/pit_clock/src/lib.rs
+++ b/kernel/pit_clock/src/lib.rs
@@ -1,45 +1,54 @@
-//! Support for the Programmable Interval Timer (PIT) system clock,
-//! which enables and configures the frequency of simple timer interrupts
-//! and basic timer-based one-shot wait period.
+//! Full support for the Programmable Interval Timer (PIT) system clock.
+//! 
+//! This crate allows one to enable/configure PIT interrupts.
+//! For a simpler crate that just allows PIT-based waiting, use `pit_clock_basic`.
 
 #![no_std]
+#![feature(abi_x86_interrupt)]
 
-extern crate spin;
 #[macro_use] extern crate log;
 extern crate port_io;
+extern crate pit_clock_basic;
+extern crate interrupts;
+extern crate x86_64;
 
 use port_io::Port;
-use spin::Mutex;
 use core::sync::atomic::{AtomicUsize, Ordering};
+use x86_64::structures::idt::InterruptStackFrame;
+
+pub use pit_clock_basic::pit_wait;
+use pit_clock_basic::*;
+
+/// The PIT Channel 0 is connected directly to IRQ 0.
+/// Because we perform the typical PIC remapping, the remapped IRQ vector number is 0x20.
+const PIT_CHANNEL_0_IRQ: u8 = interrupts::IRQ_BASE_OFFSET + 0x0;
 
 
-/// the main interrupt channel
-const CHANNEL0: u16 = 0x40;
-/// DO NOT USE
-const _CHANNEL1: u16 = 0x41;
-/// the speaker for beeping.
-/// also used for one-shot waits.
-const CHANNEL2: u16 = 0x42;
-
-const COMMAND_REGISTER: u16 = 0x43;
-
-
-/// the timer's default frequency is 1.19 MHz
-const PIT_DEFAULT_DIVIDEND_HZ: u32 = 1193182;
-const PIT_MINIMUM_FREQ: u32 = 19;
-
-static PIT_COMMAND: Mutex<Port<u8>> = Mutex::new( Port::new(COMMAND_REGISTER) );
-static PIT_CHANNEL_0: Mutex<Port<u8>> = Mutex::new( Port::new(CHANNEL0) );
-static PIT_CHANNEL_2: Mutex<Port<u8>> = Mutex::new( Port::new(CHANNEL2) );
-
-static PIT_TICKS: AtomicUsize = AtomicUsize::new(0);
-
-
-pub fn init(freq_hertz: u32) {
+/// Configures the PIT to fire an interrupt at the given frequency (in Hz).
+/// 
+/// Only Channel 0 of the PIT is directly connected to an IRQ, so it must be used.
+/// Note that Channel 1 does not exist and Channel 2 is reserved for non-interrupt timer usage.
+/// 
+/// ## Arguments
+/// * `freq_hertz`: the frequency in Hz of the desired PIT interrupt.
+///    The minimum value is 19 Hz, which is based on the fact that the timer register
+///    cannot be loaded with a value larger than `u16::MAX` (65535),
+///    and that the value loaded into the register is a divisor value.
+///    That divisor value is the default timer frequency 1193182 divided by `freq_hertz`.
+pub fn enable_interrupts(freq_hertz: u32) -> Result<(), &'static str> {
     let divisor = PIT_DEFAULT_DIVIDEND_HZ / freq_hertz;
-    if divisor > (u16::max_value() as u32) {
-        panic!("The chosen PIT frequency ({} Hz) is too small, it must be {} Hz or greater!", 
-                freq_hertz, PIT_MINIMUM_FREQ);
+    if divisor > u16::MAX as u32 {
+        error!("The chosen PIT frequency ({} Hz) is too small, it must be {} Hz or greater!", 
+            freq_hertz, PIT_MINIMUM_FREQ
+        );
+        return Err("The chosen PIT frequency is too small, it must be 19 Hz or greated")
+    }
+
+    // Register the interrupt handler
+    match interrupts::register_interrupt(PIT_CHANNEL_0_IRQ, pit_timer_handler) {
+        Ok(_) => { /* success, do nothing */}
+        Err(handler) if handler == pit_timer_handler as u64 => { /* already registered, do nothing */ }
+        Err(_other) => return Err(" PIT clock IRQ was already in use; sharing IRQs is currently unsupported"),
     }
 
     // SAFE because we're simply configuring the PIT clock, and the code below is correct.
@@ -52,50 +61,15 @@ pub fn init(freq_hertz: u32) {
         let _ignore: u8 = Port::new(0x60).read();
         PIT_CHANNEL_0.lock().write((divisor >> 8) as u8);
     }
+
+    Ok(())
 }
 
 
-/// Wait a certain number of microseconds, max 55555 microseconds.
-/// Uses a separate PIT clock channel, so it doesn't affect the regular PIT interrupts on PIT channel 0.
-pub fn pit_wait(microseconds: u32) -> Result<(), &'static str> {
-    let divisor = PIT_DEFAULT_DIVIDEND_HZ / (1000000/microseconds); 
-    if divisor > (u16::max_value() as u32) {
-        error!("pit_wait(): the chosen wait time {}us is too large, max value is {}!", microseconds, 1000000/PIT_MINIMUM_FREQ);
-        return Err("microsecond value was too large");
-    }
-
-    // SAFE because we're simply configuring the PIT clock, and the code below is correct.
-    unsafe {
-        let port_60 = Port::<u8>::new(0x60);
-        let port_61 = Port::<u8>::new(0x61);
-
-        // see code example: https://wiki.osdev.org/APIC_timer
-        let port_61_val = port_61.read(); 
-        port_61.write(port_61_val & 0xFD | 0x1); // sets the speaker channel 2 to be controlled by PIT hardware
-        PIT_COMMAND.lock().write(0b10110010); // channel 2, access mode: lobyte/hibyte, hardware-retriggerable one shot mode, 16-bit binary (not BCD)
-
-        // set frequency; must write the low byte first and then the high byte
-        PIT_CHANNEL_2.lock().write(divisor as u8);
-        // read from PS/2 port 0x60, which acts as a short delay and acknowledges the status register
-        let _ignore: u8 = port_60.read();
-        PIT_CHANNEL_2.lock().write((divisor >> 8) as u8);
-        
-        // reset PIT one-shot counter
-        let port_61_val = port_61.read() & 0xFE;
-        port_61.write(port_61_val); // clear bit 0
-        port_61.write(port_61_val | 0x1); // set bit 0
-        // here, PIT channel 2 timer has started counting
-        // here, should also run custom reset function (closure input), e.g., resetting APIC counter
-        
-        // wait for PIT timer to reach 0, which is tested by checking bit 5
-        while port_61.read() & 0x20 != 0 { }
-        Ok(())
-    }
-}
-
-/// this occurs on every PIT timer tick.
-/// Called by the PIT's interrupt handler
-pub fn handle_timer_interrupt() {
+extern "x86-interrupt" fn pit_timer_handler(_stack_frame: InterruptStackFrame) {
+    static PIT_TICKS: AtomicUsize = AtomicUsize::new(0);
     let ticks = PIT_TICKS.fetch_add(1, Ordering::Acquire);
     trace!("PIT timer interrupt, ticks: {}", ticks);
+
+    interrupts::eoi(Some(PIT_CHANNEL_0_IRQ));
 }

--- a/kernel/pit_clock_basic/Cargo.toml
+++ b/kernel/pit_clock_basic/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "pit_clock_basic"
+description = "Basic support for waiting using the PIT (Programmable Interval Timer)"
+version = "0.1.0"
+
+[dependencies]
+spin = "0.9.0"
+log = "0.4.8"
+
+[dependencies.port_io]
+path = "../../libs/port_io"
+
+[lib]
+crate-type = ["rlib"]

--- a/kernel/pit_clock_basic/src/lib.rs
+++ b/kernel/pit_clock_basic/src/lib.rs
@@ -1,0 +1,73 @@
+//! Basic support for waiting using the Programmable Interval Timer (PIT) clock.
+//! 
+//! Use the `pit_clock` crate for a more fully-featured PIT interface,
+//! including enabling interrupts.
+
+#![no_std]
+
+extern crate spin;
+#[macro_use] extern crate log;
+extern crate port_io;
+
+use port_io::Port;
+use spin::Mutex;
+
+/// Port for Channel 0; used for PIT interrupts.
+pub const CHANNEL0: u16 = 0x40;
+/// Port for Channel 1, which does not exist and should NOT be used.
+const _CHANNEL1: u16 = 0x41;
+/// Port for Channel 2; technically the speaker for beeps,
+/// but is also used for waiting in `pit_wait()`.
+const CHANNEL2: u16 = 0x42;
+/// Port for the PIT command register. 
+const COMMAND_REGISTER: u16 = 0x43;
+
+/// the timer's default frequency is 1.19 MHz
+pub const PIT_DEFAULT_DIVIDEND_HZ: u32 = 1193182;
+pub const PIT_MINIMUM_FREQ:        u32 = 19;
+
+pub static PIT_COMMAND:   Mutex<Port<u8>> = Mutex::new( Port::new(COMMAND_REGISTER) );
+pub static PIT_CHANNEL_0: Mutex<Port<u8>> = Mutex::new( Port::new(CHANNEL0) );
+static PIT_CHANNEL_2: Mutex<Port<u8>> = Mutex::new( Port::new(CHANNEL2) );
+
+
+/// Waits (blocking) for the given number of `microseconds` using the PIT Channel 2.
+/// 
+/// This uses a separate PIT clock channel so it doesn't affect PIT interrupts.
+/// 
+/// ## Arguments
+/// * `microseconds`: the number of microseconds to wait, max value 55555.
+pub fn pit_wait(microseconds: u32) -> Result<(), &'static str> {
+    let divisor = PIT_DEFAULT_DIVIDEND_HZ / (1000000/microseconds); 
+    if divisor > (u16::max_value() as u32) {
+        error!("pit_wait(): the chosen wait time {}us is too large, max value is {}!", microseconds, 1000000/PIT_MINIMUM_FREQ);
+        return Err("microsecond value was too large");
+    }
+
+    // SAFE because we're simply configuring the PIT clock, and the code below is correct.
+    unsafe {
+        let port_60 = Port::<u8>::new(0x60);
+        let port_61 = Port::<u8>::new(0x61);
+
+        // see code example: https://wiki.osdev.org/APIC_timer
+        let port_61_val = port_61.read(); 
+        port_61.write(port_61_val & 0xFD | 0x1); // sets the speaker channel 2 to be controlled by PIT hardware
+        PIT_COMMAND.lock().write(0b10110010); // channel 2, access mode: lobyte/hibyte, hardware-retriggerable one shot mode, 16-bit binary (not BCD)
+
+        // set frequency; must write the low byte first and then the high byte
+        PIT_CHANNEL_2.lock().write(divisor as u8);
+        // read from PS/2 port 0x60, which acts as a short delay and acknowledges the status register
+        let _ignore: u8 = port_60.read();
+        PIT_CHANNEL_2.lock().write((divisor >> 8) as u8);
+        
+        // reset PIT one-shot counter
+        let port_61_val = port_61.read() & 0xFE;
+        port_61.write(port_61_val); // clear bit 0
+        port_61.write(port_61_val | 0x1); // set bit 0
+        // here, PIT channel 2 timer has started counting
+        
+        // wait for PIT timer to reach 0, which is tested by checking bit 5
+        while port_61.read() & 0x20 != 0 { }
+        Ok(())
+    }
+}

--- a/kernel/simd_test/Cargo.toml
+++ b/kernel/simd_test/Cargo.toml
@@ -6,16 +6,11 @@ version = "0.1.0"
 
 [dependencies]
 cfg-if = "0.1.6"
+log = "0.4.8"
 
 ## Only include the SIMD crates when any SIMD extensions are enabled
 [target.'cfg(target_feature = "sse2")'.dependencies.core_simd]
 git = "https://github.com/rust-lang/stdsimd"
-
-[dependencies.pit_clock]
-path = "../pit_clock"
-
-[dependencies.log]
-version = "0.4.8"
 
 
 [lib]

--- a/kernel/simd_test/src/lib.rs
+++ b/kernel/simd_test/src/lib.rs
@@ -6,7 +6,6 @@
 cfg_if! { if #[cfg(all(simd_personality, target_feature = "sse2"))] {
 
 #[macro_use] extern crate log;
-// extern crate pit_clock;
 extern crate core_simd;
 
 use core_simd::f64x4;
@@ -28,9 +27,6 @@ pub fn test1(_: ()) {
             debug!("SIMD TEST1 (should be 1.111, 11.11, 111.1, 1111): {:?}", x);
         }
         loop_ctr += 1;
-        // for _ in 1..10 {
-        //     let _ = pit_clock::pit_wait(50000);
-        // }
     }
 }
 
@@ -50,9 +46,6 @@ pub fn test2(_: ()) {
             trace!("SIMD TEST2 (should be 2.222, 22.22, 222.2, 2222): {:?}", x);
         }
         loop_ctr += 1;
-        // for _ in 1..10 {
-        //     let _ = pit_clock::pit_wait(50000);
-        // }
     }
 }
 

--- a/kernel/tsc/Cargo.toml
+++ b/kernel/tsc/Cargo.toml
@@ -5,12 +5,10 @@ description = "TSC (TimeStamp Counter) support for performance counters on x86. 
 version = "0.1.0"
 
 [dependencies]
+log = "0.4.8"
 
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.pit_clock]
-path = "../pit_clock"
+[dependencies.pit_clock_basic]
+path = "../pit_clock_basic"
 
 
 [lib]

--- a/kernel/tsc/src/lib.rs
+++ b/kernel/tsc/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 #[macro_use] extern crate log;
-extern crate pit_clock;
+extern crate pit_clock_basic;
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -67,7 +67,7 @@ pub fn get_tsc_frequency() -> Result<u128, &'static str> {
         // a freq of zero means it hasn't yet been initialized.
         let start = tsc_ticks();
         // wait 10000 us (10 ms)
-        pit_clock::pit_wait(10000)?;
+        pit_clock_basic::pit_wait(10000)?;
         let end = tsc_ticks(); 
 
         let diff = end.sub(&start).ok_or("couldn't subtract end-start TSC tick values")?;


### PR DESCRIPTION
* Now there is `pit_clock_basic`, which implements on `pit_wait()`, and
  `pit_clock`, which is a fuller-functional crate that offers PIT interrupts.

* Changed dependent crates to use `pit_clock_basic` when possible.

* This is the first part of our quest to invert the dependencies from `interrupts` -> device crates to the more traditional device crates -> `interrupts`.