### PR TITLE
Avoid clones and shorten lock duration for MMI accesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,7 +1949,6 @@ dependencies = [
  "acpi",
  "ap_start",
  "apic",
- "irq_safety",
  "kernel_config",
  "log",
  "madt",

--- a/applications/ns/src/lib.rs
+++ b/applications/ns/src/lib.rs
@@ -91,7 +91,7 @@ fn load_crate(output: &mut String, crate_file_ref: FileRef, namespace: &Arc<Crat
     let (_new_crate_ref, _new_syms) = namespace.load_crate(
         &crate_file_ref,
         None,
-        &kernel_mmi_ref,
+        kernel_mmi_ref,
         false
     ).map_err(|e| String::from(e))?;
     writeln!(output, "Loaded crate with {} new symbols from {}", _new_syms, crate_file_ref.lock().get_absolute_path()).unwrap();

--- a/applications/swap/src/lib.rs
+++ b/applications/swap/src/lib.rs
@@ -199,7 +199,7 @@ fn do_swap(
         swap_requests, 
         override_namespace_crate_dir,
         state_transfer_functions,
-        &kernel_mmi_ref,
+        kernel_mmi_ref,
         verbose_log,
         cache_old_crates,
     );

--- a/applications/upd/src/lib.rs
+++ b/applications/upd/src/lib.rs
@@ -281,7 +281,7 @@ fn apply(base_dir_path: &Path) -> Result<(), String> {
         swap_requests, 
         Some(new_namespace_dir), 
         diffs.state_transfer_functions, 
-        &kernel_mmi_ref, 
+        kernel_mmi_ref,
         false, // verbose logging
         false, // enable_crate_cache
     ).map_err(|e| format!("crate swapping failed, error: {}", e))?;

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -49,12 +49,11 @@ extern crate console;
 
 
 
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::ops::DerefMut;
-use memory::{VirtualAddress, MemoryManagementInfo, MappedPages};
+use memory::{VirtualAddress, MappedPages, MmiRef};
 use kernel_config::memory::KERNEL_STACK_SIZE_IN_PAGES;
-use irq_safety::{MutexIrqSafe, enable_interrupts};
+use irq_safety::enable_interrupts;
 use stack::Stack;
 
 
@@ -71,7 +70,7 @@ pub fn mirror_to_vga_cb(args: core::fmt::Arguments) {
 /// This does all the rest of the module loading and initialization so that the OS 
 /// can continue running and do actual useful work.
 pub fn init(
-    kernel_mmi_ref: Arc<MutexIrqSafe<MemoryManagementInfo>>, 
+    kernel_mmi_ref: MmiRef,
     identity_mapped_pages: Vec<MappedPages>,
     bsp_initial_stack: Stack,
     ap_start_realmode_begin: VirtualAddress,

--- a/kernel/debug_info/src/lib.rs
+++ b/kernel/debug_info/src/lib.rs
@@ -583,7 +583,7 @@ impl DebugSymbols {
         let symtab = find_symbol_table(&elf_file)?;
 
         // Allocate a memory region large enough to hold all debug sections.
-        let (mut debug_sections_mp, _debug_sections_vaddr_range) = allocate_debug_section_pages(&elf_file, &kernel_mmi_ref)?;
+        let (mut debug_sections_mp, _debug_sections_vaddr_range) = allocate_debug_section_pages(&elf_file, kernel_mmi_ref)?;
         debug!("debug sections spans {:#X} to {:#X}  (size: {:#X} bytes)",
             _debug_sections_vaddr_range.start, 
             _debug_sections_vaddr_range.end,
@@ -758,7 +758,7 @@ impl DebugSymbols {
                             warn!("Looking for foreign relocation source section {:?}", demangled);
 
                             // search for the symbol's demangled name in the kernel's symbol map
-                            namespace.get_symbol_or_load(&demangled, None, &kernel_mmi_ref, false)
+                            namespace.get_symbol_or_load(&demangled, None, kernel_mmi_ref, false)
                                 .upgrade()
                                 .ok_or("Couldn't get symbol for .debug section's foreign relocation entry, nor load its containing crate")
                                 .map(|sec| (sec.address_range.start, Some(sec)))

--- a/kernel/fault_crate_swap/src/lib.rs
+++ b/kernel/fault_crate_swap/src/lib.rs
@@ -131,7 +131,7 @@ pub fn do_self_swap(
         swap_requests, 
         override_namespace_crate_dir,
         state_transfer_functions,
-        &kernel_mmi_ref,
+        kernel_mmi_ref,
         verbose_log,
         false // enable crate_cahce
     );

--- a/kernel/memfs/src/lib.rs
+++ b/kernel/memfs/src/lib.rs
@@ -102,9 +102,8 @@ impl ByteWriter for MemFile {
             };
             
             let kernel_mmi_ref = get_kernel_mmi_ref().ok_or("KERNEL_MMI was not yet initialized!")?;
-			let mut kernel_mmi = kernel_mmi_ref.lock();
             let pages = allocate_pages_by_bytes(end).ok_or("could not allocate pages")?;
-            let mut new_mapped_pages = kernel_mmi.page_table.map_allocated_pages(pages, prev_flags)?;            
+            let mut new_mapped_pages = kernel_mmi_ref.lock().page_table.map_allocated_pages(pages, prev_flags)?;
             
             // first, we need to copy over the bytes from the previous mapped pages
             {

--- a/kernel/multicore_bringup/Cargo.toml
+++ b/kernel/multicore_bringup/Cargo.toml
@@ -8,12 +8,7 @@ version = "0.1.0"
 spin = "0.9.0"
 volatile = "0.2.7"
 zerocopy = "0.5.0"
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.irq_safety]
-git = "https://github.com/theseus-os/irq_safety"
+log = "0.4.8"
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/multicore_bringup/src/lib.rs
+++ b/kernel/multicore_bringup/src/lib.rs
@@ -10,7 +10,6 @@ extern crate alloc;
 extern crate spin;
 extern crate volatile;
 extern crate zerocopy;
-extern crate irq_safety;
 extern crate memory;
 extern crate pit_clock_basic;
 extern crate stack;
@@ -26,12 +25,10 @@ use core::{
     ops::DerefMut,
     sync::atomic::Ordering,
 };
-use alloc::sync::Arc;
 use spin::Mutex;
 use volatile::Volatile;
 use zerocopy::FromBytes;
-use irq_safety::MutexIrqSafe;
-use memory::{VirtualAddress, PhysicalAddress, MappedPages, EntryFlags, MemoryManagementInfo};
+use memory::{VirtualAddress, PhysicalAddress, MappedPages, EntryFlags, MmiRef};
 use kernel_config::memory::{PAGE_SIZE, PAGE_SHIFT, KERNEL_STACK_SIZE_IN_PAGES};
 use apic::{LocalApic, get_lapics, get_my_apic_id, has_x2apic, get_bsp_id};
 use ap_start::{kstart_ap, AP_READY_FLAG};
@@ -74,14 +71,14 @@ pub struct GraphicInfo {
 /// (specifically the MADT (APIC) table).
 /// 
 /// # Arguments: 
-/// * `kernel_mmi_ref`: A reference to the locked MMI structure for the kernel.
+/// * `kernel_mmi_ref`: A reference to the MMI structure with the kernel's page table.
 /// * `ap_start_realmode_begin`: the starting virtual address of where the ap_start realmode code is.
 /// * `ap_start_realmode_end`: the ending virtual address of where the ap_start realmode code is.
 /// * `max_framebuffer_resolution`: the maximum resolution `(width, height)` of the graphical framebuffer
 ///    that an AP should request from the BIOS when it boots up in 16-bit real mode.
 ///    If `None`, there will be no maximum.
 pub fn handle_ap_cores(
-    kernel_mmi_ref: Arc<MutexIrqSafe<MemoryManagementInfo>>,
+    kernel_mmi_ref: MmiRef,
     ap_start_realmode_begin: VirtualAddress,
     ap_start_realmode_end: VirtualAddress,
     max_framebuffer_resolution: Option<(u16, u16)>,

--- a/kernel/multiple_heaps/src/lib.rs
+++ b/kernel/multiple_heaps/src/lib.rs
@@ -126,17 +126,13 @@ fn create_heap_mapping(
     size_in_bytes: usize
 ) -> Result<(MappedPages, DeferredAllocAction<'static>), &'static str> {
     let kernel_mmi_ref = get_kernel_mmi_ref().ok_or("create_heap_mapping(): KERNEL_MMI was not yet initialized!")?;
-    let mut kernel_mmi = kernel_mmi_ref.lock();
-
     let (pages, action) = allocate_pages_by_bytes_deferred(Some(starting_address), size_in_bytes)
         .map_err(|_e| "create_heap_mapping(): failed to allocate pages at the starting address")?;
     if pages.start_address().value() % HEAP_MAPPED_PAGES_SIZE_IN_BYTES != 0 {
         return Err("multiple_heaps: the allocated pages for the heap wasn't properly aligned");
     }
-    let mp = kernel_mmi.page_table.map_allocated_pages(pages, HEAP_FLAGS)?;
-
+    let mp = kernel_mmi_ref.lock().page_table.map_allocated_pages(pages, HEAP_FLAGS)?;
     // trace!("Allocated heap pages at: {:#X}", starting_address);
-
     Ok((mp, action))
 }
 

--- a/kernel/nic_initialization/src/lib.rs
+++ b/kernel/nic_initialization/src/lib.rs
@@ -62,8 +62,7 @@ pub fn allocate_memory(mem_base: PhysicalAddress, mem_size_in_bytes: usize) -> R
     // debug!("NicInit: memory base: {:#X}, memory size: {}", mem_base, mem_size_in_bytes);
 
     let kernel_mmi_ref = get_kernel_mmi_ref().ok_or("NicInit::mem_map(): KERNEL_MMI was not yet initialized!")?;
-    let mut kernel_mmi = kernel_mmi_ref.lock();
-    let nic_mapped_page = kernel_mmi.page_table.map_allocated_pages_to(pages_nic, frames_nic, NIC_MAPPING_FLAGS)?;
+    let nic_mapped_page = kernel_mmi_ref.lock().page_table.map_allocated_pages_to(pages_nic, frames_nic, NIC_MAPPING_FLAGS)?;
 
     Ok(nic_mapped_page)
 }

--- a/kernel/panic_wrapper/src/lib.rs
+++ b/kernel/panic_wrapper/src/lib.rs
@@ -61,13 +61,12 @@ pub fn panic_wrapper(panic_info: &PanicInfo) -> Result<(), &'static str> {
                 .or_else(|| mod_mgmt::get_initial_kernel_namespace())
                 .ok_or("couldn't get current task's or default namespace")?;
             let mmi_ref = task::get_my_current_task()
-                .map(|t| t.mmi.clone())
+                .map(|t| &t.mmi)
                 .or_else(|| memory::get_kernel_mmi_ref())
                 .ok_or("couldn't get current task's or default kernel MMI")?;
-            let mmi = mmi_ref.lock();
 
             stack_trace_frame_pointers::stack_trace_using_frame_pointers(
-                &mmi.page_table,
+                &mmi_ref.lock().page_table,
                 &mut |_frame_pointer, instruction_pointer: VirtualAddress| {
                     let symbol_offset = namespace.get_section_containing_address(instruction_pointer, false)
                         .map(|(sec, offset)| (sec.name.clone(), offset));

--- a/kernel/simd_personality/src/lib.rs
+++ b/kernel/simd_personality/src/lib.rs
@@ -142,14 +142,14 @@ fn internal_setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str
 	let (core_lib_simd, _ns) = CrateNamespace::get_crate_object_file_starting_with(&simd_kernel_namespace, "core-")
 		.ok_or_else(|| "couldn't find a single 'core' object file in simd_personality")?;
 	let crate_files = [compiler_builtins_simd, core_lib_simd];
-	simd_kernel_namespace.load_crates(crate_files.iter(), Some(backup_namespace), &kernel_mmi_ref, false)?;
+	simd_kernel_namespace.load_crates(crate_files.iter(), Some(backup_namespace), kernel_mmi_ref, false)?;
 	
 
 	// load the actual crate that we want to run in the simd namespace, "simd_test"
 	let (simd_test_file, _ns) = simd_app_namespace.method_get_crate_object_file_starting_with("simd_test-")
 		.ok_or_else(|| "couldn't find a single 'simd_test' object file in simd_personality")?;
 	simd_app_namespace.enable_fuzzy_symbol_matching();
-	simd_app_namespace.load_crate(&simd_test_file, Some(backup_namespace), &kernel_mmi_ref, false)?;
+	simd_app_namespace.load_crate(&simd_test_file, Some(backup_namespace), kernel_mmi_ref, false)?;
 	simd_app_namespace.disable_fuzzy_symbol_matching();
 
 

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -207,7 +207,7 @@ pub fn new_application_task_builder(
     // Load the new application crate
     let app_crate_ref = {
         let kernel_mmi_ref = get_kernel_mmi_ref().ok_or("couldn't get_kernel_mmi_ref")?;
-        CrateNamespace::load_crate_as_application(&namespace, &crate_object_file, &kernel_mmi_ref, false)?
+        CrateNamespace::load_crate_as_application(&namespace, &crate_object_file, kernel_mmi_ref, false)?
     };
 
     // Find the "main" entry point function in the new app crate

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -1053,7 +1053,6 @@ dependencies = [
  "acpi",
  "ap_start",
  "apic",
- "irq_safety",
  "kernel_config",
  "log",
  "madt",


### PR DESCRIPTION
* Change `get_kernel_mmi_ref()` to return an `Option<&'static MmiRef>` instead of eagerly `clone()`-ing the interior `Arc`.

* Avoid holding the lock on the `MmiRef` as much as possible, since it is an interrupt-disabling lock.