### PR TITLE
Refactor PS2 mouse out of `interrupts` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,10 +1307,8 @@ dependencies = [
  "locked_idt",
  "log",
  "memory",
- "mouse",
  "pic",
  "port_io",
- "ps2",
  "scheduler",
  "sleep",
  "spin 0.9.0",
@@ -1914,11 +1912,13 @@ name = "mouse"
 version = "0.1.0"
 dependencies = [
  "event_types",
+ "interrupts",
  "log",
  "mouse_data",
  "mpmc",
  "ps2",
  "spin 0.9.0",
+ "x86_64",
 ]
 
 [[package]]

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -96,7 +96,7 @@ pub fn init(key_producer: Queue<Event>, mouse_producer: Queue<Event>) -> Result<
     init_serial_port(SerialPortAddress::COM2);
 
     keyboard::init(key_producer)?;
-    mouse::init(mouse_producer);
+    mouse::init(mouse_producer)?;
 
     // Initialize/scan the PCI bus to discover PCI devices
     for dev in pci::pci_device_iter() {

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -41,12 +41,6 @@ path = "../exceptions_early"
 [dependencies.task]
 path = "../task"
 
-[dependencies.mouse]
-path = "../mouse"
-
-[dependencies.ps2]
-path = "../ps2"
-
 [dependencies.scheduler]
 path = "../scheduler"
 

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -77,7 +77,7 @@ extern "x86-interrupt" fn ps2_keyboard_handler(_stack_frame: InterruptStackFrame
 
     // whether there is any data on the port 0x60
     if indicator & 0x01 == 0x01 {
-        //whether the data is coming from the mouse
+        // Skip this if the PS2 event came from the mouse, not the keyboard
         if indicator & 0x20 != 0x20 {
             // in this interrupt, we must read the PS2_PORT scancode register before acknowledging the interrupt.
             let scan_code = ps2::ps2_read_data();

--- a/kernel/mouse/Cargo.toml
+++ b/kernel/mouse/Cargo.toml
@@ -1,17 +1,21 @@
 [package]
+authors = ["Bowen Liu <liubowenbob@hotmail.com>", "Kevin Boos <kevinaboos@gmail.com>"]
 name = "mouse"
+description = "A keyboard driver for keyboards connected to the legacy PS2 port"
 version = "0.1.0"
-authors = ["Bowen Liu <liubowenbob@hotmail.com>"]
+edition = "2018"
 
 [dependencies]
 spin = "0.9.0"
 mpmc = "0.1.6"
-
-[dependencies.log]
-version = "0.4.8"
+log = "0.4.8"
+x86_64 = "0.14.8"
 
 [dependencies.mouse_data]
 path = "../../libs/mouse_data"
+
+[dependencies.interrupts]
+path = "../interrupts"
 
 [dependencies.ps2]
 path = "../ps2"

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -1,19 +1,20 @@
+//! A basic driver for a mouse connected to the legacy PS2 port.
+
 #![no_std]
-#[macro_use]
-extern crate log;
+#![feature(abi_x86_interrupt)]
 
-extern crate mpmc;
-extern crate event_types;
-extern crate mouse_data;
-extern crate ps2;
-extern crate spin;
+#[macro_use] extern crate log;
 
+use spin::Once;
 use mpmc::Queue;
 use event_types::Event;
-use spin::Once;
-
+use x86_64::structures::idt::InterruptStackFrame;
 use mouse_data::{ButtonAction, Displacement, MouseEvent, MouseMovement};
 use ps2::{check_mouse_id, init_ps2_port2, set_mouse_id, test_ps2_port2};
+
+/// The first PS2 port for the mouse is connected directly to IRQ 0xC.
+/// Because we perform the typical PIC remapping, the remapped IRQ vector number is 0x2C.
+const PS2_MOUSE_IRQ: u8 = interrupts::IRQ_BASE_OFFSET + 0xC;
 
 static mut MOUSE_MOVE: MouseMovement = MouseMovement::default();
 static mut BUTTON_ACT: ButtonAction = ButtonAction::default();
@@ -21,30 +22,46 @@ static mut DISPLACEMENT: Displacement = Displacement::default();
 
 static MOUSE_PRODUCER: Once<Queue<Event>> = Once::new();
 
-/// Initialize the mouse driver.
-pub fn init(mouse_queue_producer: Queue<Event>) {
-    // init the second ps2 port for mouse
+/// Initialize the PS2 mouse driver and register its interrupt handler.
+/// 
+/// ## Arguments
+/// * `mouse_queue_producer`: the queue onto which the mouse interrupt handler
+///    will push new mouse events when a mouse action occurs.
+pub fn init(mouse_queue_producer: Queue<Event>) -> Result<(), &'static str> {
+    // Init the second ps2 port, which is used for the mouse.
     init_ps2_port2();
-    // test the second ps2 port
+    // Test the second port.
+    // TODO: return an error if this test fails.
     test_ps2_port2();
 
-    // set Mouse ID to 4
+    // Set Mouse ID to 4, and read it back to check that it worked.
     let _e = set_mouse_id(4);
-    // check the ID
-    let id = check_mouse_id();
-    match id {
-        Err(_e) => error!("fail to read the initial mouse ID"),
-
-        Ok(id) => {
-            info!("the initial mouse ID is: {}", id);
+    match check_mouse_id() {
+        Ok(id) => info!("the initial mouse ID is: {}", id),
+        Err(_e) => {
+            error!("Failed to read the initial PS2 mouse ID, error: {:?}", _e);
+            return Err("Failed to read the initial PS2 mouse ID");
         }
     }
 
+    // Register the interrupt handler
+    interrupts::register_interrupt(PS2_MOUSE_IRQ, ps2_mouse_handler).map_err(|e| {
+        error!("PS2 mouse IRQ {:#X} was already in use by handler {:#X}! Sharing IRQs is currently unsupported.", 
+            PS2_MOUSE_IRQ, e,
+        );
+        "PS2 mouse IRQ was already in use! Sharing IRQs is currently unsupported."
+    })?;
+
+    // Final step: set the producer end of the mouse event queue.
     MOUSE_PRODUCER.call_once(|| mouse_queue_producer);
+    Ok(())
 }
 
-/// print the mouse actions
-pub fn mouse_to_print(mouse_event: &MouseEvent) {
+/// Print details of the given mouse event.
+/// 
+/// TODO: this is silly, just impl `fmt::Debug` for `MouseEvent`
+#[allow(dead_code)]
+fn mouse_to_print(mouse_event: &MouseEvent) {
     let mouse_movement = &mouse_event.mousemove;
     let mouse_buttons = &mouse_event.buttonact;
     let mouse_displacement = &mouse_event.displacement;
@@ -99,8 +116,35 @@ pub fn mouse_to_print(mouse_event: &MouseEvent) {
     }
 }
 
+
+
+/// The interrupt handler for a ps2-connected mouse, registered at IRQ 0x2C.
+extern "x86-interrupt" fn ps2_mouse_handler(_stack_frame: InterruptStackFrame) {
+
+    let indicator = ps2::ps2_status_register();
+
+    // whether there is any data on the port 0x60
+    if indicator & 0x01 == 0x01 {
+        //whether the data is coming from the mouse
+        if indicator & 0x20 == 0x20 {
+            let readdata = ps2::handle_mouse_packet();
+            if (readdata & 0x80 == 0x80) || (readdata & 0x40 == 0x40) {
+                error!("The overflow bits in the mouse data packet's first byte are set! Discarding the whole packet.");
+            } else if readdata & 0x08 == 0 {
+                error!("Third bit should in the mouse data packet's first byte should be always be 1. Discarding the whole packet since the bit is 0 now.");
+            } else {
+                let _mouse_event = handle_mouse_input(readdata);
+                // mouse_to_print(&_mouse_event);
+            }
+        }
+    }
+
+    interrupts::eoi(Some(PS2_MOUSE_IRQ));
+}
+
+
 /// return a Mouse Event according to the data
-pub fn handle_mouse_input(readdata: u32) -> Result<(), &'static str> {
+fn handle_mouse_input(readdata: u32) -> Result<(), &'static str> {
     let action = unsafe { &mut BUTTON_ACT };
     let mmove = unsafe { &mut MOUSE_MOVE };
     let dis = unsafe { &mut DISPLACEMENT };
@@ -116,7 +160,7 @@ pub fn handle_mouse_input(readdata: u32) -> Result<(), &'static str> {
     if let Some(producer) = MOUSE_PRODUCER.get() {
         producer.push(event).map_err(|_e| "Fail to enqueue the mouse event")
     } else {
-        warn!("handle_keyboard_input(): MOUSE_PRODUCER wasn't yet initialized, dropping keyboard event {:?}.", event);
-        Err("keyboard event queue not ready")
+        warn!("handle_mouse_input(): MOUSE_PRODUCER wasn't yet initialized, dropping mouse event {:?}.", event);
+        Err("mouse event queue not ready")
     }
 }

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -714,10 +714,8 @@ dependencies = [
  "locked_idt",
  "log",
  "memory",
- "mouse",
  "pic",
  "port_io",
- "ps2",
  "scheduler",
  "sleep",
  "spin 0.9.0",
@@ -1020,11 +1018,13 @@ name = "mouse"
 version = "0.1.0"
 dependencies = [
  "event_types",
+ "interrupts",
  "log",
  "mouse_data",
  "mpmc",
  "ps2",
  "spin 0.9.0",
+ "x86_64",
 ]
 
 [[package]]


### PR DESCRIPTION
* Inverts the dependency chain from `interrupts` -> `mouse` to
  `mouse` -> `interrupts`, which is more typical.

* The PS2 mouse driver now registers its own interrupt as normal.