### PR TITLE
Refactor PS2 keyboard out of `interrupts` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,6 @@ dependencies = [
  "exceptions_early",
  "gdt",
  "irq_safety",
- "keyboard",
  "locked_idt",
  "log",
  "memory",
@@ -1442,11 +1441,13 @@ name = "keyboard"
 version = "0.1.0"
 dependencies = [
  "event_types",
+ "interrupts",
  "keycodes_ascii",
  "log",
  "mpmc",
  "ps2",
  "spin 0.9.0",
+ "x86_64",
 ]
 
 [[package]]

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -95,7 +95,7 @@ pub fn init(key_producer: Queue<Event>, mouse_producer: Queue<Event>) -> Result<
     init_serial_port(SerialPortAddress::COM1);
     init_serial_port(SerialPortAddress::COM2);
 
-    keyboard::init(key_producer);
+    keyboard::init(key_producer)?;
     mouse::init(mouse_producer);
 
     // Initialize/scan the PCI bus to discover PCI devices

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -41,9 +41,6 @@ path = "../exceptions_early"
 [dependencies.task]
 path = "../task"
 
-[dependencies.keyboard]
-path = "../keyboard"
-
 [dependencies.mouse]
 path = "../mouse"
 

--- a/kernel/keyboard/Cargo.toml
+++ b/kernel/keyboard/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "keyboard"
-description = "The keyboard driver"
+description = "A keyboard driver for keyboards connected to the legacy PS2 port"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies]
 spin = "0.9.0"
+x86_64 = "0.14.8"
 mpmc = "0.1.6"
-
-[dependencies.log]
-version = "0.4.8"
+log = "0.4.8"
 
 [dependencies.keycodes_ascii]
 path = "../../libs/keycodes_ascii"
@@ -19,6 +19,9 @@ path = "../event_types"
 
 [dependencies.ps2]
 path = "../ps2"
+
+[dependencies.interrupts]
+path = "../interrupts"
 
 
 [lib]

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -1,19 +1,21 @@
-#![no_std]
+//! A basic driver for a keyboard connected to the legacy PS2 port.
 
-extern crate keycodes_ascii;
-extern crate spin;
-extern crate event_types;
-extern crate ps2;
-extern crate mpmc;
+#![no_std]
+#![feature(abi_x86_interrupt)]
+
 #[macro_use] extern crate log;
 
-
+use core::sync::atomic::{AtomicBool, Ordering};
 use keycodes_ascii::{Keycode, KeyboardModifiers, KEY_RELEASED_OFFSET, KeyAction, KeyEvent};
 use spin::Once;
 use mpmc::Queue;
 use event_types::Event;
-use ps2::{init_ps2_port1,test_ps2_port1,keyboard_led,keyboard_detect,KeyboardType};
+use ps2::{init_ps2_port1, test_ps2_port1, keyboard_led, keyboard_detect, KeyboardType};
+use x86_64::structures::idt::InterruptStackFrame;
 
+/// The first PS2 port for the keyboard is connected directly to IRQ 1.
+/// Because we perform the typical PIC remapping, the remapped IRQ vector number is 0x21.
+const PS2_KEYBOARD_IRQ: u8 = interrupts::IRQ_BASE_OFFSET + 0x1;
 
 // TODO: avoid unsafe static mut using the following: https://www.reddit.com/r/rust/comments/1wvxcn/lazily_initialized_statics/cf61im5/
 static mut KBD_MODIFIERS: KeyboardModifiers = KeyboardModifiers::new();
@@ -28,37 +30,97 @@ const NUM_LED: u8 = 0b010;
 /// Bitmask for the Caps Lock keyboard LED
 const CAPS_LED: u8 = 0b100;
 
