### PR TITLE
Add `set_flags()` function for re-mapping pages with new flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,6 @@ dependencies = [
  "kernel_config",
  "log",
  "memory_structs",
- "page_table_entry",
  "spin 0.9.0",
  "static_assertions",
 ]
@@ -2200,6 +2199,7 @@ name = "page_table_entry"
 version = "0.1.0"
 dependencies = [
  "bit_field 0.7.0",
+ "frame_allocator",
  "kernel_config",
  "memory_structs",
  "zerocopy",

--- a/kernel/entryflags_x86_64/src/lib.rs
+++ b/kernel/entryflags_x86_64/src/lib.rs
@@ -62,8 +62,11 @@ bitflags! {
     }
 }
 
+/// A mask for the bits of a page table entry that contain the physical frame address.
+pub const PAGE_TABLE_ENTRY_FRAME_MASK: u64 = 0x000_FFFFFFFFFF_000;
+
 // Ensure that we never expose reserved bits [12:51] as part of the `EntryFlags` interface.
-const_assert_eq!(EntryFlags::all().bits() & 0x000_FFFFFFFFFF_000, 0);
+const_assert_eq!(EntryFlags::all().bits() & PAGE_TABLE_ENTRY_FRAME_MASK, 0);
 
 impl EntryFlags {
     /// Returns a new, all-zero `EntryFlags` with no bits enabled.

--- a/kernel/frame_allocator/Cargo.toml
+++ b/kernel/frame_allocator/Cargo.toml
@@ -18,8 +18,5 @@ path = "../kernel_config"
 [dependencies.memory_structs]
 path = "../memory_structs"
 
-[dependencies.page_table_entry]
-path = "../page_table_entry"
-
 [lib]
 crate-type = ["rlib"]

--- a/kernel/mapper_spillful/src/lib.rs
+++ b/kernel/mapper_spillful/src/lib.rs
@@ -150,8 +150,7 @@ impl MapperSpillful {
                 .and_then(|p2| p2.next_table_mut(page.p2_index()))
                 .ok_or("mapping code does not support huge pages")?;
             
-            let frame = p1[page.p1_index()].pointed_frame().ok_or("remap(): page not mapped")?;
-            p1[page.p1_index()].set_entry(frame, new_flags | EntryFlags::PRESENT);
+            p1[page.p1_index()].set_flags(new_flags | EntryFlags::PRESENT);
 
             tlb_flush_virt_addr(page.start_address());
         }

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -111,7 +111,7 @@ pub fn create_mapping(size_in_bytes: usize, flags: EntryFlags) -> Result<MappedP
 }
 
 
-pub static BROADCAST_TLB_SHOOTDOWN_FUNC: Once<fn(PageRange)> = Once::new();
+static BROADCAST_TLB_SHOOTDOWN_FUNC: Once<fn(PageRange)> = Once::new();
 
 /// Set the function callback that will be invoked every time a TLB shootdown is necessary,
 /// i.e., during page table remapping and unmapping operations.
@@ -200,7 +200,7 @@ pub fn init(
         }
     }
 
-    frame_allocator::init(free_regions.iter().flatten(), reserved_regions.iter().flatten())?;
+    let into_alloc_frames_fn = frame_allocator::init(free_regions.iter().flatten(), reserved_regions.iter().flatten())?;
     debug!("Initialized new frame allocator!");
     frame_allocator::dump_frame_allocator_state();
 
@@ -218,7 +218,10 @@ pub fn init(
         boot_info_pages,
         higher_half_mapped_pages,
         identity_mapped_pages
-    ) = paging::init(boot_info)?;
+    ) = paging::init(
+        boot_info,
+        into_alloc_frames_fn,
+    )?;
 
     debug!("Done with paging::init(). new page_table: {:?}", page_table);
     Ok((

--- a/kernel/memory/src/paging/mod.rs
+++ b/kernel/memory/src/paging/mod.rs
@@ -198,6 +198,7 @@ pub fn get_current_p4() -> Frame {
 /// Otherwise, it returns a str error message. 
 pub fn init(
     boot_info: &multiboot2::BootInformation,
+    into_alloc_frames_fn: fn(FrameRange) -> AllocatedFrames,
 ) -> Result<(
         PageTable,
         MappedPages,
@@ -209,6 +210,10 @@ pub fn init(
         [Option<MappedPages>; 32]
     ), &'static str>
 {
+    // Store the callback from `frame_allocator::init()` that allows the `Mapper` to convert
+    // `page_table_entry::UnmappedFrames` back into `AllocatedFrames`.
+    mapper::INTO_ALLOCATED_FRAMES_FUNC.call_once(|| into_alloc_frames_fn);
+
     let (aggregated_section_memory_bounds, _sections_memory_bounds) = find_section_memory_bounds(boot_info)?;
     debug!("{:X?}\n{:X?}", aggregated_section_memory_bounds, _sections_memory_bounds);
     

--- a/kernel/memory/src/paging/table.rs
+++ b/kernel/memory/src/paging/table.rs
@@ -36,7 +36,7 @@ pub struct Table<L: TableLevel> {
 
 impl<L: TableLevel> Table<L> {
     /// Zero out (clear) all entries in this page table frame. 
-    pub fn zero(&mut self) {
+    pub(crate) fn zero(&mut self) {
         for entry in self.entries.iter_mut() {
             entry.zero();
         }

--- a/kernel/memory_structs/src/lib.rs
+++ b/kernel/memory_structs/src/lib.rs
@@ -23,7 +23,7 @@ use core::{
 };
 use kernel_config::memory::{MAX_PAGE_NUMBER, PAGE_SIZE};
 #[cfg(target_arch = "x86_64")]
-pub use entryflags_x86_64::EntryFlags;
+pub use entryflags_x86_64::{EntryFlags, PAGE_TABLE_ENTRY_FRAME_MASK};
 use zerocopy::FromBytes;
 use paste::paste;
 

--- a/kernel/memory_x86_64/src/lib.rs
+++ b/kernel/memory_x86_64/src/lib.rs
@@ -16,7 +16,7 @@ extern crate entryflags_x86_64;
 extern crate x86_64;
 
 pub use multiboot2::BootInformation;
-pub use entryflags_x86_64::EntryFlags;
+pub use entryflags_x86_64::{EntryFlags, PAGE_TABLE_ENTRY_FRAME_MASK};
 
 use kernel_config::memory::KERNEL_OFFSET;
 use memory_structs::{

--- a/kernel/page_table_entry/Cargo.toml
+++ b/kernel/page_table_entry/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "page_table_entry"
 description = "Defines the structure of page table entries on x86_64"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies]
 bit_field = "0.7.0"
@@ -14,6 +15,8 @@ path = "../kernel_config"
 [dependencies.memory_structs]
 path = "../memory_structs"
 
+[dependencies.frame_allocator]
+path = "../frame_allocator"
 
 [lib]
 crate-type = ["rlib"]

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "kernel_config",
  "log",
  "memory_structs",
- "page_table_entry",
  "spin 0.9.0",
  "static_assertions",
 ]
@@ -1098,6 +1097,7 @@ name = "page_table_entry"
 version = "0.1.0"
 dependencies = [
  "bit_field 0.7.0",
+ "frame_allocator",
  "kernel_config",
  "memory_structs",
  "zerocopy",


### PR DESCRIPTION
* Also, remove the direct dependency from `frame_allocator` to `page_table_entry` in favor of a callback function returned by `frame_allocator::init()`.

* This will allow the `PageTableEntry` functions to require an `AllocatedFrames` object to set a page table entry's frame, which proves that the caller has exclusive access to an owned physical frame.