### PR TITLE
Use crate metavariable in print crates

### DIFF
--- a/kernel/print/src/lib.rs
+++ b/kernel/print/src/lib.rs
@@ -27,8 +27,8 @@ pub fn set_default_print_output(producer: DFQueueProducer<Event>) {
 /// Calls `print!()` with an extra newilne `\n` appended to the end. 
 #[macro_export]
 macro_rules! println {
-    ($fmt:expr) => (print!(concat!($fmt, "\n")));
-    ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
+    ($fmt:expr) => ($crate::print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => ($crate::print!(concat!($fmt, "\n"), $($arg)*));
 }
 
 /// The main printing macro, which simply pushes an output event to the event queue. 

--- a/kernel/terminal_print/src/lib.rs
+++ b/kernel/terminal_print/src/lib.rs
@@ -30,8 +30,8 @@ use spin::Mutex;
 /// Calls `print!()` with an extra newline ('\n') appended to the end. 
 #[macro_export]
 macro_rules! println {
-    ($fmt:expr) => (print!(concat!($fmt, "\n")));
-    ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
+    ($fmt:expr) => ($crate::print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => ($crate::print!(concat!($fmt, "\n"), $($arg)*));
 
 }
 


### PR DESCRIPTION
Avoids having to import the `print` macro when using `println` with newer Rust versions (without `#[macro_use]`).

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>