### PR TITLE
Refactor ATA disk interrupts out of `interrupts` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,12 +157,14 @@ name = "ata"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "interrupts",
  "io",
  "log",
  "pci",
  "port_io",
  "spin 0.9.0",
  "storage_device",
+ "x86_64",
 ]
 
 [[package]]

--- a/kernel/ata/Cargo.toml
+++ b/kernel/ata/Cargo.toml
@@ -1,18 +1,21 @@
 [package]
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "ata"
-description = "Support for accessing ATA (IDE) disks"
+description = "Storage device driver for ATA (IDE) disks"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies]
 bitflags = "1.1.0"
+log = "0.4.8"
 spin = "0.9.0"
-
-[dependencies.log]
-version = "0.4.8"
+x86_64 = "0.14.8"
 
 [dependencies.port_io]
 path = "../../libs/port_io"
+
+[dependencies.interrupts]
+path = "../interrupts"
 
 [dependencies.pci]
 path = "../pci"

--- a/kernel/interrupts/src/lib.rs
+++ b/kernel/interrupts/src/lib.rs
@@ -168,8 +168,6 @@ pub fn init_ap(
 /// Establishes the default interrupt handlers that are statically known.
 fn set_handlers(idt: &mut InterruptDescriptorTable) {
     // idt[0x28].set_handler_fn(rtc_handler);
-    idt[0x2E].set_handler_fn(primary_ata_handler);
-    idt[0x2F].set_handler_fn(secondary_ata_handler);
 
     idt[tlb_shootdown::TLB_SHOOTDOWN_IPI_IRQ as usize].set_handler_fn(ipi_handler);
 }
@@ -401,22 +399,6 @@ extern "x86-interrupt" fn pic_spurious_interrupt_handler(_stack_frame: Interrupt
     
 //     rtc::handle_rtc_interrupt();
 // }
-
-
-/// 0x2E
-extern "x86-interrupt" fn primary_ata_handler(_stack_frame: InterruptStackFrame ) {
-    info!("Primary ATA Interrupt (0x2E)");
-
-    eoi(Some(IRQ_BASE_OFFSET + 0xE));
-}
-
-
-/// 0x2F
-extern "x86-interrupt" fn secondary_ata_handler(_stack_frame: InterruptStackFrame ) {
-    info!("Secondary ATA Interrupt (0x2F)");
-    
-    eoi(Some(IRQ_BASE_OFFSET + 0xF));
-}
 
 
 extern "x86-interrupt" fn ipi_handler(_stack_frame: InterruptStackFrame) {


### PR DESCRIPTION
* ATA interrupts are now registered as normal in the ATA crate,
  specifically after an IDE controller is discovered.