### PR TITLE
Refactor serializable crate metadata types into a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,9 +614,7 @@ name = "crate_metadata_serde"
 version = "0.1.0"
 dependencies = [
  "hashbrown",
- "log",
  "serde",
- "str_ref",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,7 @@ name = "crate_metadata"
 version = "0.1.0"
 dependencies = [
  "cow_arc",
+ "crate_metadata_serde",
  "fs_node",
  "goblin",
  "hashbrown",
@@ -606,6 +607,16 @@ dependencies = [
  "spin 0.9.0",
  "str_ref",
  "xmas-elf",
+]
+
+[[package]]
+name = "crate_metadata_serde"
+version = "0.1.0"
+dependencies = [
+ "hashbrown",
+ "log",
+ "serde",
+ "str_ref",
 ]
 
 [[package]]
@@ -1877,6 +1888,7 @@ dependencies = [
  "cow_arc",
  "cpio_reader",
  "crate_metadata",
+ "crate_metadata_serde",
  "crate_name_utils",
  "cstr_core",
  "fs_node",

--- a/kernel/crate_metadata/Cargo.toml
+++ b/kernel/crate_metadata/Cargo.toml
@@ -35,10 +35,10 @@ path = "../memory"
 [dependencies.fs_node]
 path = "../fs_node"
 
+[dependencies.crate_metadata_serde]
+path = "../crate_metadata_serde"
+
 [dependencies.serde]
 version = "1.0.137"
 default-features = false
 features = ["derive"]
-
-[lib]
-crate-type = ["rlib"]

--- a/kernel/crate_metadata_serde/Cargo.toml
+++ b/kernel/crate_metadata_serde/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "crate_metadata_serde"
+version = "0.1.0"
+description = "Standalone types that represent (de)serializable crate metadata structures"
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+log = "0.4.8"
+
+[dependencies.str_ref]
+path = "../../libs/str_ref"
+
+[dependencies.hashbrown]
+version = "0.11.2"
+features = ["nightly", "serde"]
+
+[dependencies.serde]
+version = "1.0.137"
+default-features = false
+features = ["derive"]
+

--- a/kernel/crate_metadata_serde/Cargo.toml
+++ b/kernel/crate_metadata_serde/Cargo.toml
@@ -5,12 +5,6 @@ description = "Standalone types that represent (de)serializable crate metadata s
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 edition = "2018"
 
-[dependencies]
-log = "0.4.8"
-
-[dependencies.str_ref]
-path = "../../libs/str_ref"
-
 [dependencies.hashbrown]
 version = "0.11.2"
 features = ["nightly", "serde"]

--- a/kernel/crate_metadata_serde/src/lib.rs
+++ b/kernel/crate_metadata_serde/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! This is currently only used to parse and serialize the `nano_core` binary at compile time.
 //! The `nano_core`'s [`SerializedCrate`] is then included as a boot module
-//! so it can be deserialized into a [`LoadedCrate`] at runtime.
+//! so it can be deserialized into a LoadedCrate at runtime by `mod_mgmt`.
 //! 
 //! Some other types have been moved from `crate_metadata` into this crate because
 //! they are required for (de)serialization, e.g., [`SectionType`].
@@ -68,9 +68,9 @@ pub struct SerializedSection {
     pub ty: SectionType,
     /// Whether or not the section is global.
     pub global: bool,
-    /// The starting [`VirtualAddress`] of the range covered by this section.
+    /// The starting virtual address of the range covered by this section.
     pub virtual_address: usize,
-    /// The offset into the [`MappedPages`] where this section starts.
+    /// The offset into this section's containing `MappedPages` where this section starts.
     pub offset: usize,
     /// The size of the section.
     pub size: usize,

--- a/kernel/crate_metadata_serde/src/lib.rs
+++ b/kernel/crate_metadata_serde/src/lib.rs
@@ -1,0 +1,152 @@
+//! Standalone crate containing (de)serializable types for crate and section metadata.
+//! 
+//! The primary reason this exists is because `LoadedCrate` and `LoadedSection`
+//! make copious usage of `Arc` and `Weak` reference-counted pointer types,
+//! which cannot be properly (de)serialized by `serde`. 
+//! The types in this module remove those refcount types so that they can be
+//! reconstructed individually at runtime after deserialization by the `crate_metadata` crate.
+//!
+//! This is currently only used to parse and serialize the `nano_core` binary at compile time.
+//! The `nano_core`'s [`SerializedCrate`] is then included as a boot module
+//! so it can be deserialized into a [`LoadedCrate`] at runtime.
+//! 
+//! Some other types have been moved from `crate_metadata` into this crate because
+//! they are required for (de)serialization, e.g., [`SectionType`].
+//! 
+//! ## Goal: minimal dependencies
+//! This crate's dependencies should be kept to a bare minimum in order to 
+//! minimize the dependencies of the `tools/serialize_nano_core` executable,
+//! allowing it to build and run quickly.
+//! 
+//! Thus, instead of using Theseus-specific types here in this crate,
+//! we prefer using types from this crate in other Theseus kernel crates.
+//! For example, instead of implementing the routines to convert a `SerializedCrate`
+//! into a `LoadedCrate` here, we implement the routine to create a `LoadedCrate`
+//! from a `SerializedCrate` in the `mod_mgmt` crate itself.
+//! In other words, other larger/complex Theseus crates should depend on this crate
+//! instead of this crate depending on other Theseus crates.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    string::String,
+};
+use hashbrown::HashMap;
+use serde::{Deserialize, Serialize};
+
+/// A (de)serializable representation of a loaded crate that is `serde`-compatible.
+///
+/// See [`LoadedCrate`] for more detail on the fields of this struct.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SerializedCrate {
+    /// The name of the crate.
+    pub crate_name: String,
+    /// A map containing all the sections of the crate.
+    pub sections: HashMap<Shndx, SerializedSection>,
+    /// A set containing the global sectinos of the crate.
+    pub global_sections: BTreeSet<Shndx>,
+    /// A set containing the thread-local storage (TLS) sections of the crate.
+    pub tls_sections: BTreeSet<Shndx>,
+    /// A set containing the `.data` and `.bss` sections of the crate.
+    pub data_sections: BTreeSet<Shndx>,
+    /// A map of symbol names to their constant values, which contain assembler and linker
+    /// constants.
+    pub init_symbols: BTreeMap<String, usize>,
+}
+
+/// A (de)serializable representation of a loaded section that is `serde`-compatible.
+///
+/// See [`LoadedSection`] for more detail on the fields of this struct.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SerializedSection {
+    /// The full name of the section.
+    pub name: String,
+    /// The type of the section.
+    pub ty: SectionType,
+    /// Whether or not the section is global.
+    pub global: bool,
+    /// The starting [`VirtualAddress`] of the range covered by this section.
+    pub virtual_address: usize,
+    /// The offset into the [`MappedPages`] where this section starts.
+    pub offset: usize,
+    /// The size of the section.
+    pub size: usize,
+}
+
+/// A Section Header iNDeX (SHNDX), as specified by the ELF format. 
+/// Even though this is typically encoded as a `u16`,
+/// its decoded form can exceed the max size of `u16`.
+pub type Shndx = usize;
+
+pub const TEXT_SECTION_NAME             : &str = ".text";
+pub const RODATA_SECTION_NAME           : &str = ".rodata";
+pub const DATA_SECTION_NAME             : &str = ".data";
+pub const BSS_SECTION_NAME              : &str = ".bss";
+pub const TLS_DATA_SECTION_NAME         : &str = ".tdata";
+pub const TLS_BSS_SECTION_NAME          : &str = ".tbss";
+pub const GCC_EXCEPT_TABLE_SECTION_NAME : &str = ".gcc_except_table";
+pub const EH_FRAME_SECTION_NAME         : &str = ".eh_frame";
+
+/// The possible types of sections that can be loaded from a crate object file.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+pub enum SectionType {
+    /// A `text` section contains executable code, i.e., functions. 
+    Text,
+    /// An `rodata` section contains read-only data, i.e., constants.
+    Rodata,
+    /// A `data` section contains data that is both readable and writable, i.e., static variables. 
+    Data,
+    /// A `bss` section is just like a data section, but is automatically initialized to all zeroes at load time.
+    Bss,
+    /// A `.tdata` section is a read-only section that holds the initial data "image" 
+    /// for a thread-local storage (TLS) area.
+    TlsData,
+    /// A `.tbss` section is a read-only section that holds all-zero data for a thread-local storage (TLS) area.
+    /// This is is effectively an empty placeholder: the all-zero data section doesn't actually exist in memory.
+    TlsBss,
+    /// A `.gcc_except_table` section contains landing pads for exception handling,
+    /// comprising the LSDA (Language Specific Data Area),
+    /// which is effectively used to determine when we should stop the stack unwinding process
+    /// (e.g., "catching" an exception). 
+    /// 
+    /// Blog post from author of gold linker: <https://www.airs.com/blog/archives/464>
+    /// 
+    /// Mailing list discussion here: <https://gcc.gnu.org/ml/gcc-help/2010-09/msg00116.html>
+    /// 
+    /// Here is a sample repository parsing this section: <https://github.com/nest-leonlee/gcc_except_table>
+    /// 
+    GccExceptTable,
+    /// The `.eh_frame` section contains information about stack unwinding and destructor functions
+    /// that should be called when traversing up the stack for cleanup. 
+    /// 
+    /// Blog post from author of gold linker: <https://www.airs.com/blog/archives/460>
+    /// Some documentation here: <https://gcc.gnu.org/wiki/Dwarf2EHNewbiesHowto>
+    /// 
+    EhFrame,
+}
+impl SectionType {    
+    /// Returns the const `&str` name of this `SectionType`.
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::Text           => TEXT_SECTION_NAME,
+            Self::Rodata         => RODATA_SECTION_NAME,
+            Self::Data           => DATA_SECTION_NAME, 
+            Self::Bss            => BSS_SECTION_NAME,
+            Self::TlsData        => TLS_DATA_SECTION_NAME,
+            Self::TlsBss         => TLS_BSS_SECTION_NAME,
+            Self::GccExceptTable => GCC_EXCEPT_TABLE_SECTION_NAME,
+            Self::EhFrame        => EH_FRAME_SECTION_NAME,
+        }
+    } 
+
+    /// Returns `true` if `Data` or `Bss`, otherwise `false`.
+    pub fn is_data_or_bss(&self) -> bool {
+        match self {
+            Self::Data | Self::Bss => true,
+            _ => false,
+        }
+    }
+}

