### PR TITLE
Use `ok_or_else` and `unwrap_or_else` variants where appropriate.

### DIFF
--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -316,7 +316,7 @@ impl LoadedCrate {
     pub fn crate_name_without_hash(&self) -> &str {
         self.crate_name.split(CRATE_HASH_DELIMITER)
             .next()
-            .unwrap_or_else(|| &self.crate_name)
+            .unwrap_or(&self.crate_name)
     }
 
     /// Returns this crate name as a symbol prefix, including a trailing "`::`".
@@ -447,7 +447,7 @@ impl LoadedCrate {
             let new_sec_mapped_pages_offset = old_sec.mapped_pages_offset;
             let (new_sec_mapped_pages_ref, new_sec_virt_addr) = match old_sec.typ {
                 SectionType::Text => (
-                    new_text_pages_ref.clone().ok_or_else(|| "BUG: missing text pages in newly-copied crate")?,
+                    new_text_pages_ref.clone().ok_or("BUG: missing text pages in newly-copied crate")?,
                     new_text_pages_locked.as_ref().and_then(|tp| tp.address_at_offset(new_sec_mapped_pages_offset)),
                 ),
                 SectionType::Rodata
@@ -455,16 +455,16 @@ impl LoadedCrate {
                 | SectionType::TlsBss
                 | SectionType::TlsData 
                 | SectionType::EhFrame => (
-                    new_rodata_pages_ref.clone().ok_or_else(|| "BUG: missing rodata pages in newly-copied crate")?,
+                    new_rodata_pages_ref.clone().ok_or("BUG: missing rodata pages in newly-copied crate")?,
                     new_rodata_pages_locked.as_ref().and_then(|rp| rp.address_at_offset(new_sec_mapped_pages_offset)),
                 ),
                 SectionType::Data
                 | SectionType::Bss => (
-                    new_data_pages_ref.clone().ok_or_else(|| "BUG: missing data pages in newly-copied crate")?,
+                    new_data_pages_ref.clone().ok_or("BUG: missing data pages in newly-copied crate")?,
                     new_data_pages_locked.as_ref().and_then(|dp| dp.address_at_offset(new_sec_mapped_pages_offset)),
                 ),
             };
-            let new_sec_virt_addr = new_sec_virt_addr.ok_or_else(|| "BUG: couldn't get virt_addr for new section")?;
+            let new_sec_virt_addr = new_sec_virt_addr.ok_or("BUG: couldn't get virt_addr for new section")?;
 
             let new_sec = Arc::new(LoadedSection::with_dependencies(
                 old_sec.typ,                            // section type is the same
@@ -492,18 +492,18 @@ impl LoadedCrate {
             let new_sec_mapped_pages = match new_sec.typ {
                 SectionType::Text => new_text_pages_locked
                     .as_mut()
-                    .ok_or_else(|| "BUG: missing text pages in newly-copied crate")?,
+                    .ok_or("BUG: missing text pages in newly-copied crate")?,
                 SectionType::Rodata
                 | SectionType::TlsBss
                 | SectionType::TlsData
                 | SectionType::GccExceptTable
                 | SectionType::EhFrame => new_rodata_pages_locked
                     .as_mut()
-                    .ok_or_else(|| "BUG: missing rodata pages in newly-copied crate")?,
+                    .ok_or("BUG: missing rodata pages in newly-copied crate")?,
                 SectionType::Data
                 | SectionType::Bss => new_data_pages_locked
                     .as_mut()
-                    .ok_or_else(|| "BUG: missing data pages in newly-copied crate")?,
+                    .ok_or("BUG: missing data pages in newly-copied crate")?,
             };
             let new_sec_mapped_pages_offset = new_sec.mapped_pages_offset;
 
@@ -539,7 +539,7 @@ impl LoadedCrate {
             // which are completely safe to clone without needing any fix ups. 
             for internal_dep in &new_sec.inner.read().internal_dependencies {
                 let source_sec = new_sections.get(&internal_dep.source_sec_shndx)
-                    .ok_or_else(|| "Couldn't get new section specified by an internal dependency's source_sec_shndx")?;
+                    .ok_or("Couldn't get new section specified by an internal dependency's source_sec_shndx")?;
 
                 // The source and target (new_sec) sections might be the same, so we need to check first
                 // to ensure that we don't cause deadlock by trying to lock the same section twice.
@@ -572,7 +572,7 @@ impl LoadedCrate {
         // set the new_crate's `sections` list, since we didn't do it earlier
         {
             let mut new_crate_mut = new_crate.lock_as_mut()
-                .ok_or_else(|| "BUG: LoadedCrate::deep_copy(): couldn't get exclusive mutable access to newly-copied crate")?;
+                .ok_or("BUG: LoadedCrate::deep_copy(): couldn't get exclusive mutable access to newly-copied crate")?;
             new_crate_mut.sections = new_sections;
         }
 
@@ -761,7 +761,7 @@ impl LoadedSection {
     pub fn section_name_without_hash(sec_name: &str) -> &str {
         sec_name.rfind(SECTION_HASH_DELIMITER)
             .and_then(|end| sec_name.get(0 .. (end + SECTION_HASH_DELIMITER.len())))
-            .unwrap_or_else(|| &sec_name)
+            .unwrap_or(&sec_name)
     }
 
 

--- a/kernel/crate_swap/src/lib.rs
+++ b/kernel/crate_swap/src/lib.rs
@@ -260,17 +260,17 @@ pub fn swap_crates(
         let new_crate_ref = if is_optimized {
             debug!("swap_crates(): OPTIMIZED: looking for new crate {:?} in cache", new_crate_name);
             namespace_of_new_crates.get_crate(&new_crate_name)
-                .ok_or_else(|| "BUG: swap_crates(): Couldn't get new crate from optimized cache")?
+                .ok_or("BUG: swap_crates(): Couldn't get new crate from optimized cache")?
         } else {
             #[cfg(not(loscd_eval))]
             debug!("looking for newly-loaded crate {:?} in temp namespace", new_crate_name);
             namespace_of_new_crates.get_crate(&new_crate_name)
-                .ok_or_else(|| "BUG: Couldn't get new crate that should've just been loaded into a new temporary namespace")?
+                .ok_or("BUG: Couldn't get new crate that should've just been loaded into a new temporary namespace")?
         };
 
         // scope the lock on the `new_crate_ref`
         {
-            let mut new_crate = new_crate_ref.lock_as_mut().ok_or_else(|| 
+            let mut new_crate = new_crate_ref.lock_as_mut().ok_or(
                 "BUG: swap_crates(): new_crate was unexpectedly shared in another namespace (couldn't get as exclusively mutable)...?"
             )?;
 
@@ -302,9 +302,7 @@ pub fn swap_crates(
                     let mut iter = new_crate.data_sections_iter().filter(|sec| sec.name.starts_with(&*prefix));
                     iter.next()
                         .filter(|_| iter.next().is_none()) // ensure single element
-                        .ok_or_else(|| 
-                            "couldn't find destination section in new crate to copy old_sec's data into (.data/.bss state transfer)"
-                        )
+                        .ok_or("couldn't find destination section in new crate to copy old_sec's data into (.data/.bss state transfer)")
                 }?;
 
                 #[cfg(not(loscd_eval))]

--- a/kernel/fault_crate_swap/src/lib.rs
+++ b/kernel/fault_crate_swap/src/lib.rs
@@ -470,7 +470,7 @@ fn iterative_swap_policy() -> Option<String> {
             if let Some(error_crate) = unhandled_list[0].crate_error_occured.clone() {
 
                 let error_crate_name = error_crate.clone();
-                let error_crate_name_simple = error_crate_name.split("-").next().unwrap_or_else(|| &error_crate_name);
+                let error_crate_name_simple = error_crate_name.split("-").next().unwrap_or(&error_crate_name);
 
                 // We check whether the fault is logged previously
                 let fe_last_fault = fault_log::get_the_most_recent_match(error_crate_name_simple);

--- a/kernel/fault_log/src/lib.rs
+++ b/kernel/fault_log/src/lib.rs
@@ -203,7 +203,7 @@ pub fn log_panic_entry(panic_info: &PanicInfo) {
         let panic_file = location.file();
         let mut error_crate_iter = panic_file.split('/');
         error_crate_iter.next();
-        let error_crate_name_simple = error_crate_iter.next().unwrap_or_else(|| panic_file);
+        let error_crate_name_simple = error_crate_iter.next().unwrap_or(panic_file);
         debug!("panic file {}",error_crate_name_simple);
         fe.crate_error_occured = Some(error_crate_name_simple.to_string());
     } else {
@@ -247,7 +247,7 @@ pub fn log_handled_fault(fe: FaultEntry){
 
 /// Provides the most recent entry in the log for given crate
 /// Utility function for iterative crate replacement
-pub fn get_the_most_recent_match(error_crate : &str) -> Option<FaultEntry> {
+pub fn get_the_most_recent_match(error_crate: &str) -> Option<FaultEntry> {
 
     #[cfg(not(downtime_eval))]
     debug!("getting the most recent match");
@@ -256,7 +256,7 @@ pub fn get_the_most_recent_match(error_crate : &str) -> Option<FaultEntry> {
     for fault_entry in FAULT_LIST.lock().iter() {
         if let Some(crate_error_occured) = &fault_entry.crate_error_occured {
             let error_crate_name = crate_error_occured.clone();
-            let error_crate_name_simple = error_crate_name.split('-').next().unwrap_or_else(|| &error_crate_name);
+            let error_crate_name_simple = error_crate_name.split('-').next().unwrap_or(&error_crate_name);
             if error_crate_name_simple == error_crate {
                 let item = fault_entry.clone();
                 fe = Some(item);

--- a/kernel/frame_allocator/src/lib.rs
+++ b/kernel/frame_allocator/src/lib.rs
@@ -280,7 +280,7 @@ impl Chunk {
     }
 
     /// Returns a new `Chunk` with an empty range of frames. 
-    fn empty() -> Chunk {
+    const fn empty() -> Chunk {
         Chunk {
             typ: MemoryRegionType::Unknown,
             frames: FrameRange::empty(),

--- a/kernel/ixgbe/src/lib.rs
+++ b/kernel/ixgbe/src/lib.rs
@@ -1287,7 +1287,7 @@ pub fn rx_poll_mq(qid: usize, nic_id: PciLocation) -> Result<ReceivedFrame, &'st
 
 /// A helper function to send a test packet on a nic transmit queue (only for testing purposes).
 pub fn tx_send_mq(qid: usize, nic_id: PciLocation, packet: Option<TransmitBuffer>) -> Result<(), &'static str> {
-    let packet = packet.unwrap_or(test_packets::create_dhcp_test_packet()?);
+    let packet = packet.map(Ok).unwrap_or_else(|| test_packets::create_dhcp_test_packet())?;
     let nic_ref = get_ixgbe_nic(nic_id)?;
     let mut nic = nic_ref.lock();  
 

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -966,7 +966,7 @@ impl CrateNamespace {
     ) -> Result<(), &'static str> {
 
         for weak_dep in &old_section.inner.read().sections_dependent_on_me {
-            let target_sec = weak_dep.section.upgrade().ok_or_else(|| "couldn't upgrade WeakDependent.section")?;
+            let target_sec = weak_dep.section.upgrade().ok_or("couldn't upgrade WeakDependent.section")?;
             let relocation_entry = weak_dep.relocation;
 
             debug!("rewrite_section_dependents(): target_sec: {:?}, old_sec: {:?}, new_sec: {:?}", target_sec, old_section, new_section);
@@ -1131,7 +1131,7 @@ impl CrateNamespace {
         // Set up the new_crate's sections, since we couldn't do it when `new_crate` was created.
         {
             let mut new_crate_mut = new_crate.lock_as_mut()
-                .ok_or_else(|| "BUG: load_crate_sections(): couldn't get exclusive mutable access to new_crate")?;
+                .ok_or("BUG: load_crate_sections(): couldn't get exclusive mutable access to new_crate")?;
             new_crate_mut.sections        = loaded_sections;
             new_crate_mut.global_sections = global_sections;
             new_crate_mut.tls_sections    = tls_sections;
@@ -1878,7 +1878,7 @@ impl CrateNamespace {
                 if let Some((ref dp_ref, ref mut dp)) = read_write_pages_locked {
                     // here: we're ready to copy the data/bss section to the proper address
                     let dest_vaddr = dp.address_at_offset(data_offset)
-                        .ok_or_else(|| "BUG: data_offset wasn't within data_pages")?;
+                        .ok_or("BUG: data_offset wasn't within data_pages")?;
                     let dest_slice: &mut [u8] = dp.as_slice_mut(data_offset, sec_size)?;
                     match sec.get_data(&elf_file) {
                         Ok(SectionData::Undefined(sec_data)) => dest_slice.copy_from_slice(sec_data),
@@ -1919,7 +1919,7 @@ impl CrateNamespace {
                 if let Some((ref rp_ref, ref mut rp)) = read_only_pages_locked {
                     // here: we're ready to copy the rodata section to the proper address
                     let dest_vaddr = rp.address_at_offset(rodata_offset)
-                        .ok_or_else(|| "BUG: rodata_offset wasn't within rodata_mapped_pages")?;
+                        .ok_or("BUG: rodata_offset wasn't within rodata_mapped_pages")?;
                     let dest_slice: &mut [u8] = rp.as_slice_mut(rodata_offset, sec_size)?;
                     match sec.get_data(&elf_file) {
                         Ok(SectionData::Undefined(sec_data)) => dest_slice.copy_from_slice(sec_data),
@@ -1963,7 +1963,7 @@ impl CrateNamespace {
                 if let Some((ref rp_ref, ref mut rp)) = read_only_pages_locked {
                     // here: we're ready to copy the rodata section to the proper address
                     let dest_vaddr = rp.address_at_offset(rodata_offset)
-                        .ok_or_else(|| "BUG: rodata_offset wasn't within rodata_mapped_pages")?;
+                        .ok_or("BUG: rodata_offset wasn't within rodata_mapped_pages")?;
                     let dest_slice: &mut [u8]  = rp.as_slice_mut(rodata_offset, sec_size)?;
                     match sec.get_data(&elf_file) {
                         Ok(SectionData::Undefined(sec_data)) => dest_slice.copy_from_slice(sec_data),
@@ -2002,7 +2002,7 @@ impl CrateNamespace {
                 if let Some((ref rp_ref, ref mut rp)) = read_only_pages_locked {
                     // here: we're ready to copy the rodata section to the proper address
                     let dest_vaddr = rp.address_at_offset(rodata_offset)
-                        .ok_or_else(|| "BUG: rodata_offset wasn't within rodata_mapped_pages")?;
+                        .ok_or("BUG: rodata_offset wasn't within rodata_mapped_pages")?;
                     let dest_slice: &mut [u8]  = rp.as_slice_mut(rodata_offset, sec_size)?;
                     match sec.get_data(&elf_file) {
                         Ok(SectionData::Undefined(sec_data)) => dest_slice.copy_from_slice(sec_data),

--- a/kernel/mod_mgmt/src/replace_nano_core_crates.rs
+++ b/kernel/mod_mgmt/src/replace_nano_core_crates.rs
@@ -114,7 +114,7 @@ fn load_crate_using_nano_core_data_sections(
     // (2) Go through the .data/.bss sections in the partially loaded new crate,
     //     and replace them with references to the corresponding data section in the nano_core.
     {
-        let mut new_crate = new_crate_ref.lock_as_mut().ok_or_else(|| "BUG: could not get exclusive mutable access to newly-loaded crate")?;
+        let mut new_crate = new_crate_ref.lock_as_mut().ok_or("BUG: could not get exclusive mutable access to newly-loaded crate")?;
 
         for shndx in new_crate.data_sections.clone() {
             let new_data_sec = new_crate.sections.get_mut(&shndx).ok_or_else(|| {

--- a/kernel/path/src/lib.rs
+++ b/kernel/path/src/lib.rs
@@ -88,7 +88,7 @@ impl Path {
     pub fn basename<'a>(&'a self) -> &'a str {
         self.rcomponents()
             .next()
-            .unwrap_or_else(|| &self.path)
+            .unwrap_or(&self.path)
     }
 
     /// Like [`basename()`](#method.basename), but excludes the file extension, if present.
@@ -96,7 +96,7 @@ impl Path {
         self.basename()
             .split(EXTENSION_DELIMITER)
             .find(|&x| x != "")
-            .unwrap_or_else(|| &self.path)
+            .unwrap_or(&self.path)
     }
 
     /// Returns the file extension, if present. 

--- a/kernel/smoltcp_helper/src/lib.rs
+++ b/kernel/smoltcp_helper/src/lib.rs
@@ -58,7 +58,7 @@ pub fn get_default_iface() -> Result<NetworkInterfaceRef, &'static str> {
         .iter()
         .next()
         .cloned()
-        .ok_or_else(|| "no network interfaces available")
+        .ok_or("no network interfaces available")
 }
 
 /// A convenience function for connecting a socket.

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -95,7 +95,7 @@ impl<'p> From<&PanicInfo<'p>> for PanicInfoOwned {
     fn from(info: &PanicInfo) -> PanicInfoOwned {
         let msg = info.message()
             .map(|m| format!("{}", m))
-            .unwrap_or_else(|| String::new());
+            .unwrap_or_default();
         let (file, line, column) = if let Some(loc) = info.location() {
             (String::from(loc.file()), loc.line(), loc.column())
         } else {

--- a/tools/copy_latest_crate_objects/src/main.rs
+++ b/tools/copy_latest_crate_objects/src/main.rs
@@ -134,14 +134,14 @@ fn main() -> Result<(), String> {
         return Ok(());
     }
 
-    let mut kernel_prefix = matches.opt_str("kernel-prefix").unwrap_or("k".to_string());
+    let mut kernel_prefix = matches.opt_str("kernel-prefix").unwrap_or_else(|| "k".to_string());
     if !kernel_prefix.ends_with(MODULE_PREFIX_DELIMITER) {
         kernel_prefix.push_str(MODULE_PREFIX_DELIMITER);
     }
     if kernel_prefix.matches(MODULE_PREFIX_DELIMITER).count() > 1 {
         return Err(format!("kernel-prefix {:?} must only contain one '#' character at the end!", kernel_prefix));
     }
-    let mut app_prefix = matches.opt_str("app-prefix").unwrap_or("a".to_string());
+    let mut app_prefix = matches.opt_str("app-prefix").unwrap_or_else(|| "a".to_string());
     if !app_prefix.ends_with(MODULE_PREFIX_DELIMITER) {
         app_prefix.push_str(MODULE_PREFIX_DELIMITER);
     }

--- a/tools/grub_cfg_generation/src/main.rs
+++ b/tools/grub_cfg_generation/src/main.rs
@@ -56,7 +56,7 @@ fn create_grub_cfg_string(input_directory: String) -> Result<String, String> {
     // Creates string to write to grub.cfg file by looking through all files in input_directory
     let mut content = String::new();
     
-    let mut path_to_exe = std::env::current_exe().unwrap_or(std::path::PathBuf::new());
+    let mut path_to_exe = std::env::current_exe().unwrap_or_default();
     // go up three directories to remove the "target/<build_mode>/name"
     path_to_exe.pop(); path_to_exe.pop(); path_to_exe.pop();
 
@@ -71,7 +71,7 @@ fn create_grub_cfg_string(input_directory: String) -> Result<String, String> {
     for path in fs::read_dir(input_directory).map_err(|e| e.to_string())? {
         let path = path.map_err(|e| e.to_string())?;
         let p = path.path();
-        let file_name = p.file_name().and_then(|f| f.to_str()).ok_or(format!("Path error in path {:?}", path))?;
+        let file_name = p.file_name().and_then(|f| f.to_str()).ok_or_else(|| format!("Path error in path {:?}", path))?;
         content.push_str(&format!("\tmodule2 /modules/{0:50}\t\t{1:50}\n", file_name, file_name));
     }
 


### PR DESCRIPTION
* No functional changes to the code, just changes to satisfy clippy and avoid unnecessarily eager error handling code.