### PR TITLE
Add rustfmt.toml, ignore all for now

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,12 @@
+ignore = [
+    "/applications",
+    "/compiler_plugins",
+    "/kernel",
+    "/libs",
+    "/libtheseus",
+    "/old_crates",
+    "/ports",
+    "/theseus_features",
+    "/tlibc",
+    "/tools"
+]


### PR DESCRIPTION
instead of just `/` I added all the subfolders of root which contain rust code within them, so we can remove these if we're ever done formatting them