### PR TITLE
Uncomment passing complexity lints

### DIFF
--- a/kernel/page_table_entry/src/lib.rs
+++ b/kernel/page_table_entry/src/lib.rs
@@ -1,13 +1,13 @@
 //! Defines the structure of Page Table Entries (PTEs) on x86_64.
 //!
 //! This crate is also useful for frame deallocation, because it can determine
-//! when a frame is mapped exclusively to only one page table entry, 
-//! and therefore when it is safe to deallocate. 
-//! 
+//! when a frame is mapped exclusively to only one page table entry,
+//! and therefore when it is safe to deallocate.
+//!
 //! Because Theseus ensures a bijective (1-to-1) mapping
 //! between virtual pages and physical frames,
-//! it is almost always the case that the frame pointed to 
-//! by a newly-unmapped page table entry can be deallocated. 
+//! it is almost always the case that the frame pointed to
+//! by a newly-unmapped page table entry can be deallocated.
 //!
 
 #![no_std]
@@ -17,13 +17,12 @@ use memory_structs::{Frame, FrameRange, PAGE_TABLE_ENTRY_FRAME_MASK, EntryFlags,
 use bit_field::BitField;
 use kernel_config::memory::PAGE_SHIFT;
 use zerocopy::FromBytes;
-use frame_allocator::AllocatedFrames;
 
 /// A page table entry, which is a `u64` value under the hood.
 ///
 /// It contains a the physical address of the `Frame` being mapped by this entry
 /// and the access bits (encoded `EntryFlags`) that describes how it's mapped,
-/// e.g., readable, writable, no exec, etc. 
+/// e.g., readable, writable, no exec, etc.
 ///
 /// There isn't and shouldn't be any way to create/instantiate a new `PageTableEntry` directly.
 /// You can only obtain a reference to an `PageTableEntry` by going through a page table's `Table` struct itself.
@@ -42,20 +41,20 @@ impl PageTableEntry {
         self.0 = 0;
     }
 
-    /// Removes the mapping represented by this page table entry. 
-    /// 
+    /// Removes the mapping represented by this page table entry.
+    ///
     /// If the frame(s) pointed to by this entry were mapped exlusively,
     /// i.e., owned by this entry and not mapped anywhere else by any other entries,
-    /// then this function returns those frames. 
+    /// then this function returns those frames.
     /// This is useful because those returned frames can then be safely deallocated.
     pub fn set_unmapped(&mut self) -> UnmapResult {
         let frame = self.frame_value();
         let flags = self.flags();
         self.zero();
 
-        // Since we don't support huge pages, this PTE can only cover one 4KiB frame. 
-        // Once we support huge pages, we can use a type parameter 
-        // to specify whether this is a 4KiB, 2MiB, or 1GiB PTE. 
+        // Since we don't support huge pages, this PTE can only cover one 4KiB frame.
+        // Once we support huge pages, we can use a type parameter
+        // to specify whether this is a 4KiB, 2MiB, or 1GiB PTE.
         let frame_range = FrameRange::new(frame, frame);
         if flags.is_exclusive() {
             UnmapResult::Exclusive(UnmappedFrames(frame_range))
@@ -70,7 +69,7 @@ impl PageTableEntry {
     }
 
     /// Returns the physical `Frame` pointed to (mapped by) this `PageTableEntry`.
-    /// If this page table entry is not `PRESENT`, this returns `None`. 
+    /// If this page table entry is not `PRESENT`, this returns `None`.
     pub fn pointed_frame(&self) -> Option<Frame> {
         if self.flags().intersects(EntryFlags::PRESENT) {
             Some(self.frame_value())
@@ -90,13 +89,13 @@ impl PageTableEntry {
     ///
     /// This is the actual mapping action that informs the MMU of a new mapping.
     ///
-    /// Note: this performs no checks about the current value of this page table entry. 
+    /// Note: this performs no checks about the current value of this page table entry.
     pub fn set_entry(&mut self, frame: Frame, flags: EntryFlags) {
         self.0 = (frame.start_address().value() as u64) | flags.bits();
     }
 
     /// Sets the flags components of this `PageTableEntry` to `new_flags`.
-    /// 
+    ///
     /// This does not modify the frame part of the page table entry.
     pub fn set_flags(&mut self, new_flags: EntryFlags) {
         self.0 = self.0 & PAGE_TABLE_ENTRY_FRAME_MASK | new_flags.bits();
@@ -110,11 +109,11 @@ impl PageTableEntry {
 /// The frames returned from the action of unmapping a page table entry.
 /// See the `PageTableEntry::set_unmapped()` function.
 ///
-/// If exclusive, the contained `UnmappedFrames` can be used to deallocate frames. 
+/// If exclusive, the contained `UnmappedFrames` can be used to deallocate frames.
 ///
 /// If non-exclusive, the contained `FrameRange` is provided just for debugging feedback.
 /// Note that we use `FrameRange` instead of `Frame` because a single page table entry
-/// can map many frames, e.g., using huge pages. 
+/// can map many frames, e.g., using huge pages.
 #[must_use]
 pub enum UnmapResult {
     Exclusive(UnmappedFrames),

--- a/lints.txt
+++ b/lints.txt
@@ -1,99 +1,99 @@
 # Complexity
 bind-instead-of-map
 bool-comparison
-# borrowed-box
-# bytes-count-to-len
+borrowed-box
+bytes-count-to-len
 # char-lit-as-u8
 # clone-on-copy
-# crosspointer-transmute
-# deprecated-cfg-attr
-# deref-addrof
+crosspointer-transmute
+deprecated-cfg-attr
+deref-addrof
 # derivable-impls
-# diverging-sub-expression
-# double-comparisons
-# double-parens
-# duration-subsec
+diverging-sub-expression
+double-comparisons
+double-parens
+duration-subsec
 # explicit-counter-loop
-# explicit-write
-# extra-unused-lifetimes
-# filter-map-identity
+explicit-write
+extra-unused-lifetimes
+filter-map-identity
 filter-next
-# flat-map-identity
-# get-last-with-len
+flat-map-identity
+get-last-with-len
 # identity-op
-# inspect-for-each
+inspect-for-each
 # int-plus-one
-# iter-count
-# manual-filter-map
-# manual-find-map
+iter-count
+manual-filter-map
+manual-find-map
 # manual-flatten
-# manual-split-once
-# manual-strip
-# manual-swap
+manual-split-once
+manual-strip
+manual-swap
 manual-unwrap-or
-# map-flatten
-# map-identity
-# match-as-ref
-# match-single-binding
-# needless-arbitrary-self-type
-# needless-bool
-# needless-borrowed-reference
+map-flatten
+map-identity
+match-as-ref
+match-single-binding
+needless-arbitrary-self-type
+needless-bool
+needless-borrowed-reference
 # needless-lifetimes
-# needless-match
-# needless-option-as-deref
-# needless-option-take
+needless-match
+needless-option-as-deref
+needless-option-take
 # needless-question-mark
-# needless-splitn
-# needless-update
-# neg-cmp-op-on-partial-ord
-# no-effect
+needless-splitn
+needless-update
+neg-cmp-op-on-partial-ord
+no-effect
 nonminimal-bool
-# option-as-ref-deref
-# option-filter-map
-# option-map-unit-fn
-# or-then-unwrap
-# overflow-check-conditional
-# partialeq-ne-impl
-# precedence
+option-as-ref-deref
+option-filter-map
+option-map-unit-fn
+or-then-unwrap
+overflow-check-conditional
+partialeq-ne-impl
+precedence
 # ptr-offset-with-cast
-# range-zip-with-len
-# redundant-closure-call
-# redundant-slicing
-# repeat-once
-# result-map-unit-fn
-# search-is-some
-# short-circuit-statement
-# single-element-loop
-# skip-while-next
-# string-from-utf8-as-bytes
-# strlen-on-c-strings
-# temporary-assignment
+range-zip-with-len
+redundant-closure-call
+redundant-slicing
+repeat-once
+result-map-unit-fn
+search-is-some
+short-circuit-statement
+single-element-loop
+skip-while-next
+string-from-utf8-as-bytes
+strlen-on-c-strings
+temporary-assignment
 # too-many-arguments
-# transmute-bytes-to-str
-# transmute-float-to-int
-# transmute-int-to-bool
-# transmute-int-to-char
-# transmute-int-to-float
-# transmute-num-to-bytes
-# transmute-ptr-to-ref
-# transmutes-expressible-as-ptr-casts
+transmute-bytes-to-str
+transmute-float-to-int
+transmute-int-to-bool
+transmute-int-to-char
+transmute-int-to-float
+transmute-num-to-bytes
+transmute-ptr-to-ref
+transmutes-expressible-as-ptr-casts
 # type-complexity
-# unit-arg
+unit-arg
 # unnecessary-cast
-# unnecessary-filter-map
-# unnecessary-find-map
-# unnecessary-operation
-# unnecessary-sort-by
-# unnecessary-unwrap
-# unneeded-wildcard-pattern
+unnecessary-filter-map
+unnecessary-find-map
+unnecessary-operation
+unnecessary-sort-by
+unnecessary-unwrap
+unneeded-wildcard-pattern
 useless-asref
 # useless-conversion
 # useless-format
-# vec-box
+vec-box
 while-let-loop
-# wildcard-in-or-patterns
-# zero-divided-by-zero
-# zero-prefixed-literal
+wildcard-in-or-patterns
+zero-divided-by-zero
+zero-prefixed-literal
 # Correctness
 absurd-extreme-comparisons
 # almost-swapped


### PR DESCRIPTION
My editor automatically removed the trailing white space, please let me know if I should remove that commit. I just wanted to remove the unneeded import that was giving me a warning even though I had everything turned off.

I added all the complexity lints that are passing. I will add the others but this is a first chunk. I am a new contributor to the project so wanted to make sure my ducks are in a row before doing too much.