-/// Initialize the keyboard driver. 
-/// Arguments: a reference to a queue onto which keyboard events should be enqueued. 
-pub fn init(keyboard_queue_producer: Queue<Event>) { 
-    // set keyboard to scancode set 1
-
-    //init the first ps2 port for keyboard
+/// Initialize the PS2 keyboard driver and register its interrupt handler.
+/// 
+/// ## Arguments
+/// * `keyboard_queue_producer`: the queue onto which the keyboard interrupt handler
+///    will push new keyboard events when a key action occurs.
+pub fn init(keyboard_queue_producer: Queue<Event>) -> Result<(), &'static str> {
+    // Init the first ps2 port, which is used for the keyboard.
     init_ps2_port1();
-    //test the first port
+    // Test the first port.
+    // TODO: return an error if this test fails.
     test_ps2_port1();
-    match keyboard_detect(){
-        Err(e) => { 
-            error!("failed to read keyboard type due to: {} ", e)
-        },
-        Ok(s) => {
-            match s {
-                KeyboardType::AncientATKeyboard => info!("Ancient AT Keyboard with translator enabled in the PS/2 Controller"),
-                KeyboardType::MF2Keyboard => info!("MF2Keyboard"),
-                KeyboardType::MF2KeyboardWithPSControllerTranslator => info!("MF2 Keyboard with translator enabled in PS/2 Controller"),
+    // Detect which kind of keyboard is connected.
+    // TODO: actually do something with the keyboard type.
+    match keyboard_detect() {
+        Ok(KeyboardType::AncientATKeyboard) => info!("Ancient AT Keyboard with translator enabled in the PS/2 Controller"),
+        Ok(KeyboardType::MF2Keyboard) => info!("MF2Keyboard"),
+        Ok(KeyboardType::MF2KeyboardWithPSControllerTranslator) => info!("MF2 Keyboard with translator enabled in PS/2 Controller"),
+        Err(e) => {
+            error!("Failed to detect the Ps2 keyboard type, error: {} ", e);
+            return Err("Failed to detect the PS2 keyboard type");
+        }
+    }
+
+    // TODO: set keyboard to scancode set 1, since that's the only one we support (?)
+
+    // Register the interrupt handler
+    interrupts::register_interrupt(PS2_KEYBOARD_IRQ, ps2_keyboard_handler).map_err(|e| {
+        error!("PS2 keyboard IRQ {:#X} was already in use by handler {:#X}! Sharing IRQs is currently unsupported.", 
+            PS2_KEYBOARD_IRQ, e,
+        );
+        "PS2 keyboard IRQ was already in use! Sharing IRQs is currently unsupported."
+    })?;
+
+    // Final step: set the producer end of the keyboard event queue.
+    KEYBOARD_PRODUCER.call_once(|| keyboard_queue_producer);
+    Ok(())
+}
+
+/// The interrupt handler for a ps2-connected keyboard, registered at IRQ 0x21.
+extern "x86-interrupt" fn ps2_keyboard_handler(_stack_frame: InterruptStackFrame) {
+    // see this: https://forum.osdev.org/viewtopic.php?f=1&t=32655
+    static EXTENDED_SCANCODE: AtomicBool = AtomicBool::new(false);
+
+    let indicator = ps2::ps2_status_register();
+
+    // whether there is any data on the port 0x60
+    if indicator & 0x01 == 0x01 {
+        //whether the data is coming from the mouse
+        if indicator & 0x20 != 0x20 {
+            // in this interrupt, we must read the PS2_PORT scancode register before acknowledging the interrupt.
+            let scan_code = ps2::ps2_read_data();
+            // trace!("PS2_PORT interrupt: raw scan_code {:#X}", scan_code);
+
+
+            let extended = EXTENDED_SCANCODE.load(Ordering::SeqCst);
+
+            // 0xE0 indicates an extended scancode, so we must wait for the next interrupt to get the actual scancode
+            if scan_code == 0xE0 {
+                if extended {
+                    error!("PS2_PORT interrupt: got two extended scancodes (0xE0) in a row! Shouldn't happen.");
+                }
+                // mark it true for the next interrupt
+                EXTENDED_SCANCODE.store(true, Ordering::SeqCst);
+            } else if scan_code == 0xE1 {
+                error!("PAUSE/BREAK key pressed ... ignoring it!");
+                // TODO: handle this, it's a 6-byte sequence (over the next 5 interrupts)
+                EXTENDED_SCANCODE.store(true, Ordering::SeqCst);
+            } else { // a regular scancode, go ahead and handle it
+                // if the previous interrupt's scan_code was an extended scan_code, then this one is not
+                if extended {
+                    EXTENDED_SCANCODE.store(false, Ordering::SeqCst);
+                }
+                if scan_code != 0 {  // a scan code of zero is a PS2_PORT error that we can ignore
+                    if let Err(e) = handle_keyboard_input(scan_code, extended) {
+                        error!("ps2_keyboard_handler: error handling PS2_PORT input: {:?}", e);
+                    }
+                }
             }
         }
     }
-    KEYBOARD_PRODUCER.call_once(|| {
-        keyboard_queue_producer
-    });
+    
+    interrupts::eoi(Some(PS2_KEYBOARD_IRQ));
 }
 
 
 
-/// returns Ok(()) if everything was handled properly.
+/// Called from the keyboard interrupt handler when a keystroke is recognized.
+/// 
+/// Returns Ok(()) if everything was handled properly.
 /// Otherwise, returns an error string.
-pub fn handle_keyboard_input(scan_code: u8, extended: bool) -> Result<(), &'static str> {
+fn handle_keyboard_input(scan_code: u8, extended: bool) -> Result<(), &'static str> {
     // SAFE: no real race conditions with keyboard presses
     let modifiers = unsafe { &mut KBD_MODIFIERS };
     // debug!("KBD_MODIFIERS before {}: {:?}", scan_code, modifiers);
@@ -100,42 +162,33 @@ pub fn handle_keyboard_input(scan_code: u8, extended: bool) -> Result<(), &'stat
         _ => { } // do nothing
     }
 
-//    debug!("KBD_MODIFIERS after {}: {:?}", scan_code, modifiers);
+    // debug!("KBD_MODIFIERS after {}: {:?}", scan_code, modifiers);
 
     // second,  put the keycode and it's action (pressed or released) in the keyboard queue
-    match scan_code {
-        x => { 
-            let (adjusted_scan_code, action) = if x < KEY_RELEASED_OFFSET { 
-                (scan_code, KeyAction::Pressed) 
-            } else { 
-                (scan_code - KEY_RELEASED_OFFSET, KeyAction::Released) 
-            };
+    let (adjusted_scan_code, action) = if scan_code < KEY_RELEASED_OFFSET { 
+        (scan_code, KeyAction::Pressed) 
+    } else { 
+        (scan_code - KEY_RELEASED_OFFSET, KeyAction::Released) 
+    };
 
-            let keycode = Keycode::from_scancode(adjusted_scan_code); 
-            match keycode {
-                Some(keycode) => {
-                    let event = Event::new_keyboard_event(KeyEvent::new(keycode, action, modifiers.clone()));
-                    if let Some(producer) = KEYBOARD_PRODUCER.get() {
-                        producer.push(event).map_err(|_e| "keyboard input queue is full")
-                    }
-                    else {
-                        warn!("handle_keyboard_input(): KEYBOARD_PRODUCER wasn't yet initialized, dropping keyboard event {:?}.", event);
-                        Err("keyboard event queue not ready")
-                    }
-                }
-
-                _ => {
-                    if scan_code == 0xe0 {
-                        Ok(()) //ignore 0xe0 prefix
-                    } else { 
-                        warn!("handle_keyboard_input(): Unknown keycode: {:?}", keycode);
-                        Err("unknown keyboard scancode") 
-                    }
-                }
-            }
+    if let Some(keycode) = Keycode::from_scancode(adjusted_scan_code) {
+        let event = Event::new_keyboard_event(KeyEvent::new(keycode, action, modifiers.clone()));
+        if let Some(producer) = KEYBOARD_PRODUCER.get() {
+            producer.push(event).map_err(|_e| "keyboard input queue is full")
+        } else {
+            warn!("handle_keyboard_input(): KEYBOARD_PRODUCER wasn't yet initialized, dropping keyboard event {:?}.", event);
+            Err("keyboard event queue not ready")
+        }
+    } else {
+        if scan_code == 0xE0 {
+            Ok(()) //ignore 0xE0 prefix
+        } else { 
+            error!("handle_keyboard_input(): Unknown scancode: {:?}, adjusted scancode: {:?}",
+                scan_code, adjusted_scan_code
+            );
+            Err("unknown keyboard scancode") 
         }
     }
-
 }
 
 

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
  "memory",
  "msr",
  "owning_ref",
- "pit_clock",
+ "pit_clock_basic",
  "raw-cpuid",
  "spin 0.9.0",
  "static_assertions",
@@ -711,15 +711,11 @@ dependencies = [
  "exceptions_early",
  "gdt",
  "irq_safety",
- "kernel_config",
- "keyboard",
- "lazy_static",
  "locked_idt",
  "log",
  "memory",
  "mouse",
  "pic",
- "pit_clock",
  "port_io",
  "ps2",
  "scheduler",
@@ -804,18 +800,6 @@ dependencies = [
 [[package]]
 name = "kernel_config"
 version = "0.1.0"
-
-[[package]]
-name = "keyboard"
-version = "0.1.0"
-dependencies = [
- "event_types",
- "keycodes_ascii",
- "log",
- "mpmc",
- "ps2",
- "spin 0.9.0",
-]
 
 [[package]]
 name = "keycodes_ascii"
@@ -1080,7 +1064,7 @@ dependencies = [
  "memory",
  "mod_mgmt",
  "pause",
- "pit_clock",
+ "pit_clock_basic",
  "spin 0.9.0",
  "stack",
  "volatile 0.2.7",
@@ -1215,7 +1199,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "pit_clock"
+name = "pit_clock_basic"
 version = "0.1.0"
 dependencies = [
  "log",
@@ -1727,7 +1711,7 @@ name = "tsc"
 version = "0.1.0"
 dependencies = [
  "log",
- "pit_clock",
+ "pit_clock_basic",
 ]
 
 [[package]]


### PR DESCRIPTION
* Inverts the dependency chain from `interrupts` -> `keyboard` to
  `keyboard` -> `interrupts`, which is more typical.

* The PS2 keyboard driver now registers its own interrupt as normal.