### PR TITLE
Make `Task::block` and `Task::unblock` fallible

### DIFF
--- a/applications/channel_eval/src/lib.rs
+++ b/applications/channel_eval/src/lib.rs
@@ -96,7 +96,8 @@ fn test_multiple(iterations: usize) -> Result<(), &'static str> {
         .spawn()?;
 
     info!("test_multiple(): Finished spawning the sender and receiver tasks");
-    t2.unblock(); t1.unblock();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -1419,9 +1419,11 @@ impl Shell {
             if let Ok(job_num) = job_num.parse::<isize>() {
                 if let Some(job) = self.jobs.get_mut(&job_num) {
                     for task_ref in &job.tasks {
-                        let _ = task_ref.unblock();
-                        // TODO: Do we want to set the job status of an exited task to running?
-                        job.status = JobStatus::Running;
+                        if let Err(_) = task_ref.unblock() {
+                            job.status = JobStatus::Stopped;
+                        } else {
+                            job.status = JobStatus::Running;
+                        }
                     }
                     self.clear_cmdline(false)?;
                     self.redisplay_prompt();
@@ -1451,9 +1453,11 @@ impl Shell {
                 if let Some(job) = self.jobs.get_mut(&job_num) {
                     self.fg_job_num = Some(job_num);
                     for task_ref in &job.tasks {
-                        let _ = task_ref.unblock();
-                        // TODO: Do we want to set the job status of an exited task to running?
-                        job.status = JobStatus::Running;
+                        if let Err(_) = task_ref.unblock() {
+                            job.status = JobStatus::Stopped;
+                        } else {
+                            job.status = JobStatus::Running;
+                        }
                     }
                     return Ok(());
                 }

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -106,11 +106,12 @@ pub fn main(_args: Vec<String>) -> isize {
         };
     }
 
+    // block this task, because it never needs to actually run again
+    task::get_my_current_task().unwrap().block().unwrap();
+    scheduler::schedule();
+
     loop {
-        // block this task, because it never needs to actually run again
-        if let Some(my_task) = task::get_my_current_task() {
-            my_task.block().unwrap();
-        }
+        warn!("BUG: blocked shell task was scheduled in unexpectedly");
     }
 
     // TODO: when `join` puts this task to sleep instead of spinning, we can re-enable it.

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -28,7 +28,7 @@ extern crate libterm;
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate log;
 
-use event_types::{Event};
+use event_types::Event;
 use keycodes_ascii::{Keycode, KeyAction, KeyEvent};
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
@@ -109,7 +109,7 @@ pub fn main(_args: Vec<String>) -> isize {
     loop {
         // block this task, because it never needs to actually run again
         if let Some(my_task) = task::get_my_current_task() {
-            my_task.block();
+            my_task.block().unwrap();
         }
     }
 
@@ -462,8 +462,9 @@ impl Shell {
                 app_io::lock_and_execute(&|_flags_guard, _streams_guard| {
                     // Stop all tasks in the job.
                     for task_ref in task_refs {
-                        if task_ref.has_exited() { continue; }
-                        task_ref.block();
+                        if task_ref.block().is_err() {
+                            continue;
+                        }
 
                         // Here we must wait for the running application to stop before releasing the lock,
                         // because the previous `block` method will NOT stop the application immediately.
@@ -770,7 +771,7 @@ impl Shell {
 
                 // All IO streams have been set up for the new tasks. Safe to unblock them now.
                 for task_ref in &new_job.tasks {
-                    task_ref.unblock();
+                    task_ref.unblock().unwrap();
                 }
 
                 // Allocate a job number for the new job. It will start from 1 and choose the smallest number
@@ -1418,9 +1419,8 @@ impl Shell {
             if let Ok(job_num) = job_num.parse::<isize>() {
                 if let Some(job) = self.jobs.get_mut(&job_num) {
                     for task_ref in &job.tasks {
-                        if !task_ref.has_exited() {
-                            task_ref.unblock();
-                        }
+                        let _ = task_ref.unblock();
+                        // TODO: Do we want to set the job status of an exited task to running?
                         job.status = JobStatus::Running;
                     }
                     self.clear_cmdline(false)?;
@@ -1451,9 +1451,8 @@ impl Shell {
                 if let Some(job) = self.jobs.get_mut(&job_num) {
                     self.fg_job_num = Some(job_num);
                     for task_ref in &job.tasks {
-                        if !task_ref.has_exited() {
-                            task_ref.unblock();
-                        }
+                        let _ = task_ref.unblock();
+                        // TODO: Do we want to set the job status of an exited task to running?
                         job.status = JobStatus::Running;
                     }
                     return Ok(());

--- a/applications/test_channel/src/lib.rs
+++ b/applications/test_channel/src/lib.rs
@@ -182,7 +182,8 @@ fn rendezvous_test_oneshot() -> Result<(), &'static str> {
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("rendezvous_test_oneshot(): Finished spawning the sender and receiver tasks");
-    t2.unblock(); t1.unblock();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -213,7 +214,8 @@ fn rendezvous_test_multiple(send_count: usize, receive_count: usize, send_panic:
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("rendezvous_test_multiple(): Finished spawning the sender and receiver tasks");
-    t2.unblock(); t1.unblock();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -306,7 +308,8 @@ fn asynchronous_test_oneshot() -> Result<(), &'static str> {
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("asynchronous_test_oneshot(): Finished spawning the sender and receiver tasks");
-    t2.unblock(); t1.unblock();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -335,7 +338,8 @@ fn asynchronous_test_multiple(send_count: usize, receive_count: usize, send_pani
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("asynchronous_test_multiple(): Finished spawning the sender and receiver tasks");
-    t2.unblock(); t1.unblock();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;

--- a/applications/test_mutex_sleep/src/lib.rs
+++ b/applications/test_mutex_sleep/src/lib.rs
@@ -59,7 +59,9 @@ fn test_contention() -> Result<(), &'static str> {
 
     warn!("Finished spawning the 3 tasks");
 
-    t3.unblock(); t2.unblock(); t1.unblock();
+    t3.unblock().unwrap();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -115,7 +117,9 @@ fn test_lockstep() -> Result<(), &'static str> {
 
     warn!("Finished spawning the 3 tasks");
 
-    t3.unblock(); t2.unblock(); t1.unblock();
+    t3.unblock().unwrap();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;

--- a/applications/test_realtime/src/lib.rs
+++ b/applications/test_realtime/src/lib.rs
@@ -42,7 +42,7 @@ pub fn main(_args: Vec<String>) -> isize {
         scheduler::set_periodicity(&periodic_task_1, 1000).unwrap();
 
         // start the tasks
-        periodic_task_1.unblock();
+        periodic_task_1.unblock().unwrap();
 
         0
     }

--- a/applications/test_realtime/src/lib.rs
+++ b/applications/test_realtime/src/lib.rs
@@ -57,6 +57,6 @@ fn _task_delay_tester(_arg: usize) {
         iter += 1;
 
         // This desk will sleep periodically for 1000 systicks
-        sleep::sleep_periodic(&start_time, 1000);
+        sleep::sleep_periodic(&start_time, 1000).unwrap();
     }
 }

--- a/applications/test_wait_queue/src/lib.rs
+++ b/applications/test_wait_queue/src/lib.rs
@@ -55,7 +55,7 @@ fn rmain() -> Result<(), &'static str> {
     let t3 = spawn::new_task_builder(
         |tref| {
             warn!("DeezNutz:  testing spurious wakeup on task {:?}", tref);
-            tref.unblock();
+            tref.unblock().unwrap();
         }, 
         t1.clone(),
         )
@@ -68,10 +68,10 @@ fn rmain() -> Result<(), &'static str> {
 
     // give the wait task (t1) a chance to run before the notify task
     for _ in 0..100 { scheduler::schedule(); }
-    t3.unblock();
+    t3.unblock().unwrap();
     
     for _ in 0..100 { scheduler::schedule(); }
-    t2.unblock();
+    t2.unblock().unwrap();
 
 
     t1.join()?;

--- a/kernel/deferred_interrupt_tasks/src/lib.rs
+++ b/kernel/deferred_interrupt_tasks/src/lib.rs
@@ -171,7 +171,10 @@ fn deferred_task_entry_point<DIA, Arg, Success, Failure>(
             Err(failure) => error!("Deferred interrupt action returned failure: {:?}", debugit!(failure)),
         }
 
-        curr_task.block().expect("BUG: deffered_task_entry_point: couldn't block task");
+        if curr_task.block().is_err() {
+            error!("deffered_task_entry_point: couldn't block task");
+        }
+
         scheduler::schedule();
     }
 }

--- a/kernel/deferred_interrupt_tasks/src/lib.rs
+++ b/kernel/deferred_interrupt_tasks/src/lib.rs
@@ -171,7 +171,7 @@ fn deferred_task_entry_point<DIA, Arg, Success, Failure>(
             Err(failure) => error!("Deferred interrupt action returned failure: {:?}", debugit!(failure)),
         }
 
-        curr_task.block();
+        curr_task.block().expect("BUG: deffered_task_entry_point: couldn't block task");
         scheduler::schedule();
     }
 }

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -187,8 +187,7 @@ impl SerialPort {
                     Ok(SerialPortAddress::COM1 | SerialPortAddress::COM3) => {
                         INTERRUPT_ACTION_COM1_COM3.call_once(|| 
                             Box::new(move || {
-                                deferred_task
-                                    .unblock()
+                                deferred_task.unblock()
                                     .expect("BUG: com_1_com3_interrupt_handler: couldn't unblock deferred task");
                             })
                         );
@@ -196,8 +195,7 @@ impl SerialPort {
                     Ok(SerialPortAddress::COM2 | SerialPortAddress::COM4) => {
                         INTERRUPT_ACTION_COM2_COM4.call_once(|| 
                             Box::new(move || {
-                                deferred_task
-                                    .unblock()
+                                deferred_task.unblock()
                                     .expect("BUG: com_2_com4_interrupt_handler: couldn't unblock deferred task");
                             })
                         );

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -186,12 +186,20 @@ impl SerialPort {
                 match SerialPortAddress::try_from(base_port) {
                     Ok(SerialPortAddress::COM1 | SerialPortAddress::COM3) => {
                         INTERRUPT_ACTION_COM1_COM3.call_once(|| 
-                            Box::new(move || { deferred_task.unblock(); })
+                            Box::new(move || {
+                                deferred_task
+                                    .unblock()
+                                    .expect("BUG: com_1_com3_interrupt_handler: couldn't unblock deferred task");
+                            })
                         );
                     }
                     Ok(SerialPortAddress::COM2 | SerialPortAddress::COM4) => {
                         INTERRUPT_ACTION_COM2_COM4.call_once(|| 
-                            Box::new(move || { deferred_task.unblock(); })
+                            Box::new(move || {
+                                deferred_task
+                                    .unblock()
+                                    .expect("BUG: com_2_com4_interrupt_handler: couldn't unblock deferred task");
+                            })
                         );
                     }
                     Err(_) => warn!("Registering interrupt handler for unknown serial port at {:#X}", base_port),

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -88,7 +88,7 @@ fn add_to_delayed_tasklist(new_node: SleepingTaskNode) {
 fn remove_next_task_from_delayed_tasklist() {
     let mut delayed_tasklist = DELAYED_TASKLIST.lock();
     if let Some(SleepingTaskNode { taskref, .. }) = delayed_tasklist.pop() {
-        let _ = taskref.unblock();
+        taskref.unblock().expect("failed to unblock sleeping task");
 
         match delayed_tasklist.peek() {
             Some(SleepingTaskNode { resume_time, .. }) => 

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -18,7 +18,7 @@ extern crate scheduler;
 use core::sync::atomic::{Ordering, AtomicUsize};
 use alloc::collections::binary_heap::BinaryHeap;
 use irq_safety::MutexIrqSafe;
-use task::{get_my_current_task, TaskRef};
+use task::{get_my_current_task, TaskRef, RunState};
 
 /// Contains the `TaskRef` and the associated wakeup time for an entry in DELAYED_TASKLIST.
 #[derive(Clone, Eq, PartialEq)]
@@ -108,29 +108,38 @@ pub fn unblock_sleeping_tasks() {
 }
 
 /// Blocks the current task by putting it to sleep for `duration` ticks.
-pub fn sleep(duration: usize) {
+///
+/// Returns the current task's run state if it can't be blocked.
+pub fn sleep(duration: usize) -> Result<(), RunState> {
     let current_tick_count = TICK_COUNT.load(Ordering::SeqCst);
     let resume_time = current_tick_count + duration;
 
     let current_task = get_my_current_task().unwrap().clone();
     // Add the current task to the delayed tasklist and then block it.
     add_to_delayed_tasklist(SleepingTaskNode{taskref: current_task.clone(), resume_time});
-    current_task.block().unwrap();
+    current_task.block()?;
     scheduler::schedule();
+    Ok(())
 }
 
 /// Blocks the current task by putting it to sleep until a specific tick count is reached,
 /// given by `resume_time`.
-pub fn sleep_until(resume_time: usize) {
+///
+/// Returns the current task's run state if it can't be blocked.
+pub fn sleep_until(resume_time: usize) -> Result<(), RunState> {
     let current_tick_count = TICK_COUNT.load(Ordering::SeqCst);
 
     if resume_time > current_tick_count {
-        sleep(resume_time - current_tick_count);
+        sleep(resume_time - current_tick_count)?;
     }
+    
+    Ok(())
 }
 
 /// Blocks the current task for a fixed time `period`, which starts from the given `last_resume_time`.
-pub fn sleep_periodic(last_resume_time: &AtomicUsize, period: usize) {
+///
+/// Returns the current task's run state if it can't be blocked.
+pub fn sleep_periodic(last_resume_time: &AtomicUsize, period: usize) -> Result<(), RunState> {
     let new_resume_time = last_resume_time.fetch_add(period, Ordering::SeqCst) + period;
-    sleep_until(new_resume_time);
+    sleep_until(new_resume_time)
 }

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -88,7 +88,7 @@ fn add_to_delayed_tasklist(new_node: SleepingTaskNode) {
 fn remove_next_task_from_delayed_tasklist() {
     let mut delayed_tasklist = DELAYED_TASKLIST.lock();
     if let Some(SleepingTaskNode { taskref, .. }) = delayed_tasklist.pop() {
-        taskref.unblock();
+        let _ = taskref.unblock();
 
         match delayed_tasklist.peek() {
             Some(SleepingTaskNode { resume_time, .. }) => 
@@ -115,7 +115,7 @@ pub fn sleep(duration: usize) {
     let current_task = get_my_current_task().unwrap().clone();
     // Add the current task to the delayed tasklist and then block it.
     add_to_delayed_tasklist(SleepingTaskNode{taskref: current_task.clone(), resume_time});
-    current_task.block();
+    current_task.block().unwrap();
     scheduler::schedule();
 }
 

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -356,9 +356,9 @@ impl<F, A, R> TaskBuilder<F, A, R>
 
         // The new task is ready to be scheduled in, now that its stack trampoline has been set up.
         if self.blocked {
-            new_task.block();
+            new_task.block().unwrap();
         } else {
-            new_task.unblock();
+            new_task.unblock().unwrap();
         }
 
         // The new task is marked as idle

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -356,9 +356,11 @@ impl<F, A, R> TaskBuilder<F, A, R>
 
         // The new task is ready to be scheduled in, now that its stack trampoline has been set up.
         if self.blocked {
-            new_task.block_initing_task().unwrap();
+            new_task.block_initing_task()
+                .map_err(|_| "BUG: newly-spawned blocked task was not in the Initing runstate")?;
         } else {
-            new_task.unblock_initing_task().unwrap();
+            new_task.make_inited_task_runnable()
+                .map_err(|_| "BUG: newly-spawned task was not in the Initing runstate")?;
         }
 
         // The new task is marked as idle

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -356,9 +356,9 @@ impl<F, A, R> TaskBuilder<F, A, R>
 
         // The new task is ready to be scheduled in, now that its stack trampoline has been set up.
         if self.blocked {
-            new_task.block().unwrap();
+            new_task.block_initing_task().unwrap();
         } else {
-            new_task.unblock().unwrap();
+            new_task.unblock_initing_task().unwrap();
         }
 
         // The new task is marked as idle

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -726,6 +726,18 @@ impl Task {
         }
     }
 
+    /// Unblocks this `Task` if it is currently in the initialisation run state.
+    ///
+    /// Returns the previous runstate (i.e. `RunState::Initing`) on success, and
+    /// the current runstate on error.
+    pub fn unblock_initing_task(&self) -> Result<RunState, RunState> {
+        if self.runstate.compare_exchange(RunState::Initing, RunState::Runnable).is_ok() {
+            Ok(RunState::Initing)
+        } else {
+            Err(self.runstate.load())
+        }
+    }
+
     /// Sets this `Task` as this core's current task.
     /// 
     /// Currently this is achieved by writing a pointer to the `TaskLocalData` 

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -694,10 +694,13 @@ impl Task {
         }
     }
 
-    /// Blocks this `Task` if it is currently in the initialisation run state.
+    /// Blocks this `Task` if it is a newly-spawned task currently being initialized.
     ///
-    /// Returns the previous runstate (i.e. `RunState::Initing`) on success, and
-    /// the current runstate on error.
+    /// This is a special case only to be used when spawning a new task that
+    /// should not be immediately scheduled in; it will fail for all other cases.
+    ///
+    /// Returns the previous runstate (i.e. `RunState::Initing`) on success,
+    /// or the current runstate on error.
     pub fn block_initing_task(&self) -> Result<RunState, RunState> {
         if self.runstate.compare_exchange(RunState::Initing, RunState::Blocked).is_ok() {
             Ok(RunState::Initing)

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -726,18 +726,6 @@ impl Task {
         }
     }
 
-    /// Unblocks this `Task` if it is currently in the initialisation run state.
-    ///
-    /// Returns the previous runstate (i.e. `RunState::Initing`) on success, and
-    /// the current runstate on error.
-    pub fn unblock_initing_task(&self) -> Result<RunState, RunState> {
-        if self.runstate.compare_exchange(RunState::Initing, RunState::Runnable).is_ok() {
-            Ok(RunState::Initing)
-        } else {
-            Err(self.runstate.load())
-        }
-    }
-
     /// Sets this `Task` as this core's current task.
     /// 
     /// Currently this is achieved by writing a pointer to the `TaskLocalData` 

--- a/kernel/wait_queue/src/lib.rs
+++ b/kernel/wait_queue/src/lib.rs
@@ -9,7 +9,7 @@ extern crate scheduler;
 
 use alloc::collections::VecDeque;
 use irq_safety::MutexIrqSafe;
-use task::TaskRef;
+use task::{TaskRef, RunState};
 
 
 /// An object that holds a blocked `Task` 
@@ -20,17 +20,23 @@ pub struct WaitGuard {
 impl WaitGuard {
     /// Blocks the given `Task` and returns a new `WaitGuard` object
     /// that will automatically unblock that Task when it is dropped. 
-    pub fn new(task: TaskRef) -> WaitGuard {
-        task.block().unwrap();
-        WaitGuard {
+    ///
+    /// Returns an error if the task cannot be blocked. See [`Task::block`] for
+    ///  more details.
+    pub fn new(task: TaskRef) -> Result<WaitGuard, RunState> {
+        task.block()?;
+        Ok(WaitGuard {
             task,
-        }
+        })
     }
 
     /// Blocks the task guarded by this waitguard,
     /// which is useful to re-block a task after it spuriously woke up. 
-    pub fn block_again(&self) {
-        self.task.block().unwrap();
+    ///
+    /// Returns an error if the task cannot be blocked. See [`Task::block`] for
+    ///  more details.
+    pub fn block_again(&self) -> Result<RunState, RunState> {
+        self.task.block()
     }
 
     /// Returns a reference to the `Task` being blocked in this `WaitGuard`.


### PR DESCRIPTION
Previously, exited tasks could be blocked or unblocked leading to a panic during context switching.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>