### PR TITLE
`task_switch`: drop the `next` `TaskRef` right before the context switch

### DIFF
--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -12,7 +12,6 @@ cfg_if::cfg_if! {
     }
 }
 
-use core::ops::Deref;
 use apic::get_my_apic_id;
 use task::{get_my_current_task, TaskRef};
 
@@ -51,7 +50,7 @@ pub fn schedule() -> bool {
     };
 
     let (did_switch, recovered_preemption_guard) = curr_task.task_switch(
-        next_task.deref(),
+        next_task,
         apic_id,
         preemption_guard,
     ); 


### PR DESCRIPTION
* `task_switch()` now takes an owned `TaskRef` object for the `next`
  task instead of a `&Task`, which prevents that `next` `TaskRef` object
  from being on the stack frame of the `schedule()` function
  (or whatever other function may call `task_switch() in the future).

* This avoids a rare issue where a task may not be immediately dropped
  upon exiting and being reaped, because a reference to the task might
  still persist as a local variable on a different task's stack,
  due to the way that `schedule()` previously invoked `task_switch()`.

* Also states our intent more clearly in `task_switch()`  by ensuring
  that `next` cannot be invalidly accessed after the context switch
  operation has returned.