--- a/kernel/crate_metadata_serde/src/lib.rs
+++ b/kernel/crate_metadata_serde/src/lib.rs
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 
 /// A (de)serializable representation of a loaded crate that is `serde`-compatible.
 ///
-/// See [`LoadedCrate`] for more detail on the fields of this struct.
+/// See `LoadedCrate` for more detail on the fields of this struct.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SerializedCrate {
     /// The name of the crate.
@@ -59,7 +59,7 @@ pub struct SerializedCrate {
 
 /// A (de)serializable representation of a loaded section that is `serde`-compatible.
 ///
-/// See [`LoadedSection`] for more detail on the fields of this struct.
+/// See `LoadedSection` for more detail on the fields of this struct.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SerializedSection {
     /// The full name of the section.

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -40,6 +40,9 @@ path = "../crate_name_utils"
 [dependencies.crate_metadata]
 path = "../crate_metadata"
 
+[dependencies.crate_metadata_serde]
+path = "../crate_metadata_serde"
+
 [dependencies.memory]
 path = "../memory"
 
@@ -54,7 +57,7 @@ path = "../fs_node"
 
 [dependencies.hashbrown]
 version = "0.11.2"
-features = ["nightly", "serde"]
+features = ["nightly"]
 
 [dependencies.vfs_node]
 path = "../vfs_node"

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -19,14 +19,12 @@ use path::Path;
 use memfs::MemFile;
 use hashbrown::HashMap;
 use rangemap::RangeMap;
-pub use crate_name_utils::{get_containing_crate_name, replace_containing_crate_name, crate_name_from_path};
+pub use crate_name_utils::*;
 pub use crate_metadata::*;
-
 
 pub mod parse_nano_core;
 pub mod replace_nano_core_crates;
-pub mod serde;
-
+mod serde;
 
 /// The name of the directory that contains all of the CrateNamespace files.
 pub const NAMESPACES_DIRECTORY_NAME: &'static str = "namespaces";
@@ -1345,7 +1343,7 @@ impl CrateNamespace {
             // Create a new `LoadedSection` to represent this section.
             let new_section = LoadedSection::new(
                 typ,
-                typ.name_str_ref(),
+                section_name_str_ref(&typ),
                 Arc::clone(mapped_pages_ref),
                 mapped_pages_offset,
                 virt_addr,
@@ -1981,7 +1979,7 @@ impl CrateNamespace {
                         shndx, 
                         Arc::new(LoadedSection::new(
                             typ,
-                            typ.name_str_ref(),
+                            section_name_str_ref(&typ),
                             Arc::clone(rp_ref),
                             rodata_offset,
                             dest_vaddr,
@@ -2020,7 +2018,7 @@ impl CrateNamespace {
                         shndx, 
                         Arc::new(LoadedSection::new(
                             typ,
-                            typ.name_str_ref(),
+                            section_name_str_ref(&typ),
                             Arc::clone(rp_ref),
                             rodata_offset,
                             dest_vaddr,

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -23,7 +23,7 @@ const NANO_CORE_FILENAME_PREFIX: &str = "nano_core.";
 const NANO_CORE_CRATE_NAME: &str = "nano_core";
 
 
-/// Deserializes the file containing the [`SerializedCrate`] representation of the already loaded
+/// Parses and/or deserializes the file containing details about the already loaded
 /// (and currently running) `nano_core` code.
 ///
 /// Basically, just searches for global (public) symbols, which are added to the system map and the crate metadata.

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -3,7 +3,7 @@
 //! As such, it performs no loading, but rather just creates metadata that represents
 //! the existing kernel code that was loaded by the bootloader, and adds those functions to the system map.
 
-use crate::{CrateNamespace, mp_range, serde::SerializedCrate};
+use crate::{CrateNamespace, mp_range};
 use alloc::{collections::{BTreeMap, BTreeSet}, string::{String, ToString}, sync::Arc};
 use fs_node::FileRef;
 use path::Path;
@@ -109,16 +109,15 @@ pub fn parse_nano_core(
             )
         }
         Some("serde") => {
-            let (deserialized, _): (SerializedCrate, _) = try_mp!(
-                bincode::serde::decode_from_slice(bytes, bincode::config::standard()).map_err(
-                    |e| {
-                        error!("parse_nano_core(): error deserializing nano_core: {e}");
-                        "parse_nano_core(): error deserializing nano_core"
-                    }
-                )
+            let (deserialized, _): (crate_metadata_serde::SerializedCrate, _) = try_mp!(
+                bincode::serde::decode_from_slice(bytes, bincode::config::standard()).map_err(|e| {
+                    error!("parse_nano_core(): error deserializing nano_core: {e}");
+                    "parse_nano_core(): error deserializing nano_core"
+                })
             );
             drop(nano_core_file_locked);
-            deserialized.into_loaded_crate(
+            crate::serde::into_loaded_crate(
+                deserialized,
                 nano_core_file,
                 real_namespace,
                 &text_pages,
@@ -313,7 +312,7 @@ fn parse_nano_core_symbol_file(
                 section_counter,
                 Arc::new(LoadedSection::new(
                     typ,
-                    typ.name_str_ref(),
+                    section_name_str_ref(&typ),
                     Arc::clone(rodata_pages),
                     mapped_pages_offset,
                     sec_vaddr,
@@ -334,7 +333,7 @@ fn parse_nano_core_symbol_file(
                 section_counter,
                 Arc::new(LoadedSection::new(
                     typ,
-                    typ.name_str_ref(),
+                    section_name_str_ref(&typ),
                     Arc::clone(rodata_pages),
                     mapped_pages_offset,
                     sec_vaddr,
@@ -555,7 +554,7 @@ fn parse_nano_core_binary(
                     section_counter,
                     Arc::new(LoadedSection::new(
                         typ,
-                        typ.name_str_ref(),
+                        section_name_str_ref(&typ),
                         Arc::clone(&rodata_pages),
                         mapped_pages_offset,
                         sec_vaddr,
@@ -576,7 +575,7 @@ fn parse_nano_core_binary(
                     section_counter,
                     Arc::new(LoadedSection::new(
                         typ,
-                        typ.name_str_ref(),
+                        section_name_str_ref(&typ),
                         Arc::clone(&rodata_pages),
                         mapped_pages_offset,
                         sec_vaddr,

--- a/kernel/mod_mgmt/src/serde.rs
+++ b/kernel/mod_mgmt/src/serde.rs
@@ -1,190 +1,123 @@
-//! Serializable versions of crate and section metadata types.
-//!
-//! The primary reason this exists is because [`LoadedCrate`] and [`LoadedSection`]
-//! make copious usage of `Arc` and `Weak` reference-counted pointer types,
-//! which cannot be properly (de)serialized by `serde`. 
-//! The types in this module remove those refcount types and then reconstruct them
-//! individually at runtime after deserialization.
-//!
-//! This is currently only used to parse and serialize the `nano_core` binary at compile time.
-//! The `nano_core`'s [`SerializedCrate`] is then included as a boot module
-//! so it can be deserialized into a [`LoadedCrate`] at runtime.
+//! Routines for converting serializable crate metadata types
+//! into the actual runtime `LoadedCrate` and `LoadedSection` types.
+//! 
+//! See [`crate_metadata_serde`] docs for more information.
 
-use crate::{CrateNamespace, mp_range};
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    string::String,
-    sync::Arc,
-};
-use cow_arc::CowArc;
-use crate_metadata::*;
-use fs_node::FileRef;
-use hashbrown::HashMap;
-use memory::{MappedPages, VirtualAddress};
-use serde::{Deserialize, Serialize};
-use spin::Mutex;
+use crate::*;
+use crate_metadata_serde::{SerializedCrate, SerializedSection};
 
-/// A (de)serializable representation of a loaded crate that is `serde`-compatible.
-///
-/// See [`LoadedCrate`] for more detail on the fields of this struct.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SerializedCrate {
-    /// The name of the crate.
-    pub crate_name: String,
-    /// A map containing all the sections of the crate.
-    pub sections: HashMap<Shndx, SerializedSection>,
-    /// A set containing the global sectinos of the crate.
-    pub global_sections: BTreeSet<Shndx>,
-    /// A set containing the thread-local storage (TLS) sections of the crate.
-    pub tls_sections: BTreeSet<Shndx>,
-    /// A set containing the `.data` and `.bss` sections of the crate.
-    pub data_sections: BTreeSet<Shndx>,
-    /// A map of symbol names to their constant values, which contain assembler and linker
-    /// constants.
-    pub init_symbols: BTreeMap<String, usize>,
-}
+/// Converts the given [`SerializedCrate`] into a [`LoadedCrate`]
+/// and its sections into [`LoadedSection`]s.
+pub(crate) fn into_loaded_crate(
+    serialized_crate: SerializedCrate,
+    object_file: FileRef,
+    namespace: &Arc<CrateNamespace>,
+    text_pages: &Arc<Mutex<MappedPages>>,
+    rodata_pages: &Arc<Mutex<MappedPages>>,
+    data_pages: &Arc<Mutex<MappedPages>>,
+    verbose_log: bool,
+) -> Result<(StrongCrateRef, BTreeMap<String, usize>, usize), &'static str> {
+    let crate_name: StrRef = serialized_crate.crate_name.as_str().into();
+    
+    // The sections need a weak reference back to the loaded_crate, and so we first create
+    // the loaded_crate so we have something to reference when loading the sections.
+    let loaded_crate = CowArc::new(LoadedCrate {
+        crate_name:          crate_name.clone(),
+        debug_symbols_file:  Arc::downgrade(&object_file),
+        object_file,
+        sections:            HashMap::new(), // placeholder
+        text_pages:          Some((Arc::clone(text_pages), mp_range(text_pages))),
+        rodata_pages:        Some((Arc::clone(rodata_pages), mp_range(rodata_pages))),
+        data_pages:          Some((Arc::clone(data_pages), mp_range(data_pages))),
+        global_sections:     serialized_crate.global_sections,
+        tls_sections:        serialized_crate.tls_sections,
+        data_sections:       serialized_crate.data_sections,
+        reexported_symbols:  BTreeSet::new(),
+    });
 
-impl SerializedCrate {
-    /// Convert this into a [`LoadedCrate`] and its sections into [`LoadedSection`]s.
-    pub(crate) fn into_loaded_crate(
-        self,
-        object_file: FileRef,
-        namespace: &Arc<CrateNamespace>,
-        text_pages: &Arc<Mutex<MappedPages>>,
-        rodata_pages: &Arc<Mutex<MappedPages>>,
-        data_pages: &Arc<Mutex<MappedPages>>,
-        verbose_log: bool,
-    ) -> Result<(StrongCrateRef, BTreeMap<String, usize>, usize), &'static str> {
-        let crate_name: StrRef = self.crate_name.as_str().into();
-        
-        // The sections need a weak reference back to the loaded_crate, and so we first create
-        // the loaded_crate so we have something to reference when loading the sections.
-        let loaded_crate = CowArc::new(LoadedCrate {
-            crate_name:          crate_name.clone(),
-            debug_symbols_file:  Arc::downgrade(&object_file),
-            object_file,
-            sections:            HashMap::new(), // placeholder
-            text_pages:          Some((Arc::clone(text_pages), mp_range(text_pages))),
-            rodata_pages:        Some((Arc::clone(rodata_pages), mp_range(rodata_pages))),
-            data_pages:          Some((Arc::clone(data_pages), mp_range(data_pages))),
-            global_sections:     self.global_sections,
-            tls_sections:        self.tls_sections,
-            data_sections:       self.data_sections,
-            reexported_symbols:  BTreeSet::new(),
-        });
-
-        let mut sections = HashMap::with_capacity(self.sections.len());
-        for (shndx, section) in self.sections {
-            sections.insert(
-                shndx,
-                section.into_loaded_section(
-                    CowArc::downgrade(&loaded_crate),
-                    namespace,
-                    text_pages,
-                    rodata_pages,
-                    data_pages,
-                )?,
-            );
-        }
-
-        let num_new_syms = namespace.add_symbols(sections.values(), verbose_log);
-
-        let mut loaded_crate_mut = loaded_crate.lock_as_mut().ok_or(
-            "BUG: SerializedCrate::into_loaded_crate(): couldn't get exclusive mutable access to loaded_crate",
-        )?;
-        loaded_crate_mut.sections = sections;
-        drop(loaded_crate_mut);
-
-        // Add the newly-parsed nano_core crate to the kernel namespace.
-        namespace
-            .crate_tree
-            .lock()
-            .insert(crate_name, loaded_crate.clone_shallow());
-        info!(
-            "Finished parsing nano_core crate, added {} new symbols.",
-            num_new_syms
+    let mut sections = HashMap::with_capacity(serialized_crate.sections.len());
+    for (shndx, section) in serialized_crate.sections {
+        sections.insert(
+            shndx,
+            into_loaded_section(
+                section,
+                CowArc::downgrade(&loaded_crate),
+                namespace,
+                text_pages,
+                rodata_pages,
+                data_pages,
+            )?,
         );
-        
-        // // Dump loaded sections for verification. See pull request #542/#559 for more details:
-        // let loaded_crate_ref = loaded_crate.lock_as_ref();
-        // for (_, section) in loaded_crate_ref.sections.iter() {
-        //     trace!("{:016x} {} {}", section.address_range.start.value(), section.name, section.mapped_pages_offset);
-        // }
-        // drop(loaded_crate_ref);
-
-        Ok((loaded_crate, self.init_symbols, num_new_syms))
     }
+
+    let num_new_syms = namespace.add_symbols(sections.values(), verbose_log);
+
+    let mut loaded_crate_mut = loaded_crate.lock_as_mut().ok_or(
+        "BUG: SerializedCrate::into_loaded_crate(): couldn't get exclusive mutable access to loaded_crate",
+    )?;
+    loaded_crate_mut.sections = sections;
+    drop(loaded_crate_mut);
+
+    // Add the newly-parsed nano_core crate to the kernel namespace.
+    namespace.crate_tree.lock().insert(crate_name, loaded_crate.clone_shallow());
+    info!("Finished parsing nano_core crate, added {} new symbols.", num_new_syms);
+    
+    // // Dump loaded sections for verification. See pull request #542/#559 for more details:
+    // let loaded_crate_ref = loaded_crate.lock_as_ref();
+    // for (_, section) in loaded_crate_ref.sections.iter() {
+    //     trace!("{:016x} {} {}", section.address_range.start.value(), section.name, section.mapped_pages_offset);
+    // }
+    // drop(loaded_crate_ref);
+
+    Ok((loaded_crate, serialized_crate.init_symbols, num_new_syms))
 }
 
-/// A (de)serializable representation of a loaded section that is `serde`-compatible.
-///
-/// See [`LoadedSection`] for more detail on the fields of this struct.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SerializedSection {
-    /// The full name of the section.
-    pub name: String,
-    /// The type of the section.
-    pub ty: SectionType,
-    /// Whether or not the section is global.
-    pub global: bool,
-    /// The starting [`VirtualAddress`] of the range covered by this section.
-    pub virtual_address: usize,
-    /// The offset into the [`MappedPages`] where this section starts.
-    pub offset: usize,
-    /// The size of the section.
-    pub size: usize,
-}
 
-impl SerializedSection {
-    /// Convert this into a [`LoadedSection`].
-    pub(crate) fn into_loaded_section(
-        self,
-        parent_crate: WeakCrateRef,
-        namespace: &Arc<CrateNamespace>,
-        text_pages: &Arc<Mutex<MappedPages>>,
-        rodata_pages: &Arc<Mutex<MappedPages>>,
-        data_pages: &Arc<Mutex<MappedPages>>,
-    ) -> Result<Arc<LoadedSection>, &'static str> {
-        let mapped_pages = match self.ty {
-            SectionType::Text => Arc::clone(text_pages),
-            SectionType::Rodata
-            | SectionType::TlsData
-            | SectionType::TlsBss
-            | SectionType::GccExceptTable
-            | SectionType::EhFrame => Arc::clone(rodata_pages),
-            SectionType::Data | SectionType::Bss => Arc::clone(data_pages),
-        };
-        let virtual_address = VirtualAddress::new(self.virtual_address)
-            .ok_or("SerializedSection::into_loaded_section(): invalid virtual address")?;
+/// Convert the given [`SerializedSection`] into a [`LoadedSection`].
+fn into_loaded_section(
+    serialized_section: SerializedSection,
+    parent_crate: WeakCrateRef,
+    namespace: &Arc<CrateNamespace>,
+    text_pages: &Arc<Mutex<MappedPages>>,
+    rodata_pages: &Arc<Mutex<MappedPages>>,
+    data_pages: &Arc<Mutex<MappedPages>>,
+) -> Result<Arc<LoadedSection>, &'static str> {
+    let mapped_pages = match serialized_section.ty {
+        SectionType::Text => Arc::clone(text_pages),
+        SectionType::Rodata
+        | SectionType::TlsData
+        | SectionType::TlsBss
+        | SectionType::GccExceptTable
+        | SectionType::EhFrame => Arc::clone(rodata_pages),
+        SectionType::Data | SectionType::Bss => Arc::clone(data_pages),
+    };
+    let virtual_address = VirtualAddress::new(serialized_section.virtual_address)
+        .ok_or("SerializedSection::into_loaded_section(): invalid virtual address")?;
 
-        let loaded_section = Arc::new(LoadedSection {
-            name: match self.ty {
-                SectionType::EhFrame
-                | SectionType::GccExceptTable => self.ty.name_str_ref(),
-                _ => self.name.as_str().into(),
-            },
-            typ: self.ty,
-            global: self.global,
-            mapped_pages_offset: self.offset,
-            mapped_pages,
-            address_range: virtual_address..(virtual_address + self.size),
-            parent_crate,
-            inner: Default::default(),
-        });
+    let loaded_section = Arc::new(LoadedSection {
+        name: match serialized_section.ty {
+            SectionType::EhFrame
+            | SectionType::GccExceptTable => crate::section_name_str_ref(&serialized_section.ty),
+            _ => serialized_section.name.as_str().into(),
+        },
+        typ: serialized_section.ty,
+        global: serialized_section.global,
+        mapped_pages_offset: serialized_section.offset,
+        mapped_pages,
+        address_range: virtual_address..(virtual_address + serialized_section.size),
+        parent_crate,
+        inner: Default::default(),
+    });
 
-        if let SectionType::TlsData | SectionType::TlsBss = self.ty {
-            namespace
-                .tls_initializer
-                .lock()
-                .add_existing_static_tls_section(
-                    // TLS sections encode their TLS offset in the virtual address field,
-                    // which is necessary to properly calculate relocation entries that depend upon them.
-                    self.virtual_address,
-                    Arc::clone(&loaded_section),
-                )
-                .unwrap();
-        }
-
-        Ok(loaded_section)
+    if let SectionType::TlsData | SectionType::TlsBss = serialized_section.ty {
+        namespace.tls_initializer.lock().add_existing_static_tls_section(
+            // TLS sections encode their TLS offset in the virtual address field,
+            // which is necessary to properly calculate relocation entries that depend upon them.
+            serialized_section.virtual_address,
+            Arc::clone(&loaded_section),
+        )
+        .unwrap();
     }
+
+    Ok(loaded_section)
 }

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -326,6 +326,7 @@ name = "crate_metadata"
 version = "0.1.0"
 dependencies = [
  "cow_arc",
+ "crate_metadata_serde",
  "fs_node",
  "goblin",
  "hashbrown",
@@ -336,6 +337,16 @@ dependencies = [
  "spin 0.9.0",
  "str_ref",
  "xmas-elf",
+]
+
+[[package]]
+name = "crate_metadata_serde"
+version = "0.1.0"
+dependencies = [
+ "hashbrown",
+ "log",
+ "serde",
+ "str_ref",
 ]
 
 [[package]]
@@ -988,6 +999,7 @@ dependencies = [
  "const_format",
  "cow_arc",
  "crate_metadata",
+ "crate_metadata_serde",
  "crate_name_utils",
  "cstr_core",
  "fs_node",

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -344,9 +344,7 @@ name = "crate_metadata_serde"
 version = "0.1.0"
 dependencies = [
  "hashbrown",
- "log",
  "serde",
- "str_ref",
 ]
 
 [[package]]

--- a/tools/serialize_nano_core/Cargo.lock
+++ b/tools/serialize_nano_core/Cargo.lock
@@ -14,25 +14,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic_linked_list"
-version = "0.1.0"
-
-[[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "bare-metal"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
-dependencies = [
- "rustc_version 0.2.3",
-]
-
-[[package]]
 name = "bincode"
 version = "2.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,217 +33,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit_field"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff91a64014e1bc53bf643920f2c9ab5f0980d92a0948295f3ee550e9266849ad"
-
-[[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
-
-[[package]]
-name = "bitfield"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bootloader_modules"
-version = "0.1.0"
-dependencies = [
- "memory_structs",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "const_format"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2906f2480cdc015e998deac388331a0f1c1cd88744948c749513020c83c370bc"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef196d5d972878a48da7decb7686eded338b4858fbabeed513d63a7c98b2b82d"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "cortex-m"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd20d4ac4aa86f4f75f239d59e542ef67de87cce2c282818dc6e84155d3ea126"
-dependencies = [
- "bare-metal",
- "bitfield",
- "embedded-hal",
- "volatile-register",
-]
-
-[[package]]
-name = "cow_arc"
+name = "crate_metadata_serde"
 version = "0.1.0"
 dependencies = [
- "owning_ref",
- "spin 0.9.3",
-]
-
-[[package]]
-name = "crate_metadata"
-version = "0.1.0"
-dependencies = [
- "cow_arc",
- "fs_node",
- "goblin",
  "hashbrown",
  "log",
- "memory",
- "qp-trie",
  "serde",
- "spin 0.9.3",
  "str_ref",
- "xmas-elf",
-]
-
-[[package]]
-name = "crate_name_utils"
-version = "0.1.0"
-dependencies = [
- "crate_metadata",
- "itertools",
- "path",
-]
-
-[[package]]
-name = "cstr_core"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644828c273c063ab0d39486ba42a5d1f3a499d35529c759e763a9c6cb8a0fb08"
-dependencies = [
- "cty",
- "memchr",
-]
-
-[[package]]
-name = "cty"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
-
-[[package]]
-name = "delegate"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c47a31748d9cfa641f6cccb3608385fafe261ba36054f3d40d5a3ca11eb1af"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.0",
- "syn",
-]
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
-name = "embedded-hal"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
-dependencies = [
- "nb 0.1.3",
- "void",
-]
-
-[[package]]
-name = "entryflags_x86_64"
-version = "0.1.0"
-dependencies = [
- "bitflags",
- "multiboot2",
- "static_assertions",
- "xmas-elf",
-]
-
-[[package]]
-name = "frame_allocator"
-version = "0.1.0"
-dependencies = [
- "intrusive-collections",
- "kernel_config",
- "log",
- "memory_structs",
- "page_table_entry",
- "spin 0.9.3",
- "static_assertions",
-]
-
-[[package]]
-name = "fs_node"
-version = "0.1.0"
-dependencies = [
- "io",
- "lazy_static",
- "log",
- "memory",
- "spin 0.9.3",
 ]
 
 [[package]]
@@ -277,16 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "goblin"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65cd533b33e3d04c6e393225fa8919ddfcf5862ca8919c7f9a167c312ef41c2"
-dependencies = [
- "plain",
- "scroll",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,82 +70,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "intrusive-collections"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe531a7789d7120f3e17d4f3f2cd95f54418ba7354f60b7b622b6644a07888a"
-dependencies = [
- "memoffset",
-]
-
-[[package]]
-name = "io"
-version = "0.1.0"
-dependencies = [
- "core2",
- "delegate",
- "lazy_static",
- "lockable",
- "log",
- "spin 0.9.3",
-]
-
-[[package]]
-name = "irq_safety"
-version = "0.1.1"
-source = "git+https://github.com/theseus-os/irq_safety#d6be450ef6487052e5b6b174d679b77f26f93b48"
-dependencies = [
- "cortex-m",
- "owning_ref",
- "spin 0.9.3",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "itertools"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "kernel_config"
 version = "0.1.0"
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin 0.5.2",
-]
 
 [[package]]
 name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
-
-[[package]]
-name = "lock_api"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
-name = "lockable"
-version = "0.1.0"
-dependencies = [
- "irq_safety",
- "spin 0.9.3",
-]
 
 [[package]]
 name = "log"
@@ -384,200 +89,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memfs"
-version = "0.1.0"
-dependencies = [
- "fs_node",
- "io",
- "irq_safety",
- "log",
- "memory",
- "spin 0.9.3",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memory"
-version = "0.1.0"
-dependencies = [
- "atomic_linked_list",
- "bit_field 0.7.0",
- "bitflags",
- "frame_allocator",
- "irq_safety",
- "kernel_config",
- "lazy_static",
- "log",
- "memory_structs",
- "memory_x86_64",
- "multiboot2",
- "page_allocator",
- "page_table_entry",
- "spin 0.9.3",
- "x86_64",
- "xmas-elf",
- "zerocopy",
-]
-
-[[package]]
-name = "memory_structs"
-version = "0.1.0"
-dependencies = [
- "bit_field 0.7.0",
- "derive_more",
- "entryflags_x86_64",
- "kernel_config",
- "multiboot2",
- "paste",
- "xmas-elf",
- "zerocopy",
-]
-
-[[package]]
-name = "memory_x86_64"
-version = "0.1.0"
-dependencies = [
- "entryflags_x86_64",
- "kernel_config",
- "log",
- "memory_structs",
- "multiboot2",
- "x86_64",
-]
-
-[[package]]
-name = "mod_mgmt"
-version = "0.1.0"
-dependencies = [
- "bincode",
- "bootloader_modules",
- "const_format",
- "cow_arc",
- "crate_metadata",
- "crate_name_utils",
- "cstr_core",
- "fs_node",
- "hashbrown",
- "kernel_config",
- "log",
- "memfs",
- "memory",
- "path",
- "qp-trie",
- "rangemap",
- "root",
- "rustc-demangle",
- "serde",
- "spin 0.9.3",
- "util",
- "vfs_node",
- "xmas-elf",
-]
-
-[[package]]
-name = "multiboot2"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6170b6f12ea75d8d0f5621e3ed780b041a666c4a5b904c77261fe343d0e798d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.0.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
-
-[[package]]
 name = "once_cell"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
-
-[[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "git+https://github.com/theseus-os/owning-ref-rs#0d2dcdcffd75b80157d0e72fb82593a8696a9c49"
-dependencies = [
- "spin 0.9.3",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "page_allocator"
-version = "0.1.0"
-dependencies = [
- "intrusive-collections",
- "kernel_config",
- "log",
- "memory_structs",
- "spin 0.9.3",
- "static_assertions",
-]
-
-[[package]]
-name = "page_table_entry"
-version = "0.1.0"
-dependencies = [
- "bit_field 0.7.0",
- "kernel_config",
- "memory_structs",
- "zerocopy",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
-
-[[package]]
-name = "path"
-version = "0.1.0"
-dependencies = [
- "fs_node",
- "lazy_static",
- "log",
- "root",
- "spin 0.9.3",
- "vfs_node",
-]
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
@@ -589,16 +104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qp-trie"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a075ecba64154fed5429568c9c6a0e0eccc3276209e93e6133206413ea6834b4"
-dependencies = [
- "new_debug_unreachable",
- "unreachable",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,87 +111,6 @@ checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rangemap"
-version = "1.0.3"
-source = "git+https://github.com/theseus-os/rangemap?branch=const_fn_constructor#be8b0ee4cfe51d587d4317f37a2db7c75f2d2647"
-
-[[package]]
-name = "root"
-version = "0.1.0"
-dependencies = [
- "fs_node",
- "lazy_static",
- "log",
- "spin 0.9.3",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver 1.0.10",
-]
-
-[[package]]
-name = "rustversion"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scroll"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
-dependencies = [
- "rustc_version 0.2.3",
-]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -713,42 +137,11 @@ name = "serialize_nano_core"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "crate_metadata",
+ "crate_metadata_serde",
  "hashbrown",
  "kernel_config",
- "memory",
- "mod_mgmt",
  "serde",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
-source = "git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin#e006c79280042e27c4f16c7d29633eb2273752ee"
-dependencies = [
- "spin 0.9.3",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_ref"
@@ -766,47 +159,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
-
-[[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
-name = "util"
-version = "0.1.0"
-
-[[package]]
-name = "vcell"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
 
 [[package]]
 name = "version_check"
@@ -815,90 +171,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "vfs_node"
-version = "0.1.0"
-dependencies = [
- "fs_node",
- "log",
- "memory",
- "spin 0.9.3",
-]
-
-[[package]]
 name = "virtue"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "757cfbfe0d17ee6f22fe97e536d463047d451b47cf9d11e2b7d1398b0ef274dd"
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "volatile"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ca98349dda8a60ae74e04fd90c7fb4d6a4fbe01e6d3be095478aa0b76f6c0c"
-
-[[package]]
-name = "volatile-register"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
-dependencies = [
- "vcell",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "x86_64"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958cd5cb28e720db2f59ee9dc4235b5f82a183d079fb0e6caf43ad074cfdc66a"
-dependencies = [
- "bit_field 0.10.1",
- "bitflags",
- "rustversion",
- "volatile",
-]
-
-[[package]]
-name = "xmas-elf"
-version = "0.6.2"
-source = "git+https://github.com/theseus-os/xmas-elf.git#635d55f6886ae3fe0ec8a78e0bcc1238224c903d"
-dependencies = [
- "zero",
-]
-
-[[package]]
-name = "zero"
-version = "0.1.3"
-source = "git+https://github.com/theseus-os/zero.git#9fc7ff523138a21f40359b706d2d6bf91deafc62"
-
-[[package]]
-name = "zerocopy"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e59ec1d2457bd6c0dd89b50e7d9d6b0b647809bf3f0a59ac85557046950b7b2"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
-dependencies = [
- "proc-macro2",
- "syn",
- "synstructure",
-]

--- a/tools/serialize_nano_core/Cargo.lock
+++ b/tools/serialize_nano_core/Cargo.lock
@@ -43,9 +43,7 @@ name = "crate_metadata_serde"
 version = "0.1.0"
 dependencies = [
  "hashbrown",
- "log",
  "serde",
- "str_ref",
 ]
 
 [[package]]
@@ -78,15 +76,6 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
-
-[[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "once_cell"
@@ -142,10 +131,6 @@ dependencies = [
  "kernel_config",
  "serde",
 ]
-
-[[package]]
-name = "str_ref"
-version = "0.1.0"
 
 [[package]]
 name = "syn"

--- a/tools/serialize_nano_core/Cargo.toml
+++ b/tools/serialize_nano_core/Cargo.toml
@@ -6,9 +6,7 @@ authors = ["Klim Tsoutsman <klim@tsoutsman.com>"]
 description = "Creates a serialized representation of the symbols in the `nano_core` binary"
 
 [dependencies]
-crate_metadata = { path = "../../kernel/crate_metadata" }
-mod_mgmt = { path = "../../kernel/mod_mgmt" }
-memory = { path = "../../kernel/memory" }
+crate_metadata_serde = { path = "../../kernel/crate_metadata_serde" }
 kernel_config = { path = "../../kernel/kernel_config" }
 hashbrown = "0.11"
 serde = { version = "1.0", features = ["derive"] }
@@ -16,8 +14,3 @@ serde = { version = "1.0", features = ["derive"] }
 [dependencies.bincode]
 version = "2.0.0-rc.1"
 features = ["serde"]
-
-[patch.crates-io]
-### Use our fork of `rangemap`, which makes constructors const functions.
-### This can be removed once this PR lands: <https://github.com/jeffparsons/rangemap/pull/52>
-rangemap = { git = "https://github.com/theseus-os/rangemap", branch = "const_fn_constructor" }

--- a/tools/serialize_nano_core/src/main.rs
+++ b/tools/serialize_nano_core/src/main.rs
@@ -2,7 +2,7 @@
 
 mod parse;
 
-use mod_mgmt::serde::SerializedCrate;
+use crate_metadata_serde::SerializedCrate;
 use std::io::Write;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tools/serialize_nano_core/src/parse.rs
+++ b/tools/serialize_nano_core/src/parse.rs
@@ -1,6 +1,5 @@
-use crate_metadata::{SectionType, Shndx};
+use crate_metadata_serde::{SectionType, SerializedSection, Shndx};
 use hashbrown::HashMap;
-use mod_mgmt::serde::SerializedSection;
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Parses the nano_core symbol file that represents the sections and symbols


### PR DESCRIPTION
* Minimizes dependencies of `tools/serialize_nano_core`, which
  greatly reduces its build time.