### PR TITLE
Revert `linked_list_allocator` from `0.10.*` back to `0.9.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.10.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8da0e6283aace40e4e0395fe5ad7a147fac6ff47bda1f038b5044fb11683c2"
+checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
 
 [[package]]
 name = "loadc"

--- a/kernel/block_allocator/Cargo.toml
+++ b/kernel/block_allocator/Cargo.toml
@@ -4,6 +4,6 @@ name = "block_allocator"
 version = "0.1.0"
 
 [dependencies.linked_list_allocator]
-version = "0.10.3"
+version = "0.9.1"
 default-features = false
 features = [ "const_mut_refs" ]

--- a/kernel/block_allocator/src/lib.rs
+++ b/kernel/block_allocator/src/lib.rs
@@ -63,7 +63,7 @@ impl FixedSizeBlockAllocator {
     /// heap bounds are valid and that the heap is unused. This method must be
     /// called only once.
     pub unsafe fn init(&mut self, heap_start: usize, heap_size: usize) {
-        self.fallback_allocator.init(heap_start as *mut u8, heap_size);
+        self.fallback_allocator.init(heap_start, heap_size);
     }
 
     /// Allocates using the fallback allocator.

--- a/tlibc/Cargo.lock
+++ b/tlibc/Cargo.lock
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.10.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8da0e6283aace40e4e0395fe5ad7a147fac6ff47bda1f038b5044fb11683c2"
+checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
 
 [[package]]
 name = "lock_api"


### PR DESCRIPTION
* There is a problem with `linked_list_allocator` version `0.10.*` that causes Theseus to hang when built and run in loadable mode. It's related to heap deallocation but I haven't yet debugged it in depth, so I'm reverting back to the old working version until I can dive in and file an issue there.

* This reverts commit 92b9490dd1fbdca800bc6b29b6df8fa1408e9470.