### PR TITLE
Removed wildcard imports from memory & paging code

### DIFF
--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -32,9 +32,7 @@ mod paging;
 #[cfg(mapper_spillful)]
 pub mod paging;
 
-pub use self::paging::MappedPages;
-pub use self::paging::PageTable;
-pub use self::paging::Mapper;
+pub use self::paging::{MappedPages, PageTable, Mapper};
 
 pub use memory_structs::{Frame, Page, FrameRange, PageRange, VirtualAddress, PhysicalAddress};
 pub use page_allocator::{AllocatedPages, allocate_pages, allocate_pages_at,

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -33,14 +33,37 @@ mod paging;
 pub mod paging;
 
 
-pub use self::paging::*;
+pub use self::paging::MappedPages;
+pub use self::paging::PageTable;
 
-pub use memory_structs::*;
-pub use page_allocator::*;
-pub use frame_allocator::*;
+pub use memory_structs::Frame;
+pub use memory_structs::Page;
+pub use memory_structs::FrameRange;
+pub use memory_structs::PageRange;
+pub use memory_structs::VirtualAddress;
+pub use memory_structs::PhysicalAddress;
+
+pub use page_allocator::AllocatedPages;
+pub use page_allocator::allocate_pages;
+pub use page_allocator::allocate_pages_by_bytes;
+
+pub use frame_allocator::AllocatedFrames;
+pub use frame_allocator::MemoryRegionType;
+pub use frame_allocator::PhysicalMemoryRegion;
+pub use frame_allocator::allocate_frames_by_bytes;
 
 #[cfg(target_arch = "x86_64")]
-use memory_x86_64::*;
+use memory_x86_64::{
+    BootInformation,
+    get_kernel_address,
+    get_boot_info_mem_area,
+    find_section_memory_bounds,
+    get_vga_mem_addr,
+    get_modules_address,
+    tlb_flush_virt_addr,
+    tlb_flush_all,
+    get_p4,
+};
 
 #[cfg(target_arch = "x86_64")]
 pub use memory_x86_64::EntryFlags;// Export EntryFlags so that others does not need to get access to memory_<arch>.

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -36,38 +36,16 @@ pub use self::paging::MappedPages;
 pub use self::paging::PageTable;
 pub use self::paging::Mapper;
 
-pub use memory_structs::Frame;
-pub use memory_structs::Page;
-pub use memory_structs::FrameRange;
-pub use memory_structs::PageRange;
-pub use memory_structs::VirtualAddress;
-pub use memory_structs::PhysicalAddress;
+pub use memory_structs::{Frame, Page, FrameRange, PageRange, VirtualAddress, PhysicalAddress};
+pub use page_allocator::{AllocatedPages, allocate_pages, allocate_pages_at,
+    allocate_pages_by_bytes, allocate_pages_by_bytes_at};
 
-pub use page_allocator::AllocatedPages;
-pub use page_allocator::allocate_pages;
-pub use page_allocator::allocate_pages_at;
-pub use page_allocator::allocate_pages_by_bytes;
-pub use page_allocator::allocate_pages_by_bytes_at;
-
-pub use frame_allocator::AllocatedFrames;
-pub use frame_allocator::MemoryRegionType;
-pub use frame_allocator::PhysicalMemoryRegion;
-pub use frame_allocator::allocate_frames_by_bytes_at;
-pub use frame_allocator::allocate_frames_by_bytes;
-pub use frame_allocator::allocate_frames_at;
+pub use frame_allocator::{AllocatedFrames, MemoryRegionType, PhysicalMemoryRegion,
+    allocate_frames_by_bytes_at, allocate_frames_by_bytes, allocate_frames_at};
 
 #[cfg(target_arch = "x86_64")]
-use memory_x86_64::{
-    BootInformation,
-    get_kernel_address,
-    get_boot_info_mem_area,
-    find_section_memory_bounds,
-    get_vga_mem_addr,
-    get_modules_address,
-    tlb_flush_virt_addr,
-    tlb_flush_all,
-    get_p4,
-};
+use memory_x86_64::{BootInformation, get_kernel_address, get_boot_info_mem_area, find_section_memory_bounds,
+    get_vga_mem_addr, get_modules_address, tlb_flush_virt_addr, tlb_flush_all, get_p4};
 
 #[cfg(target_arch = "x86_64")]
 pub use memory_x86_64::EntryFlags;// Export EntryFlags so that others does not need to get access to memory_<arch>.

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -32,9 +32,9 @@ mod paging;
 #[cfg(mapper_spillful)]
 pub mod paging;
 
-
 pub use self::paging::MappedPages;
 pub use self::paging::PageTable;
+pub use self::paging::Mapper;
 
 pub use memory_structs::Frame;
 pub use memory_structs::Page;
@@ -45,12 +45,16 @@ pub use memory_structs::PhysicalAddress;
 
 pub use page_allocator::AllocatedPages;
 pub use page_allocator::allocate_pages;
+pub use page_allocator::allocate_pages_at;
 pub use page_allocator::allocate_pages_by_bytes;
+pub use page_allocator::allocate_pages_by_bytes_at;
 
 pub use frame_allocator::AllocatedFrames;
 pub use frame_allocator::MemoryRegionType;
 pub use frame_allocator::PhysicalMemoryRegion;
+pub use frame_allocator::allocate_frames_by_bytes_at;
 pub use frame_allocator::allocate_frames_by_bytes;
+pub use frame_allocator::allocate_frames_at;
 
 #[cfg(target_arch = "x86_64")]
 use memory_x86_64::{

--- a/kernel/memory/src/paging/mod.rs
+++ b/kernel/memory/src/paging/mod.rs
@@ -15,15 +15,34 @@ mod table;
 pub mod table;
 
 
-pub use page_table_entry::*;
+pub use page_table_entry::PageTableEntry;
 pub use self::temporary_page::TemporaryPage;
-pub use self::mapper::*;
+pub use self::mapper::Mapper;
+pub use self::mapper::MappedPages;
 
 use core::{
     ops::{Deref, DerefMut},
     fmt,
 };
-use super::*;
+use super::Frame;
+use super::FrameRange;
+use super::PageRange;
+use super::VirtualAddress;
+use super::PhysicalAddress;
+
+use super::AllocatedPages;
+use super::allocate_pages;
+
+use super::AllocatedFrames;
+
+use super::tlb_flush_all;
+use super::tlb_flush_virt_addr;
+use super::get_p4;
+use super::find_section_memory_bounds;
+use super::get_vga_mem_addr;
+use super::KERNEL_OFFSET;
+
+use super::EntryFlags;
 
 use kernel_config::memory::{RECURSIVE_P4_INDEX};
 // use kernel_config::memory::{KERNEL_TEXT_P4_INDEX, KERNEL_HEAP_P4_INDEX, KERNEL_STACK_P4_INDEX};

--- a/kernel/memory/src/paging/mod.rs
+++ b/kernel/memory/src/paging/mod.rs
@@ -16,9 +16,10 @@ pub mod table;
 
 
 pub use page_table_entry::PageTableEntry;
-pub use self::temporary_page::TemporaryPage;
-pub use self::mapper::Mapper;
-pub use self::mapper::MappedPages;
+pub use self::{
+    temporary_page::TemporaryPage,
+    mapper::{Mapper, MappedPages},
+};
 
 use core::{
     ops::{Deref, DerefMut},

--- a/kernel/memory/src/paging/mod.rs
+++ b/kernel/memory/src/paging/mod.rs
@@ -24,25 +24,10 @@ use core::{
     ops::{Deref, DerefMut},
     fmt,
 };
-use super::Frame;
-use super::FrameRange;
-use super::PageRange;
-use super::VirtualAddress;
-use super::PhysicalAddress;
-
-use super::AllocatedPages;
-use super::allocate_pages;
-
-use super::AllocatedFrames;
-
-use super::tlb_flush_all;
-use super::tlb_flush_virt_addr;
-use super::get_p4;
-use super::find_section_memory_bounds;
-use super::get_vga_mem_addr;
-use super::KERNEL_OFFSET;
-
-use super::EntryFlags;
+use super::{Frame, FrameRange, PageRange, VirtualAddress, PhysicalAddress,
+    AllocatedPages, allocate_pages, AllocatedFrames, EntryFlags,
+    tlb_flush_all, tlb_flush_virt_addr, get_p4, find_section_memory_bounds,
+    get_vga_mem_addr, KERNEL_OFFSET};
 
 use kernel_config::memory::{RECURSIVE_P4_INDEX};
 // use kernel_config::memory::{KERNEL_TEXT_P4_INDEX, KERNEL_HEAP_P4_INDEX, KERNEL_STACK_P4_INDEX};


### PR DESCRIPTION
Tiny PR to make some wildcard imports explicit in the `memory` crate.

Some of these imports were only required by other crates so I initially missed them.