### PR TITLE
PS/2 Overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,6 +1425,7 @@ name = "keycodes_ascii"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "num_enum",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,17 +718,6 @@ name = "dereffer"
 version = "0.1.0"
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,9 @@ dependencies = [
 [[package]]
 name = "mouse_data"
 version = "0.1.0"
+dependencies = [
+ "modular-bitfield",
+]
 
 [[package]]
 name = "mpmc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,6 +1862,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "modular-bitfield"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+dependencies = [
+ "modular-bitfield-impl",
+ "static_assertions",
+]
+
+[[package]]
+name = "modular-bitfield-impl"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2436,7 @@ name = "ps2"
 version = "0.1.0"
 dependencies = [
  "log",
+ "modular-bitfield",
  "port_io",
  "spin 0.9.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,19 +2119,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5adf0198d427ee515335639f275e806ca01acf9f07d7cf14bb36a10532a6169"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
 dependencies = [
- "derivative",
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1def5a3f69d4707d8a040b12785b98029a39e8c610ae685c7f6265669767482"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2437,6 +2436,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "modular-bitfield",
+ "num_enum",
  "port_io",
  "spin 0.9.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,7 @@ dependencies = [
  "keycodes_ascii",
  "log",
  "mpmc",
+ "once_cell",
  "ps2",
  "spin 0.9.0",
  "x86_64",

--- a/kernel/event_types/Cargo.toml
+++ b/kernel/event_types/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "event_types"
 description = "Types of input and output events that flow throughout the system"
 version = "0.1.0"
+edition = "2021"
 
 [dependencies.keycodes_ascii]
 path = "../../libs/keycodes_ascii"

--- a/kernel/event_types/src/lib.rs
+++ b/kernel/event_types/src/lib.rs
@@ -1,13 +1,10 @@
 #![no_std]
 
-extern crate keycodes_ascii;
-extern crate mouse_data;
 extern crate alloc;
-extern crate shapes;
 
+use alloc::string::String;
 use keycodes_ascii::KeyEvent;
 use mouse_data::MouseEvent;
-use alloc::string::String;
 use shapes::{Coord, Rectangle};
 
 /// An event describing mouse position rather than movement differential from last event.
@@ -32,7 +29,7 @@ pub struct MousePositionEvent {
     pub fifth_button_hold: bool,
 }
 
-impl Default for MousePositionEvent  {
+impl Default for MousePositionEvent {
     fn default() -> Self {
         MousePositionEvent {
             coordinate: Coord::new(0, 0),
@@ -57,10 +54,10 @@ pub enum Event {
     OutputEvent(String),
     /// Tells an application that the window manager has resized or moved its window
     /// so that it knows to refresh its display and perform any necessary tasks, such as text reflow.
-    /// 
+    ///
     /// The new position and size of the window is given by the `Rectangle` within,
     /// and represents the content area within the window that is accessible to the application,
-    /// which excludes the window title bar, borders, etc. 
+    /// which excludes the window title bar, borders, etc.
     WindowResizeEvent(Rectangle),
     /// The event tells application about mouse's position currently (including relative to a window and relative to a screen)
     MousePositionEvent(MousePositionEvent),
@@ -74,7 +71,10 @@ impl Event {
     }
 
     /// Create a new output event
-    pub fn new_output_event<S>(s: S) -> Event where S: Into<String> {
+    pub fn new_output_event<S>(s: S) -> Event
+    where
+        S: Into<String>,
+    {
         Event::OutputEvent(s.into())
     }
 
@@ -93,9 +93,7 @@ pub struct KeyboardInputEvent {
 
 impl KeyboardInputEvent {
     /// Create a new key board input event. `key` is the key input from the keyboard
-    pub fn new(key: KeyEvent) -> KeyboardInputEvent {
-        KeyboardInputEvent { 
-            key_event: key 
-        }
+    pub fn new(key_event: KeyEvent) -> KeyboardInputEvent {
+        KeyboardInputEvent { key_event }
     }
 }

--- a/kernel/keyboard/Cargo.toml
+++ b/kernel/keyboard/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "keyboard"
-description = "A keyboard driver for keyboards connected to the legacy PS2 port"
+description = "A basic driver for keyboards connected to the legacy PS2 port"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 spin = "0.9.0"

--- a/kernel/keyboard/Cargo.toml
+++ b/kernel/keyboard/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+authors = ["Kevin Boos <kevinaboos@gmail.com>, Hecatia Elegua"]
 name = "keyboard"
 description = "A basic driver for keyboards connected to the legacy PS2 port"
 version = "0.1.0"

--- a/kernel/keyboard/Cargo.toml
+++ b/kernel/keyboard/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kevin Boos <kevinaboos@gmail.com>, Hecatia Elegua"]
 name = "keyboard"
-description = "A basic driver for keyboards connected to the legacy PS2 port"
+description = "A basic driver for keyboards connected to the legacy PS/2 port"
 version = "0.1.0"
 edition = "2021"
 

--- a/kernel/keyboard/Cargo.toml
+++ b/kernel/keyboard/Cargo.toml
@@ -10,6 +10,7 @@ spin = "0.9.0"
 x86_64 = "0.14.8"
 mpmc = "0.1.6"
 log = "0.4.8"
+once_cell = { version = "1", default-features = false }
 
 [dependencies.keycodes_ascii]
 path = "../../libs/keycodes_ascii"

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -147,15 +147,15 @@ fn handle_keyboard_input(scan_code: u8, extended: bool) -> Result<(), &'static s
         // The "*Lock" keys are toggled only upon being pressed, not when released.
         x if x == Keycode::CapsLock as u8 => {
             modifiers.toggle(KeyboardModifiers::CAPS_LOCK);
-            set_keyboard_led(&modifiers);
+            set_keyboard_led(modifiers);
         }
         x if x == Keycode::ScrollLock as u8 => {
             modifiers.toggle(KeyboardModifiers::SCROLL_LOCK);
-            set_keyboard_led(&modifiers);
+            set_keyboard_led(modifiers);
         }
         x if x == Keycode::NumLock as u8 => {
             modifiers.toggle(KeyboardModifiers::NUM_LOCK);
-            set_keyboard_led(&modifiers);
+            set_keyboard_led(modifiers);
         }
 
         _ => { } // do nothing
@@ -171,7 +171,7 @@ fn handle_keyboard_input(scan_code: u8, extended: bool) -> Result<(), &'static s
     };
 
     if let Some(keycode) = Keycode::from_scancode(adjusted_scan_code) {
-        let event = Event::new_keyboard_event(KeyEvent::new(keycode, action, modifiers.clone()));
+        let event = Event::new_keyboard_event(KeyEvent::new(keycode, action, *modifiers));
         if let Some(producer) = KEYBOARD_PRODUCER.get() {
             producer.push(event).map_err(|_e| "keyboard input queue is full")
         } else {

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -10,7 +10,7 @@ use once_cell::unsync::Lazy;
 use spin::Once;
 use mpmc::Queue;
 use event_types::Event;
-use ps2::{init_ps2_port1, test_ps2_port1, keyboard_detect, KeyboardType, read_scancode, LEDState};
+use ps2::{init_ps2_port1, test_ps2_port1, keyboard_detect, KeyboardType, read_scancode, LEDState, keyboard_scancode_set, ScancodeSet};
 use x86_64::structures::idt::InterruptStackFrame;
 
 /// The first PS2 port for the keyboard is connected directly to IRQ 1.
@@ -44,7 +44,7 @@ pub fn init(keyboard_queue_producer: Queue<Event>) -> Result<(), &'static str> {
         }
     }
 
-    // TODO: set keyboard to scancode set 1, since that's the only one we support (?)
+    keyboard_scancode_set(ScancodeSet::Set2)?;
 
     // Register the interrupt handler
     interrupts::register_interrupt(PS2_KEYBOARD_IRQ, ps2_keyboard_handler).map_err(|e| {

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -60,7 +60,8 @@ pub fn init(keyboard_queue_producer: Queue<Event>) -> Result<(), &'static str> {
 
 /// The interrupt handler for a ps2-connected keyboard, registered at IRQ 0x21.
 extern "x86-interrupt" fn ps2_keyboard_handler(_stack_frame: InterruptStackFrame) {
-    // see this: [How do 0xE0 keyboard scancodes (PS/2) work?](https://forum.osdev.org/viewtopic.php?f=1&t=32655)
+    // Some of the scancodes are "extended", which means they generate two different interrupts,
+    // the first handling the E0 byte, the second handling their second byte.
     static EXTENDED_SCANCODE: AtomicBool = AtomicBool::new(false);
 
     let scan_code = read_scancode();

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -45,7 +45,8 @@ pub fn init(keyboard_queue_producer: Queue<Event>) -> Result<(), &'static str> {
         }
     }
 
-    keyboard_scancode_set(ScancodeSet::Set2)?;
+    // TODO: figure out what we should do
+    // keyboard_scancode_set(ScancodeSet::Set2)?;
 
     // Register the interrupt handler
     interrupts::register_interrupt(PS2_KEYBOARD_IRQ, ps2_keyboard_handler).map_err(|e| {

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -84,8 +84,9 @@ extern "x86-interrupt" fn ps2_keyboard_handler(_stack_frame: InterruptStackFrame
         if extended {
             EXTENDED_SCANCODE.store(false, Ordering::SeqCst);
         }
-        // a scan code of zero is a PS2_PORT error that we can ignore
-        if scan_code != 0 {
+        // a scan code of zero is a PS2_PORT error that we can ignore,
+        // a scan code of 0xFA is a command ACK response, already handled in polling (when sending a command, see ps2 crate)
+        if scan_code != 0 && scan_code != 0xFA {
             if let Err(e) = handle_keyboard_input(scan_code, extended) {
                 error!("ps2_keyboard_handler: error handling PS2_PORT input: {e:?}");
             }

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -10,7 +10,7 @@ use once_cell::unsync::Lazy;
 use spin::Once;
 use mpmc::Queue;
 use event_types::Event;
-use ps2::{init_ps2_port1, test_ps2_port1, keyboard_detect, KeyboardType, read_scancode, LEDState, keyboard_scancode_set, ScancodeSet};
+use ps2::{init_ps2_port1, test_ps2_port1, keyboard_detect, KeyboardType, read_scancode, LEDState};
 use x86_64::structures::idt::InterruptStackFrame;
 
 /// The first PS/2 port for the keyboard is connected directly to IRQ 1.

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -9,7 +9,7 @@ use log::{info, error, warn};
 use spin::Once;
 use mpmc::Queue;
 use event_types::Event;
-use ps2::{init_ps2_port1, test_ps2_port1, keyboard_led, keyboard_detect, KeyboardType, read_scancode, ps2_status_register};
+use ps2::{init_ps2_port1, test_ps2_port1, keyboard_led, keyboard_detect, KeyboardType, read_scancode};
 use x86_64::structures::idt::InterruptStackFrame;
 
 /// The first PS2 port for the keyboard is connected directly to IRQ 1.

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -9,7 +9,7 @@ use log::{info, error, warn};
 use spin::Once;
 use mpmc::Queue;
 use event_types::Event;
-use ps2::{init_ps2_port1, test_ps2_port1, keyboard_led, keyboard_detect, KeyboardType, read_scancode, LEDState};
+use ps2::{init_ps2_port1, test_ps2_port1, keyboard_detect, KeyboardType, read_scancode, LEDState};
 use x86_64::structures::idt::InterruptStackFrame;
 
 /// The first PS2 port for the keyboard is connected directly to IRQ 1.
@@ -169,10 +169,12 @@ fn handle_keyboard_input(scan_code: u8, extended: bool) -> Result<(), &'static s
 
 
 fn set_keyboard_led(modifiers: &KeyboardModifiers) {
-    keyboard_led(
+    if let Err(e) = ps2::set_keyboard_led(
         LEDState::new()
             .with_scroll_lock(modifiers.is_scroll_lock())
             .with_number_lock(modifiers.is_num_lock())
             .with_caps_lock(modifiers.is_caps_lock()),
-    );
+    ) {
+        error!("{e}");
+    }
 }

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -38,8 +38,7 @@ pub fn init(keyboard_queue_producer: Queue<Event>) -> Result<(), &'static str> {
     // Init the first ps2 port, which is used for the keyboard.
     init_ps2_port1();
     // Test the first port.
-    // TODO: return an error if this test fails.
-    test_ps2_port1();
+    test_ps2_port1()?;
     // Detect which kind of keyboard is connected.
     // TODO: actually do something with the keyboard type.
     match keyboard_detect() {

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -3,10 +3,9 @@
 #![no_std]
 #![feature(abi_x86_interrupt)]
 
-#[macro_use] extern crate log;
-
 use core::sync::atomic::{AtomicBool, Ordering};
 use keycodes_ascii::{Keycode, KeyboardModifiers, KEY_RELEASED_OFFSET, KeyAction, KeyEvent};
+use log::{info, error, warn};
 use spin::Once;
 use mpmc::Queue;
 use event_types::Event;

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -9,7 +9,7 @@ use log::{info, error, warn};
 use spin::Once;
 use mpmc::Queue;
 use event_types::Event;
-use ps2::{init_ps2_port1, test_ps2_port1, keyboard_led, keyboard_detect, KeyboardType};
+use ps2::{init_ps2_port1, test_ps2_port1, keyboard_led, keyboard_detect, KeyboardType, ps2_read_data, ps2_status_register};
 use x86_64::structures::idt::InterruptStackFrame;
 
 /// The first PS2 port for the keyboard is connected directly to IRQ 1.
@@ -72,14 +72,14 @@ extern "x86-interrupt" fn ps2_keyboard_handler(_stack_frame: InterruptStackFrame
     // see this: https://forum.osdev.org/viewtopic.php?f=1&t=32655
     static EXTENDED_SCANCODE: AtomicBool = AtomicBool::new(false);
 
-    let indicator = ps2::ps2_status_register();
+    let indicator = ps2_status_register();
 
     // whether there is any data on the port 0x60
     if indicator & 0x01 == 0x01 {
         // Skip this if the PS2 event came from the mouse, not the keyboard
         if indicator & 0x20 != 0x20 {
             // in this interrupt, we must read the PS2_PORT scancode register before acknowledging the interrupt.
-            let scan_code = ps2::ps2_read_data();
+            let scan_code = ps2_read_data();
             // trace!("PS2_PORT interrupt: raw scan_code {:#X}", scan_code);
 
 

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -9,7 +9,7 @@ use log::{info, error, warn};
 use spin::Once;
 use mpmc::Queue;
 use event_types::Event;
-use ps2::{init_ps2_port1, test_ps2_port1, keyboard_led, keyboard_detect, KeyboardType, ps2_read_data, ps2_status_register};
+use ps2::{init_ps2_port1, test_ps2_port1, keyboard_led, keyboard_detect, KeyboardType, read_scancode, ps2_status_register};
 use x86_64::structures::idt::InterruptStackFrame;
 
 /// The first PS2 port for the keyboard is connected directly to IRQ 1.
@@ -79,7 +79,7 @@ extern "x86-interrupt" fn ps2_keyboard_handler(_stack_frame: InterruptStackFrame
         // Skip this if the PS2 event came from the mouse, not the keyboard
         if indicator & 0x20 != 0x20 {
             // in this interrupt, we must read the PS2_PORT scancode register before acknowledging the interrupt.
-            let scan_code = ps2_read_data();
+            let scan_code = read_scancode();
             // trace!("PS2_PORT interrupt: raw scan_code {:#X}", scan_code);
 
 

--- a/kernel/mouse/Cargo.toml
+++ b/kernel/mouse/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Bowen Liu <liubowenbob@hotmail.com>", "Kevin Boos <kevinaboos@gmail.com>"]
+authors = ["Bowen Liu <liubowenbob@hotmail.com>", "Kevin Boos <kevinaboos@gmail.com>", "Hecatia Elegua"]
 name = "mouse"
 description = "A basic driver for a mouse connected to the legacy PS2 port"
 version = "0.1.0"

--- a/kernel/mouse/Cargo.toml
+++ b/kernel/mouse/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Bowen Liu <liubowenbob@hotmail.com>", "Kevin Boos <kevinaboos@gmail.com>", "Hecatia Elegua"]
 name = "mouse"
-description = "A basic driver for a mouse connected to the legacy PS2 port"
+description = "A basic driver for a mouse connected to the legacy PS/2 port"
 version = "0.1.0"
 edition = "2021"
 

--- a/kernel/mouse/Cargo.toml
+++ b/kernel/mouse/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 authors = ["Bowen Liu <liubowenbob@hotmail.com>", "Kevin Boos <kevinaboos@gmail.com>"]
 name = "mouse"
-description = "A keyboard driver for keyboards connected to the legacy PS2 port"
+description = "A basic driver for a mouse connected to the legacy PS2 port"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 spin = "0.9.0"

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -59,7 +59,9 @@ extern "x86-interrupt" fn ps2_mouse_handler(_stack_frame: InterruptStackFrame) {
     if mouse_packet.x_overflow() || mouse_packet.y_overflow() {
         error!("The overflow bits in the mouse data packet's first byte are set! Discarding the whole packet.");
     } else if mouse_packet.always_one() != 1 {
-        // it's very likely that the PS/2 controller send us an [interrupt](https://wiki.osdev.org/%228042%22_PS/2_Controller#Interrupts)
+        // it's very likely that the PS/2 controller send us an [interrupt](https://wiki.osdev.org/%228042%22_PS/2_Controller#Interrupts),
+        // if it did, the whole 32 bits of the mouse_packet are zero (at least on my end)
+        // checking the ps/2 controller status register's mouse_output_buffer_full might work, but this current solution does also work
         // error!("Third bit in the mouse data packet's first byte should always be 1. Discarding the whole packet since the bit is 0.");
     } else {
         let _mouse_event = handle_mouse_input(mouse_packet);

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -9,7 +9,7 @@ use mpmc::Queue;
 use event_types::Event;
 use x86_64::structures::idt::InterruptStackFrame;
 use mouse_data::{ButtonAction, MouseEvent, MouseMovementRelative};
-use ps2::{check_mouse_id, init_ps2_port2, set_mouse_id, test_ps2_port2, read_mouse_packet, MousePacketBits4};
+use ps2::{check_mouse_id, init_ps2_port2, set_mouse_id, test_ps2_port2, read_mouse_packet, MousePacketBits4, MouseId};
 
 /// The first PS2 port for the mouse is connected directly to IRQ 0xC.
 /// Because we perform the typical PIC remapping, the remapped IRQ vector number is 0x2C.
@@ -29,11 +29,13 @@ pub fn init(mouse_queue_producer: Queue<Event>) -> Result<(), &'static str> {
     test_ps2_port2()?;
 
     // Set Mouse ID to 4, and read it back to check that it worked.
-    let _e = set_mouse_id(4);
+    if let Err(e) = set_mouse_id(MouseId::Four) {
+        error!("{e}");
+    }
     match check_mouse_id() {
         Ok(id) => info!("the initial mouse ID is: {}", id),
-        Err(_e) => {
-            error!("Failed to read the initial PS2 mouse ID, error: {:?}", _e);
+        Err(e) => {
+            error!("Failed to read the initial PS2 mouse ID, error: {:?}", e);
             return Err("Failed to read the initial PS2 mouse ID");
         }
     }

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -28,10 +28,13 @@ pub fn init(mouse_queue_producer: Queue<Event>) -> Result<(), &'static str> {
     // Test the second port.
     test_ps2_port2()?;
 
-    // Set Mouse ID to 4, and read it back to check that it worked.
+    //TODO: set to 3, failed? id = 0, otherwise set to 4, failed? id = 3, otheriwse id = 4
+    // Set Mouse ID to 4.
     if let Err(e) = set_mouse_id(MouseId::Four) {
         error!("Failed to set the mouse id to four: {e}");
+        return Err("Failed to set the mouse id to four");
     }
+    // Read it back to check that it worked.
     match mouse_id() {
         Ok(id) => debug!("The PS/2 mouse ID is: {id}"),
         Err(e) => {

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -3,8 +3,7 @@
 #![no_std]
 #![feature(abi_x86_interrupt)]
 
-#[macro_use] extern crate log;
-
+use log::{info, error, warn};
 use spin::Once;
 use mpmc::Queue;
 use event_types::Event;
@@ -134,7 +133,6 @@ extern "x86-interrupt" fn ps2_mouse_handler(_stack_frame: InterruptStackFrame) {
                 error!("Third bit should in the mouse data packet's first byte should be always be 1. Discarding the whole packet since the bit is 0 now.");
             } else {
                 let _mouse_event = handle_mouse_input(readdata);
-                // mouse_to_print(&_mouse_event);
             }
         }
     }
@@ -154,7 +152,6 @@ fn handle_mouse_input(readdata: u32) -> Result<(), &'static str> {
     dis.read_from_data(readdata);
 
     let mouse_event = MouseEvent::new(*action, *mmove, *dis);
-    // mouse_to_print(&mouse_event);  // use this to debug
     let event = Event::MouseMovementEvent(mouse_event);
 
     if let Some(producer) = MOUSE_PRODUCER.get() {

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -28,7 +28,8 @@ pub fn init(mouse_queue_producer: Queue<Event>) -> Result<(), &'static str> {
     // Test the second port.
     test_ps2_port2()?;
 
-    //TODO: set to 3, failed? id = 0, otherwise set to 4, failed? id = 3, otheriwse id = 4
+    //TODO: set to 3, failed? id = 0, otherwise set to 4, failed? id = 3, otherwise id = 4
+    //the current code beneath just tries to set id = 4, so is not final
     // Set Mouse ID to 4.
     if let Err(e) = set_mouse_id(MouseId::Four) {
         error!("Failed to set the mouse id to four: {e}");
@@ -36,7 +37,13 @@ pub fn init(mouse_queue_producer: Queue<Event>) -> Result<(), &'static str> {
     }
     // Read it back to check that it worked.
     match mouse_id() {
-        Ok(id) => debug!("The PS/2 mouse ID is: {id}"),
+        Ok(id) =>  {
+            debug!("The PS/2 mouse ID is: {id:?}");
+            if !matches!(id, MouseId::Four) {
+                error!("Failed to set the mouse id to four");
+                return Err("Failed to set the mouse id to four");
+            }
+        }
         Err(e) => {
             error!("Failed to read the PS/2 mouse ID: {e}");
             return Err("Failed to read the PS/2 mouse ID");

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -119,22 +119,13 @@ fn mouse_to_print(mouse_event: &MouseEvent) {
 
 /// The interrupt handler for a ps2-connected mouse, registered at IRQ 0x2C.
 extern "x86-interrupt" fn ps2_mouse_handler(_stack_frame: InterruptStackFrame) {
-
-    let indicator = ps2::ps2_status_register();
-
-    // whether there is any data on the port 0x60
-    if indicator & 0x01 == 0x01 {
-        //whether the data is coming from the mouse
-        if indicator & 0x20 == 0x20 {
-            let readdata = handle_mouse_packet();
-            if (readdata & 0x80 == 0x80) || (readdata & 0x40 == 0x40) {
-                error!("The overflow bits in the mouse data packet's first byte are set! Discarding the whole packet.");
-            } else if readdata & 0x08 == 0 {
-                error!("Third bit should in the mouse data packet's first byte should be always be 1. Discarding the whole packet since the bit is 0 now.");
-            } else {
-                let _mouse_event = handle_mouse_input(readdata);
-            }
-        }
+    let readdata = handle_mouse_packet();
+    if (readdata & 0x80 == 0x80) || (readdata & 0x40 == 0x40) {
+        error!("The overflow bits in the mouse data packet's first byte are set! Discarding the whole packet.");
+    } else if readdata & 0x08 == 0 {
+        error!("Third bit should in the mouse data packet's first byte should be always be 1. Discarding the whole packet since the bit is 0 now.");
+    } else {
+        let _mouse_event = handle_mouse_input(readdata);
     }
 
     interrupts::eoi(Some(PS2_MOUSE_IRQ));

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -9,7 +9,7 @@ use mpmc::Queue;
 use event_types::Event;
 use x86_64::structures::idt::InterruptStackFrame;
 use mouse_data::{ButtonAction, Displacement, MouseEvent, MouseMovement};
-use ps2::{check_mouse_id, init_ps2_port2, set_mouse_id, test_ps2_port2};
+use ps2::{check_mouse_id, init_ps2_port2, set_mouse_id, test_ps2_port2, handle_mouse_packet};
 
 /// The first PS2 port for the mouse is connected directly to IRQ 0xC.
 /// Because we perform the typical PIC remapping, the remapped IRQ vector number is 0x2C.
@@ -126,7 +126,7 @@ extern "x86-interrupt" fn ps2_mouse_handler(_stack_frame: InterruptStackFrame) {
     if indicator & 0x01 == 0x01 {
         //whether the data is coming from the mouse
         if indicator & 0x20 == 0x20 {
-            let readdata = ps2::handle_mouse_packet();
+            let readdata = handle_mouse_packet();
             if (readdata & 0x80 == 0x80) || (readdata & 0x40 == 0x40) {
                 error!("The overflow bits in the mouse data packet's first byte are set! Discarding the whole packet.");
             } else if readdata & 0x08 == 0 {

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -9,7 +9,7 @@ use mpmc::Queue;
 use event_types::Event;
 use x86_64::structures::idt::InterruptStackFrame;
 use mouse_data::{ButtonAction, MouseEvent, MouseMovementRelative};
-use ps2::{check_mouse_id, init_ps2_port2, set_mouse_id, test_ps2_port2, read_mouse_packet, MousePacketBits4, MouseId};
+use ps2::{mouse_id, init_ps2_port2, set_mouse_id, test_ps2_port2, read_mouse_packet, MousePacketBits4, MouseId};
 
 /// The first PS2 port for the mouse is connected directly to IRQ 0xC.
 /// Because we perform the typical PIC remapping, the remapped IRQ vector number is 0x2C.
@@ -32,7 +32,7 @@ pub fn init(mouse_queue_producer: Queue<Event>) -> Result<(), &'static str> {
     if let Err(e) = set_mouse_id(MouseId::Four) {
         error!("{e}");
     }
-    match check_mouse_id() {
+    match mouse_id() {
         Ok(id) => info!("the initial mouse ID is: {}", id),
         Err(e) => {
             error!("Failed to read the initial PS2 mouse ID, error: {:?}", e);

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -1,4 +1,4 @@
-//! A basic driver for a mouse connected to the legacy PS2 port.
+//! A basic driver for a mouse connected to the legacy PS/2 port.
 
 #![no_std]
 #![feature(abi_x86_interrupt)]
@@ -11,19 +11,19 @@ use x86_64::structures::idt::InterruptStackFrame;
 use mouse_data::{ButtonAction, MouseEvent, MouseMovementRelative};
 use ps2::{mouse_id, init_ps2_port2, set_mouse_id, test_ps2_port2, read_mouse_packet, MousePacketBits4, MouseId};
 
-/// The first PS2 port for the mouse is connected directly to IRQ 0xC.
+/// The first PS/2 port for the mouse is connected directly to IRQ 0xC.
 /// Because we perform the typical PIC remapping, the remapped IRQ vector number is 0x2C.
 const PS2_MOUSE_IRQ: u8 = interrupts::IRQ_BASE_OFFSET + 0xC;
 
 static MOUSE_PRODUCER: Once<Queue<Event>> = Once::new();
 
-/// Initialize the PS2 mouse driver and register its interrupt handler.
+/// Initialize the PS/2 mouse driver and register its interrupt handler.
 /// 
 /// ## Arguments
 /// * `mouse_queue_producer`: the queue onto which the mouse interrupt handler
 ///    will push new mouse events when a mouse action occurs.
 pub fn init(mouse_queue_producer: Queue<Event>) -> Result<(), &'static str> {
-    // Init the second ps2 port, which is used for the mouse.
+    // Init the second PS/2 port, which is used for the mouse.
     init_ps2_port2();
     // Test the second port.
     test_ps2_port2()?;
@@ -51,7 +51,7 @@ pub fn init(mouse_queue_producer: Queue<Event>) -> Result<(), &'static str> {
     Ok(())
 }
 
-/// The interrupt handler for a ps2-connected mouse, registered at IRQ 0x2C.
+/// The interrupt handler for a PS/2-connected mouse, registered at IRQ 0x2C.
 extern "x86-interrupt" fn ps2_mouse_handler(_stack_frame: InterruptStackFrame) {
     let mouse_packet = read_mouse_packet();
     if mouse_packet.x_overflow() || mouse_packet.y_overflow() {

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -127,12 +127,12 @@ impl From<&MousePacket> for Movement {
 struct Buttons(MouseButtons);
 impl From<&MousePacket> for Buttons {
     fn from(mouse_packet: &MousePacket) -> Self {
-        Self(MouseButtons::new(
-            mouse_packet.button_left(),
-            mouse_packet.button_right(),
-            mouse_packet.button_middle(),
-            mouse_packet.button_4(),
-            mouse_packet.button_5(),
-        ))
+        Self(MouseButtons::new()
+            .with_left(mouse_packet.button_left())
+            .with_right(mouse_packet.button_right())
+            .with_middle(mouse_packet.button_middle())
+            .with_fourth(mouse_packet.button_4())
+            .with_fifth(mouse_packet.button_5())
+        )
     }
 }

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -30,8 +30,7 @@ pub fn init(mouse_queue_producer: Queue<Event>) -> Result<(), &'static str> {
     // Init the second ps2 port, which is used for the mouse.
     init_ps2_port2();
     // Test the second port.
-    // TODO: return an error if this test fails.
-    test_ps2_port2();
+    test_ps2_port2()?;
 
     // Set Mouse ID to 4, and read it back to check that it worked.
     let _e = set_mouse_id(4);

--- a/kernel/ps2/Cargo.toml
+++ b/kernel/ps2/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 spin = "0.9.0"
+modular-bitfield = "0.11.2"
 
 [dependencies.log]
 version = "0.4.8"

--- a/kernel/ps2/Cargo.toml
+++ b/kernel/ps2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ps2"
 version = "0.1.0"
 description = "Drivers supporting the PS/2 interface, for legacy keyboard/mouse devices"
-authors = ["Bowen Liu <liubowenbob@hotmail.com>"]
+authors = ["Bowen Liu <liubowenbob@hotmail.com>, Hecatia Elegua"]
 edition = "2021"
 
 [dependencies]

--- a/kernel/ps2/Cargo.toml
+++ b/kernel/ps2/Cargo.toml
@@ -3,6 +3,7 @@ name = "ps2"
 version = "0.1.0"
 description = "Drivers supporting the PS/2 interface, for legacy keyboard/mouse devices"
 authors = ["Bowen Liu <liubowenbob@hotmail.com>"]
+edition = "2021"
 
 [dependencies]
 spin = "0.9.0"

--- a/kernel/ps2/Cargo.toml
+++ b/kernel/ps2/Cargo.toml
@@ -9,6 +9,10 @@ edition = "2021"
 spin = "0.9.0"
 modular-bitfield = "0.11.2"
 
+[dependencies.num_enum]
+version = "0.5.7"
+default-features = false
+
 [dependencies.log]
 version = "0.4.8"
 

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -17,48 +17,93 @@ static PS2_DATA_PORT: Mutex<Port<u8>> = Mutex::new(Port::new(0x60));
 static PS2_COMMAND_AND_STATUS_PORT: Mutex<Port<u8>> = Mutex::new(Port::new(0x64));
 
 // https://wiki.osdev.org/%228042%22_PS/2_Controller#PS.2F2_Controller_Commands
+// quite a few of these are commented out because they're either unused, deprecated or non-standard.
 /// Command types which can be sent to the PS/2 Controller
+/// 
+/// Naming perspective: Output means "out of the device into the host".
+/// e.g. [WriteByteToPort2InputBuffer] means "write byte out of the host into port 2"
 enum HostToControllerCommand {
     /// returns [ControllerConfigurationByte]
     ReadFromInternalRAMByte0 = 0x20,
-    // ReadFromInternalRAMByteN = 0x21, //0x21-0x3F; N is the command byte & 0x1F; return Unknown/non-standard
+    
+    // return is non-standard
+    // /// 0x21-0x3F; N is the command byte & 0x1F
+    // ReadFromInternalRAMByteN = 0x21,
+
     /// sets [ControllerConfigurationByte]
     WriteToInternalRAMByte0 = 0x60,
-    // WriteToInternalRAMByteN = 0x61, //0x61-0x7F; N is the command byte & 0x1F
+
+    // usage is non-standard
+    // /// 0x61-0x7F; N is the command byte & 0x1F
+    // WriteToInternalRAMByteN = 0x61,
+
+    // these are all deprecated 
     // PasswordInstalledTest = 0xA4,
     // LoadSecurity = 0xA5,
     // EnableSecurity = 0xA6,
+    
     /// sets [ControllerConfigurationByte] `port2_clock_disabled`
-    DisablePort2 = 0xA7, //NOTE: only if 2 PS/2 ports supported
+    /// 
+    /// Note: only if 2 PS/2 ports supported
+    DisablePort2 = 0xA7,
     /// clears [ControllerConfigurationByte] `port2_clock_disabled`
-    EnablePort2 = 0xA8,  //NOTE: only if 2 PS/2 ports supported
+    /// 
+    /// Note: only if 2 PS/2 ports supported
+    EnablePort2 = 0xA8,
     /// returns [PortTestResult]
-    TestPort2 = 0xA9, //NOTE: only if 2 PS/2 ports supported
+    /// 
+    /// Note: only if 2 PS/2 ports supported
+    TestPort2 = 0xA9,
     /// returns [ControllerTestResult]
     TestController = 0xAA,
     /// returns [PortTestResult]
     TestPort1 = 0xAB,
-    ///// read all bytes of internal RAM
+
+    // unused
+    // /// read all bytes of internal RAM
     // DiagnosticDump = 0xAC,
+
     /// sets [ControllerConfigurationByte] `port1_clock_disabled`
     DisablePort1 = 0xAD,
     /// clears [ControllerConfigurationByte] `port1_clock_disabled`
     EnablePort1 = 0xAE,
-    // ReadControllerInputPort = 0xC0, //return Unknown/non-standard
+
+    // return is non-standard
+    // ReadControllerInputPort = 0xC0,
+
+    // both unused
     // CopyBits0to3ofInputPortToStatusBits4to7 = 0xC1,
     // CopyBits4to7ofInputPortToStatusBits4to7 = 0xC2,
-    ///// returns [ControllerOutputPort] (not implemented, https://wiki.osdev.org/%228042%22_PS/2_Controller#PS.2F2_Controller_Output_Port)
+
+    // both unused and therefore not implemented, https://wiki.osdev.org/%228042%22_PS/2_Controller#PS.2F2_Controller_Output_Port
+    // /// returns [ControllerOutputPort]
     // ReadControllerOutputPort = 0xD0,
-    ///// reads [ControllerOutputPort] (not implemented, https://wiki.osdev.org/%228042%22_PS/2_Controller#PS.2F2_Controller_Output_Port)
-    // WriteByteToControllerOutputPort = 0xD1, //Check if output buffer is empty first
-    ///// makes it look like the byte written was received from the first PS/2 port
-    // WriteByteToPort1OutputBuffer = 0xD2, //NOTE: only if 2 PS/2 ports supported
-    ///// makes it look like the byte written was received from the second PS/2 port
-    // WriteByteToPort2OutputBuffer = 0xD3, //NOTE: only if 2 PS/2 ports supported //https://wiki.osdev.org/%228042%22_PS/2_Controller#Buffer_Naming_Perspective OUTPUT means "out of the device into host"
+    // /// sets [ControllerOutputPort]
+    // ///
+    // /// Note: Check if the output buffer is empty first
+    // WriteByteToControllerOutputPort = 0xD1,
+
+    // both unused
+    // /// makes it look like the byte written was received from the first PS/2 port
+    // /// 
+    // /// Note: only if 2 PS/2 ports supported
+    // WriteByteToPort1OutputBuffer = 0xD2,
+    // /// makes it look like the byte written was received from the second PS/2 port
+    // /// 
+    // /// Note: only if 2 PS/2 ports supported
+    // WriteByteToPort2OutputBuffer = 0xD3,
+
     /// sends next byte to the second PS/2 port
-    WriteByteToPort2InputBuffer = 0xD4, //NOTE: only if 2 PS/2 ports supported
+    /// 
+    /// Note: only if 2 PS/2 ports supported
+    WriteByteToPort2InputBuffer = 0xD4,
+
+    // both unused
     // ReadTestInputs = 0xE0,
-    // PulseOutputLineLowFor6ms = 0xF0, //0xF0-0xFF; Bits 0 to 3 correspond to 4 different output lines and are used as a mask (0 = pulse line, 1 = don't pulse line); Bit 0 corresponds to the "reset" line. The other output lines don't have a standard/defined purpose.
+    // /// 0xF0-0xFF; Bits 0 to 3 correspond to 4 different output lines and are used as a mask:
+    // /// 0 = pulse line, 1 = don't pulse line; Bit 0 corresponds to the "reset" line.
+    // /// The other output lines don't have a standard/defined purpose.
+    // PulseOutputLineLowFor6ms = 0xF0,
 }
 
 /// Write a command to the PS/2 command port/register

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -524,17 +524,10 @@ pub enum SampleRate {
 
 /// set ps2 mouse's sampling rate
 fn set_mouse_sampling_rate(value: SampleRate) -> Result<(), &'static str> {
-    // if command is not acknowledged
-    if let Err(_e) = command_to_mouse(HostToMouseCommandOrData::MouseCommand(SampleRate)) {
-        Err("set mouse sampling rate failled, please try again")
-    } else {
-        // if second byte command is not acknowledged
-        if let Err(_e) = command_to_mouse(HostToMouseCommandOrData::SampleRate(value)) {
-            Err("set mouse sampling rate failled, please try again")
-        } else {
-            Ok(())
-        }
-    }
+    command_to_mouse(HostToMouseCommandOrData::MouseCommand(SampleRate))
+        .and(command_to_mouse(HostToMouseCommandOrData::SampleRate(value)))
+        .map_err(|_| "could not set mouse sampling rate")
+    
 }
 
 pub enum MouseId {

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -600,12 +600,8 @@ fn reset_mouse() -> Result<(), &'static str> {
 
 /// resend the most recent packet again
 fn mouse_resend() -> Result<(), &'static str> {
-    if let Err(_e) = command_to_mouse(HostToMouseCommandOrData::MouseCommand(HostToMouseCommand::ResendByte)) {
-        Err("mouse resend request failled, please request again")
-    } else {
-        // mouse resend request succeeded
-        Ok(())
-    }
+    command_to_mouse(HostToMouseCommandOrData::MouseCommand(HostToMouseCommand::ResendByte))
+        .map_err(|_| "mouse resend request failed, please request again")
 }
 
 /// enable the packet streaming

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -175,27 +175,22 @@ enum WritableData {
     HostToDevice(HostToDevice)
 }
 
-// NOTE: could also use a macro / reminds me of serde
 impl From<WritableData> for u8 {
     fn from(value: WritableData) -> Self {
+        use HostToKeyboardCommandOrData::*;
+        use HostToMouseCommandOrData::*;
         match value {
-            WritableData::Configuration(value) => value.into_bytes()[0],
-            WritableData::HostToDevice(value) => {
-                match value {
-                    HostToDevice::Keyboard(value) => {
-                        match value {
-                            HostToKeyboardCommandOrData::KeyboardCommand(c) => c as u8,
-                            HostToKeyboardCommandOrData::LEDState(l) => l.into_bytes()[0],
-                            HostToKeyboardCommandOrData::ScancodeSet(s) => s as u8,
+            WritableData::Configuration(value) => u8::from_ne_bytes(value.into_bytes()),
+            WritableData::HostToDevice(value) => match value {
+                HostToDevice::Keyboard(value) => match value {
+                    KeyboardCommand(c) => c as u8,
+                    LEDState(l) => u8::from_ne_bytes(l.into_bytes()),
+                    ScancodeSet(s) => s as u8,
                         }
-                    }
-                    HostToDevice::Mouse(value) => {
-                        match value {
-                            HostToMouseCommandOrData::MouseCommand(c) => c as u8,
-                            HostToMouseCommandOrData::MouseResolution(r) => r as u8,
-                            HostToMouseCommandOrData::SampleRate(s) => s as u8,
-                        }
-                    }
+                HostToDevice::Mouse(value) => match value {
+                    MouseCommand(c) => c as u8,
+                    MouseResolution(r) => r as u8,
+                    SampleRate(s) => s as u8,
                 }
             }
         }

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -74,9 +74,14 @@ pub fn ps2_status_register() -> u8 {
     PS2_COMMAND_AND_STATUS_PORT.lock().read()
 }
 
-/// read dat from ps2 data port (0x60)
+/// Read data from the PS/2 data port
 pub fn ps2_read_data() -> u8 {
     PS2_DATA_PORT.lock().read()
+}
+
+/// Write data to the PS/2 data port
+fn ps2_write_data(value: u8) {
+    unsafe { PS2_DATA_PORT.lock().write(value) };
 }
 
 /// read the config of the ps2 port
@@ -88,7 +93,7 @@ fn ps2_read_config() -> u8 {
 /// write the new config to the ps2 command port (0x64)
 fn ps2_write_config(value: u8) {
     ps2_write_command(WriteToInternalRAMByte0);
-    unsafe { PS2_DATA_PORT.lock().write(value) };
+    ps2_write_data(value);
 }
 
 /// initialize the first ps2 data port
@@ -195,7 +200,7 @@ fn test_ps2_port(port: PS2Port) {
 
 /// write data to the first ps2 data port and return the response
 fn data_to_port1(value: u8) -> u8 {
-    unsafe { PS2_DATA_PORT.lock().write(value) };
+    ps2_write_data(value);
     ps2_read_data()
 }
 
@@ -256,7 +261,7 @@ fn command_to_mouse(value: u8) -> Result<(), &'static str> {
 /// write data to the second ps2 output buffer
 fn write_to_second_output_buffer(value: u8) {
     ps2_write_command(WriteByteToPort2OutputBuffer);
-    unsafe { PS2_DATA_PORT.lock().write(value) };
+    ps2_write_data(value);
 }
 
 /// read mouse data packet; will work for mouse with ID 3 or 4

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -189,24 +189,24 @@ pub struct ControllerConfigurationByte {
     must_be_zero: u1,
 }
 
-/// read the config of the ps2 port
+/// read the config of the PS/2 port
 fn read_config() -> ControllerConfigurationByte {
     write_command(ReadFromInternalRAMByte0);
     ControllerConfigurationByte::from_bytes([read_data()])
 }
 
-/// write the new config to the ps2 command port (0x64)
+/// write the new config to the PS/2 command port (0x64)
 fn write_config(value: ControllerConfigurationByte) {
     write_command(WriteToInternalRAMByte0);
     write_data(WritableData::Configuration(value));
 }
 
-/// initialize the first ps2 data port
+/// initialize the first PS/2 data port
 pub fn init_ps2_port1() {
     init_ps2_port(PS2Port::One);
 }
 
-/// initialize the second ps2 data port
+/// initialize the second PS/2 data port
 pub fn init_ps2_port2() {
     init_ps2_port(PS2Port::Two);
 }
@@ -252,26 +252,26 @@ fn flush_output_buffer() {
     debug!("ps2::flush_output_buffer: {}", read_data());
 }
 
-/// test the first ps2 data port
+/// test the first PS/2 data port
 pub fn test_ps2_port1() -> Result<(), &'static str> {
     test_ps2_port(PS2Port::One)
 }
 
-// test the second ps2 data port
+// test the second PS/2 data port
 pub fn test_ps2_port2() -> Result<(), &'static str> {
     test_ps2_port(PS2Port::Two)
 }
 
 // see https://wiki.osdev.org/%228042%22_PS/2_Controller#Initialising_the_PS.2F2_Controller
 fn test_ps2_port(port: PS2Port) -> Result<(), &'static str> {
-    // test the ps2 controller
+    // test the PS/2 controller
     write_command(TestController);
     match read_controller_test_result()? {
         ControllerTestResult::Passed => debug!("passed PS/2 controller test"),
         ControllerTestResult::Failed => Err("failed PS/2 controller test")?,
     }
 
-    // test the ps2 data port
+    // test the PS/2 data port
     match port {
         PS2Port::One => write_command(TestPort1),
         PS2Port::Two => write_command(TestPort2),
@@ -285,7 +285,7 @@ fn test_ps2_port(port: PS2Port) -> Result<(), &'static str> {
         DataLineStuckHigh => Err("failed PS/2 port test, clock line stuck high")?,
     }
 
-    // enable PS2 interrupt and see the new config
+    // enable PS/2 interrupt and see the new config
     let config = read_config();
     let port_interrupt_enabled = match port {
         PS2Port::One => config.port1_interrupt_enabled(),
@@ -297,12 +297,12 @@ fn test_ps2_port(port: PS2Port) -> Result<(), &'static str> {
     };
 
     if port_interrupt_enabled {
-        debug!("ps2 port {} interrupt enabled", port as u8 + 1)
+        debug!("PS/2 port {} interrupt enabled", port as u8 + 1)
     } else {
         Err("PS/2 port test config's interrupt disabled")?
     }
     if clock_enabled {
-        debug!("ps2 port {} clock enabled", port as u8 + 1)
+        debug!("PS/2 port {} clock enabled", port as u8 + 1)
     } else {
         Err("PS/2 port test config's clock disabled")?
     }
@@ -580,7 +580,7 @@ pub enum SampleRate {
     _200 = 200
 }
 
-/// set ps2 mouse's sampling rate
+/// set PS/2 mouse's sampling rate
 fn set_mouse_sampling_rate(value: SampleRate) -> Result<(), &'static str> {
     command_to_mouse(HostToMouseCommandOrData::MouseCommand(SampleRate))
         .and(command_to_mouse(HostToMouseCommandOrData::SampleRate(value)))

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -75,7 +75,7 @@ pub fn ps2_status_register() -> u8 {
 }
 
 /// Read data from the PS/2 data port
-pub fn ps2_read_data() -> u8 {
+fn ps2_read_data() -> u8 {
     PS2_DATA_PORT.lock().read()
 }
 
@@ -494,4 +494,8 @@ pub fn keyboard_detect() -> Result<KeyboardType, &'static str> {
         0x83 => Ok(KeyboardType::MF2Keyboard),
         _ => Ok(KeyboardType::AncientATKeyboard),
     }
+}
+
+pub fn read_scancode() -> u8 {
+    ps2_read_data()
 }

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -258,19 +258,14 @@ pub fn write_to_second_output_buffer(value: u8) {
     unsafe { PS2_PORT.lock().write(value) };
 }
 
-/// read mouse data packet
+/// read mouse data packet; will work for mouse with ID 3 or 4
 pub fn handle_mouse_packet() -> u32 {
-    // since nowadays almost every mouse has scroll, so there is a 4 byte packet
-    // which means that only mouse with ID 3 or 4 can be applied this function
-    // because the mouse is initialized to have ID 3 or 4, so this function can
-    // handle the mouse data packet
-
-    let byte_1 = ps2_read_data() as u32;
-    let byte_2 = ps2_read_data() as u32;
-    let byte_3 = ps2_read_data() as u32;
-    let byte_4 = ps2_read_data() as u32;
-    let readdata = (byte_4 << 24) | (byte_3 << 16) | (byte_2 << 8) | byte_1;
-    readdata
+    u32::from_le_bytes([
+        ps2_read_data(),
+        ps2_read_data(),
+        ps2_read_data(),
+        ps2_read_data(),
+    ])
 }
 
 /// set ps2 mouse's sampling rate

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -633,7 +633,7 @@ pub fn set_keyboard_led(value: LEDState) -> Result<(), &'static str> {
 }
 
 /// set the scancode set of the keyboard
-fn keyboard_scancode_set(value: ScancodeSet) -> Result<(), &'static str> {
+pub fn keyboard_scancode_set(value: ScancodeSet) -> Result<(), &'static str> {
     command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(SetScancodeSet))
         .and(command_to_keyboard(HostToKeyboardCommandOrData::ScancodeSet(value)))
         .map_err(|_| "failed to set the keyboard scancode set")

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -605,33 +605,19 @@ fn mouse_resend() -> Result<(), &'static str> {
 }
 
 /// enable the packet streaming
-pub fn enable_mouse_packet_streaming() -> Result<(), &'static str> {
-    if let Err(_e) = command_to_mouse(HostToMouseCommandOrData::MouseCommand(EnableDataReporting)) {
+fn enable_mouse_packet_streaming() -> Result<(), &'static str> {
+    command_to_mouse(HostToMouseCommandOrData::MouseCommand(EnableDataReporting)).map_err(|_| {
         warn!("enable streaming failed");
-        Err("enable mouse streaming failed")
-    } else {
-        Ok(())
-    }
+        "enable mouse streaming failed"
+    })
 }
 
 /// disable the packet streaming
-pub fn disable_mouse_packet_streaming() -> Result<(), &'static str> {
-    if data_to_port2(0xf5) as u8 != 0xfa {
-        for x in 0..15 {
-            if x == 14 {
-                warn!("disable mouse streaming failed");
-                return Err("disable mouse streaming failed");
-            }
-            let response = read_data();
-
-            if response != 0xfa {
-                trace!("{response}");
-            } else {
-                return Ok(());
-            }
-        }
-    }
-    Ok(())
+fn disable_mouse_packet_streaming() -> Result<(), &'static str> {
+    command_to_mouse(HostToMouseCommandOrData::MouseCommand(DisableDataReporting)).map_err(|_| {
+        warn!("disable mouse streaming failed");
+        "disable mouse streaming failed"
+    })
 }
 
 pub enum MouseResolution {

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -12,7 +12,7 @@ static PS2_COMMAND_PORT: Mutex<Port<u8>> = Mutex::new(Port::new(0x64));
 
 /// clean the PS2 data port (0x60) output buffer
 /// also return the vec of data previously in the buffer which may be useful
-pub fn ps2_clean_buffer() -> Vec<u8> {
+fn ps2_clean_buffer() -> Vec<u8> {
     let mut buffer_data = Vec::new();
     loop {
         // if no more data in the output buffer
@@ -26,7 +26,7 @@ pub fn ps2_clean_buffer() -> Vec<u8> {
 }
 
 /// write command to the command ps2 port (0x64)
-pub fn ps2_write_command(value: u8) {
+fn ps2_write_command(value: u8) {
     unsafe {
         PS2_COMMAND_PORT.lock().write(value);
     }
@@ -43,13 +43,13 @@ pub fn ps2_read_data() -> u8 {
 }
 
 /// read the config of the ps2 port
-pub fn ps2_read_config() -> u8 {
+fn ps2_read_config() -> u8 {
     ps2_write_command(0x20);
     ps2_read_data()
 }
 
 /// write the new config to the ps2 command port (0x64)
-pub fn ps2_write_config(value: u8) {
+fn ps2_write_config(value: u8) {
     ps2_write_command(0x60);
     unsafe { PS2_PORT.lock().write(value) };
 }
@@ -157,19 +157,19 @@ fn test_ps2_port(port: PS2Port) {
 }
 
 /// write data to the first ps2 data port and return the response
-pub fn data_to_port1(value: u8) -> u8 {
+fn data_to_port1(value: u8) -> u8 {
     unsafe { PS2_PORT.lock().write(value) };
     ps2_read_data()
 }
 
 /// write data to the second ps2 data port and return the response
-pub fn data_to_port2(value: u8) -> u8 {
+fn data_to_port2(value: u8) -> u8 {
     ps2_write_command(0xD4);
     data_to_port1(value)
 }
 
 /// write command to the keyboard and return the result
-pub fn command_to_keyboard(value: u8) -> Result<(), &'static str> {
+fn command_to_keyboard(value: u8) -> Result<(), &'static str> {
     let response = data_to_port1(value);
 
     match response {
@@ -199,7 +199,7 @@ pub fn command_to_keyboard(value: u8) -> Result<(), &'static str> {
 }
 
 /// write command to the mouse and return the result
-pub fn command_to_mouse(value: u8) -> Result<(), &'static str> {
+fn command_to_mouse(value: u8) -> Result<(), &'static str> {
     // if the mouse doesn't acknowledge the command return error
     let response = data_to_port2(value);
     if response != 0xFA {
@@ -217,7 +217,7 @@ pub fn command_to_mouse(value: u8) -> Result<(), &'static str> {
 }
 
 /// write data to the second ps2 output buffer
-pub fn write_to_second_output_buffer(value: u8) {
+fn write_to_second_output_buffer(value: u8) {
     ps2_write_command(0xD3);
     unsafe { PS2_PORT.lock().write(value) };
 }
@@ -233,7 +233,7 @@ pub fn handle_mouse_packet() -> u32 {
 }
 
 /// set ps2 mouse's sampling rate
-pub fn set_sampling_rate(value: u8) -> Result<(), &'static str> {
+fn set_sampling_rate(value: u8) -> Result<(), &'static str> {
     // if command is not acknowledged
     if let Err(_e) = command_to_mouse(0xF3) {
         Err("set mouse sampling rate failled, please try again")
@@ -338,7 +338,7 @@ pub fn check_mouse_id() -> Result<u8, &'static str> {
 }
 
 /// reset the mouse
-pub fn reset_mouse() -> Result<(), &'static str> {
+fn reset_mouse() -> Result<(), &'static str> {
     if let Err(_e) = command_to_mouse(0xFF) {
         Err("reset mouse failled please try again")
     } else {
@@ -355,7 +355,7 @@ pub fn reset_mouse() -> Result<(), &'static str> {
 }
 
 /// resend the most recent packet again
-pub fn mouse_resend() -> Result<(), &'static str> {
+fn mouse_resend() -> Result<(), &'static str> {
     if let Err(_e) = command_to_mouse(0xFE) {
         Err("mouse resend request failled, please request again")
     } else {
@@ -366,7 +366,7 @@ pub fn mouse_resend() -> Result<(), &'static str> {
 
 /// enable or disable the packet streaming
 /// also return the vec of data previously in the buffer which may be useful
-pub fn mouse_packet_streaming(enable: bool) -> Result<Vec<u8>, &'static str> {
+fn mouse_packet_streaming(enable: bool) -> Result<Vec<u8>, &'static str> {
     if enable {
         if let Err(_e) = command_to_mouse(0xf4) {
             warn!("enable streaming failed");
@@ -400,7 +400,7 @@ pub fn mouse_packet_streaming(enable: bool) -> Result<Vec<u8>, &'static str> {
 /// parameter :
 /// 0x00: 1 count/mm; 0x01 2 count/mm;
 /// 0x02 4 count/mm; 0x03 8 count/mm;
-pub fn mouse_resolution(value: u8) -> Result<(), &'static str> {
+fn mouse_resolution(value: u8) -> Result<(), &'static str> {
     if let Err(_e) = command_to_mouse(0xE8) {
         warn!("command set mouse resolution is not accepted");
         Err("set mouse resolution failed!!!")
@@ -426,7 +426,7 @@ pub fn keyboard_led(value: u8) {
 /// set the scancode set of the keyboard
 /// 0: get the current set; 1: set 1
 /// 2: set 2; 3: set 3
-pub fn keyboard_scancode_set(value: u8) -> Result<(), &'static str> {
+fn keyboard_scancode_set(value: u8) -> Result<(), &'static str> {
     if let Err(_e) = command_to_keyboard(0xF0) {
         return Err("failed to set the keyboard scancode set");
     } else if let Err(_e) = command_to_keyboard(value) {

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -396,8 +396,8 @@ pub enum HostToMouseCommand {
     ResetWrapMode = 0xEC,
     SetWrapMode = 0xEE,
     SetRemoteMode = 0xF0, //NOTE: same value as SetScancodeSet
-    GetDeviceID = 0xF2, //NOTE: same value as IdentifyKeyboard; TODO: See Detecting PS/2 Device Types for the response bytes
-    SampleRate = 0xF3,  //NOTE: same value as SetRepeatRateAndDelay; valid values are 10, 20, 40, 60, 80, 100, 200
+    GetDeviceID = 0xF2, //NOTE: same value as IdentifyKeyboard
+    SampleRate = 0xF3,  //NOTE: same value as SetRepeatRateAndDelay
     EnableDataReporting = 0xF4, //NOTE: same value as EnableScanning
     DisableDataReporting = 0xF5, //NOTE: same value as DisableScanning
     SetDefaults = 0xF6, //NOTE: same

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -255,6 +255,8 @@ pub fn init_ps2_port1() {
 pub fn init_ps2_port2() {
     init_ps2_port(PS2Port::Two);
 }
+
+#[derive(Clone, Copy)]
 enum PS2Port {
     One,
     Two,
@@ -510,23 +512,26 @@ pub enum HostToMouseCommandOrData {
 }
 
 // https://wiki.osdev.org/PS/2_Mouse#Mouse_Device_Over_PS.2F2
+// the comments right beside the fields are just there for some intuition on PS/2
 #[derive(Clone)]
 pub enum HostToMouseCommand {
-    SetScaling = 0xE6, //1 or 2
-    SetResolution = 0xE8, //[MouseResolution]
+    /// either to 1 or 2
+    SetScaling = 0xE6,
+    /// set [MouseResolution]
+    SetResolution = 0xE8,
     StatusRequest = 0xE9,
     SetStreamMode = 0xEA,
     ReadData = 0xEB,
     ResetWrapMode = 0xEC,
     SetWrapMode = 0xEE,
-    SetRemoteMode = 0xF0, //NOTE: same value as SetScancodeSet
-    GetDeviceID = 0xF2, //NOTE: same value as IdentifyKeyboard
-    SampleRate = 0xF3,  //NOTE: same value as SetRepeatRateAndDelay
-    EnableDataReporting = 0xF4, //NOTE: same value as EnableScanning
-    DisableDataReporting = 0xF5, //NOTE: same value as DisableScanning
-    SetDefaults = 0xF6, //NOTE: same
-    ResendByte = 0xFE,  //NOTE: same
-    Reset = 0xFF,       //NOTE: same
+    SetRemoteMode = 0xF0, //same value as SetScancodeSet
+    GetDeviceID = 0xF2, //same value as IdentifyKeyboard
+    SampleRate = 0xF3,  //same value as SetRepeatRateAndDelay
+    EnableDataReporting = 0xF4, //same value as EnableScanning
+    DisableDataReporting = 0xF5, //same value as DisableScanning
+    SetDefaults = 0xF6, //same
+    ResendByte = 0xFE,  //same
+    Reset = 0xFF,       //same
 }
 
 /// write command to the keyboard and handle the result
@@ -664,6 +669,7 @@ pub enum MousePacket {
     Four(MousePacket4)
 }
 
+// demultiplexes [MousePacket] and provides standard values
 impl MousePacket {
     pub fn button_left(&self) -> bool {
         match self {
@@ -913,6 +919,7 @@ pub fn keyboard_detect() -> Result<KeyboardType, &'static str> {
     keyboard_type
 }
 
+/// reads a Scancode (for now an untyped u8)
 pub fn read_scancode() -> u8 {
     read_data()
 }

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -504,14 +504,12 @@ impl MousePacketBits4 {
 
 /// read mouse data packet; will work for mouse with ID 4 and probably 3
 pub fn read_mouse_packet() -> MousePacketBits4 {
-    let packet = MousePacketBits4::from_bytes([
+    MousePacketBits4::from_bytes([
         read_data(),
         read_data(),
         read_data(),
         read_data()
-    ]);
-    info!("read_mouse_packet: {packet:?}");
-    packet
+    ])
 }
 
 pub enum SampleRate {
@@ -668,9 +666,9 @@ pub fn keyboard_detect() -> Result<KeyboardType, &'static str> {
         0xAB => {
             match read_data() {
                 0x41 | 0xC1 => Ok(KeyboardType::MF2KeyboardWithPSControllerTranslator),
-        0x83 => Ok(KeyboardType::MF2Keyboard),
+                0x83 => Ok(KeyboardType::MF2Keyboard),
                 _ => Err("unrecognized keyboard type")
-    }
+            }
         }
         _ => Err("unrecognized keyboard type")
     };

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -365,18 +365,15 @@ fn test_ps2_port(port: PS2Port) -> Result<(), &'static str> {
     Ok(())
 }
 
-#[derive(TryFromPrimitive)]
-#[repr(u8)]
-enum ControllerTestResult {
-    Passed = 0x55,
-    //NOTE: can just be removed
-    Failed = 0xFC,
-}
-
 /// must only be called after writing the [TestController] command
 /// otherwise would read bogus data
-fn read_controller_test_result() -> Result<ControllerTestResult, &'static str> {
-    read_data().try_into().map_err(|_| "failed to read controller test result")
+fn read_controller_test_result() -> Result<(), &'static str> {
+    const CONTROLLER_TEST_PASSED: u8 = 0x55;
+    if read_data() != CONTROLLER_TEST_PASSED {
+        Err("failed PS/2 controller test")
+    } else {
+        Ok(())
+    }
 }
 
 #[derive(TryFromPrimitive)]

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -637,9 +637,8 @@ pub enum SampleRate {
 /// set PS/2 mouse's sampling rate
 fn set_mouse_sampling_rate(value: SampleRate) -> Result<(), &'static str> {
     command_to_mouse(HostToMouseCommandOrData::MouseCommand(SampleRate))
-        .and(command_to_mouse(HostToMouseCommandOrData::SampleRate(value)))
+        .and_then(|_| command_to_mouse(HostToMouseCommandOrData::SampleRate(value)))
         .map_err(|_| "failed to set the mouse sampling rate")
-    
 }
 
 pub enum MouseId {
@@ -732,23 +731,21 @@ pub enum MouseResolution {
 #[allow(dead_code)]
 fn mouse_resolution(value: MouseResolution) -> Result<(), &'static str> {
     command_to_mouse(HostToMouseCommandOrData::MouseCommand(SetResolution))
-        .and(command_to_mouse(HostToMouseCommandOrData::MouseResolution(value)))
-        .map_err(|_| {
-            "failed to set the mouse resolution"
-        })
+        .and_then(|_| command_to_mouse(HostToMouseCommandOrData::MouseResolution(value)))
+        .map_err(|_| "failed to set the mouse resolution")
 }
 
 /// set LED status of the keyboard
 pub fn set_keyboard_led(value: LEDState) -> Result<(), &'static str> {
     command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(SetLEDStatus))
-        .and(command_to_keyboard(HostToKeyboardCommandOrData::LEDState(value)))
+        .and_then(|_| command_to_keyboard(HostToKeyboardCommandOrData::LEDState(value)))
         .map_err(|_| "failed to set the keyboard led")
 }
 
 /// set the scancode set of the keyboard
 pub fn keyboard_scancode_set(value: ScancodeSet) -> Result<(), &'static str> {
     command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(SetScancodeSet))
-        .and(command_to_keyboard(HostToKeyboardCommandOrData::ScancodeSet(value)))
+        .and_then(|_| command_to_keyboard(HostToKeyboardCommandOrData::ScancodeSet(value)))
         .map_err(|_| "failed to set the keyboard scancode set")
 }
 

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -10,19 +10,16 @@ use spin::Mutex;
 static PS2_DATA_PORT: Mutex<Port<u8>> = Mutex::new(Port::new(0x60));
 static PS2_COMMAND_AND_STATUS_PORT: Mutex<Port<u8>> = Mutex::new(Port::new(0x64));
 
-/// clean the PS2 data port (0x60) output buffer
-/// also return the vec of data previously in the buffer which may be useful
-fn ps2_clean_buffer() -> Vec<u8> {
-    let mut buffer_data = Vec::new();
+/// Clean the [PS2_DATA_PORT] output buffer
+fn ps2_clean_buffer() {
     loop {
         // if no more data in the output buffer
         if ps2_status_register() & 0x01 == 0 {
             break;
         } else {
-            buffer_data.push(ps2_read_data());
+            ps2_read_data();
         }
     }
-    buffer_data
 }
 
 // https://wiki.osdev.org/%228042%22_PS/2_Controller#PS.2F2_Controller_Commands

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -574,19 +574,16 @@ pub fn mouse_id() -> Result<u8, &'static str> {
 
 /// reset the mouse
 fn reset_mouse() -> Result<(), &'static str> {
-    if let Err(_e) = command_to_mouse(HostToMouseCommandOrData::MouseCommand(Reset)) {
-        Err("reset mouse failled please try again")
-    } else {
-        for _x in 0..14 {
-            let more_bytes = read_data();
-            if more_bytes == 0xAA {
+    command_to_mouse(HostToMouseCommandOrData::MouseCommand(Reset))?; 
+    for _ in 0..14 {
+        //BAT = Basic Assurance Test
+        let bat_code = read_data();
+        if bat_code == 0xAA {
                 // command reset mouse succeeded
                 return Ok(());
             }
         }
-        warn!("disable streaming failed");
-        Err("fail to command reset mouse fail!!!")
-    }
+    Err("failed to reset mouse")
 }
 
 /// resend the most recent packet again

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -756,14 +756,19 @@ pub enum KeyboardType {
     AncientATKeyboard,
 }
 
-///detect the keyboard's type
+/// detect the [KeyboardType]
+/// 
+/// Note:
+/// On the identify command, [KeyboardType::AncientATKeyboard] usually returns no bytes at all, but [read_data] always returns a byte.
+/// This means [read_data] would return 0x00 here, even though the value is already reserved for the device type "Standard PS/2 mouse".
+/// As we only care about detecting keyboard types here, it should work.
 pub fn keyboard_detect() -> Result<KeyboardType, &'static str> {
     command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(DisableScanning))?;
 
     command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(IdentifyKeyboard))?; 
 
     let keyboard_type = match read_data() {
-        //None => Ok(KeyboardType::AncientATKeyboard)
+        0x00 => Ok(KeyboardType::AncientATKeyboard),
         0xAB => {
             match read_data() {
                 0x41 | 0xC1 => Ok(KeyboardType::MF2KeyboardWithPSControllerTranslator),

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use log::{warn, info};
+use log::{warn, info, trace};
 use port_io::Port;
 use spin::Mutex;
 
@@ -12,13 +12,8 @@ static PS2_COMMAND_AND_STATUS_PORT: Mutex<Port<u8>> = Mutex::new(Port::new(0x64)
 
 /// Clean the [PS2_DATA_PORT] output buffer
 fn ps2_clean_buffer() {
-    loop {
-        // if no more data in the output buffer
-        if ps2_status_register() & 0x01 == 0 {
-            break;
-        } else {
-            ps2_read_data();
-        }
+    while ps2_status_register() & 0x01 != 0 {
+        trace!("{}",ps2_read_data());
     }
 }
 

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use log::trace;
+use log::debug;
 use num_enum::TryFromPrimitive;
 use port_io::Port;
 use spin::Mutex;
@@ -233,7 +233,7 @@ fn init_ps2_port(port: PS2Port) {
 /// Clean the [PS2_DATA_PORT] output buffer, skipping the [ControllerToHostStatus] `output_buffer_full` check
 fn flush_output_buffer() {
     //NOTE(hecatia): on my end, this is always 250 for port 1 and 65 for port 2, even if read multiple times
-    trace!("ps2::flush_output_buffer: {}", read_data());
+    debug!("ps2::flush_output_buffer: {}", read_data());
 }
 
 /// test the first ps2 data port
@@ -251,7 +251,7 @@ fn test_ps2_port(port: PS2Port) -> Result<(), &'static str> {
     // test the ps2 controller
     write_command(TestController);
     match read_controller_test_result()? {
-        ControllerTestResult::Passed => trace!("passed PS/2 controller test"),
+        ControllerTestResult::Passed => debug!("passed PS/2 controller test"),
         ControllerTestResult::Failed => Err("failed PS/2 controller test")?,
     }
 
@@ -262,7 +262,7 @@ fn test_ps2_port(port: PS2Port) -> Result<(), &'static str> {
     }
     use PortTestResult::*;
     match read_port_test_result()? {
-        Passed => trace!("passed PS/2 port {} test", port as u8 + 1),
+        Passed => debug!("passed PS/2 port {} test", port as u8 + 1),
         ClockLineStuckLow => Err("failed PS/2 port test, clock line stuck low")?,
         ClockLineStuckHigh => Err("failed PS/2 port test, clock line stuck high")?,
         DataLineStuckLow => Err("failed PS/2 port test, data line stuck low")?,
@@ -281,12 +281,12 @@ fn test_ps2_port(port: PS2Port) -> Result<(), &'static str> {
     };
 
     if port_interrupt_enabled {
-        trace!("ps2 port {} interrupt enabled", port as u8 + 1)
+        debug!("ps2 port {} interrupt enabled", port as u8 + 1)
     } else {
         Err("PS/2 port test config's interrupt disabled")?
     }
     if clock_enabled {
-        trace!("ps2 port {} clock enabled", port as u8 + 1)
+        debug!("ps2 port {} clock enabled", port as u8 + 1)
     } else {
         Err("PS/2 port test config's clock disabled")?
     }

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -78,29 +78,38 @@ type bool1 = bool;
 pub struct ControllerToHostStatus {
     /// When using [Polling](https://wiki.osdev.org/%228042%22_PS/2_Controller#Polling), must be `true` before attempting to read data from [PS2_DATA_PORT].
     /// When using [Interrupts](https://wiki.osdev.org/%228042%22_PS/2_Controller#Interrupts), guaranteed to be `true`, because an interrupt only happens if the buffer is full
+    #[allow(dead_code)]
     output_buffer_full: bool1,
     /// Must be `false` before attempting to write data to [PS2_DATA_PORT] or [PS2_COMMAND_AND_STATUS_PORT]
+    #[allow(dead_code)]
     input_buffer_full: bool1,
     /// Cleared on reset; set when the system passed Power-on self-test
+    #[allow(dead_code)]
     system_passed_self_test: bool1,
     /// Input buffer should be written to: 0 - [PS2_DATA_PORT], 1 - [PS2_COMMAND_AND_STATUS_PORT]
+    #[allow(dead_code)]
     input_buffer_is_command: u1,
     /// Whether or not communication is inhibited (via switch) / Unknown (chipset specific) / (more likely unused on modern systems)
+    #[allow(dead_code)]
     keyboard_enabled: bool1,
     ///// Keyboard didn't generate clock signals within 15 ms of "request-to-send" (exclusive to AT-compatible mode)
     // transmit_timeout: bool1,
     ///// Keyboard didn't generate clock signals within 20 ms of command reception (exclusive to AT-compatible mode)
     // receive_timeout: bool1,
     /// Similar to `output_buffer_full`, except for mouse
+    #[allow(dead_code)]
     mouse_output_buffer_full: bool1,
     /// Timeout during keyboard command receive or response (Same as [transmit_timeout] + [receive_timeout])
+    #[allow(dead_code)]
     timeout_error: bool1,
     /// Should be odd parity, set to `true` if even parity received
+    #[allow(dead_code)]
     parity_error: bool1,
 }
 
 /// Read the PS/2 status port/register
 /// Note: Currently unused, might be used later for error checking
+#[allow(dead_code)]
 fn status_register() -> ControllerToHostStatus {
     ControllerToHostStatus::from_bytes([PS2_COMMAND_AND_STATUS_PORT.lock().read()])
 }
@@ -123,11 +132,15 @@ pub struct ControllerConfigurationByte {
     port1_interrupt_enabled: bool1,
     port2_interrupt_enabled: bool1, //NOTE: only if 2 PS/2 ports supported
     /// Cleared on reset; set when the system passed Power-on self-test
+    #[allow(dead_code)]
     system_passed_self_test: bool1,
+    #[allow(dead_code)]
     should_be_zero: u1,
     port1_clock_disabled: bool1,
     port2_clock_disabled: bool1, //NOTE: only if 2 PS/2 ports supported
+    #[allow(dead_code)]
     port1_translation: bool1,
+    #[allow(dead_code)]
     must_be_zero: u1,
 }
 
@@ -420,6 +433,7 @@ fn command_to_mouse(value: HostToMouseCommandOrData) -> Result<(), &'static str>
 }
 
 /// write data to the second ps2 output buffer
+#[allow(dead_code)]
 fn write_to_second_output_buffer(value: u8) {
     write_command(WriteByteToPort2OutputBuffer);
     write_data(value);
@@ -452,7 +466,9 @@ pub struct MousePacketBits4 {
     z_movement: B4, //u8 with #[bits = 4] attribute didn't work
     pub button_4: bool1,
     pub button_5: bool1,
+    #[allow(dead_code)]
     zero1: u1,
+    #[allow(dead_code)]
     zero2: u1,
 }
 
@@ -562,6 +578,7 @@ pub fn mouse_id() -> Result<u8, &'static str> {
 }
 
 /// reset the mouse
+#[allow(dead_code)]
 fn reset_mouse() -> Result<(), &'static str> {
     command_to_mouse(HostToMouseCommandOrData::MouseCommand(Reset))?; 
     for _ in 0..14 {
@@ -576,6 +593,7 @@ fn reset_mouse() -> Result<(), &'static str> {
 }
 
 /// resend the most recent packet again
+#[allow(dead_code)]
 fn mouse_resend() -> Result<(), &'static str> {
     command_to_mouse(HostToMouseCommandOrData::MouseCommand(HostToMouseCommand::ResendByte))
         .map_err(|_| "mouse resend request failed, please request again")
@@ -606,6 +624,7 @@ pub enum MouseResolution {
 }
 
 /// set the resolution of the mouse
+#[allow(dead_code)]
 fn mouse_resolution(value: MouseResolution) -> Result<(), &'static str> {
     command_to_mouse(HostToMouseCommandOrData::MouseCommand(SetResolution))
         .and(command_to_mouse(HostToMouseCommandOrData::MouseResolution(value)))

--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -629,34 +629,26 @@ pub enum MouseResolution {
 
 /// set the resolution of the mouse
 fn mouse_resolution(value: MouseResolution) -> Result<(), &'static str> {
-    if let Err(_e) = command_to_mouse(HostToMouseCommandOrData::MouseCommand(SetResolution)) {
-        warn!("command set mouse resolution is not accepted");
-        Err("set mouse resolution failed!!!")
-    } else if let Err(_e) = command_to_mouse(HostToMouseCommandOrData::MouseResolution(value)) {
-        warn!("the resolution value is not accepted");
-        Err("set mouse resolution failed!!!")
-    } else {
-        Ok(())
-    }
+    command_to_mouse(HostToMouseCommandOrData::MouseCommand(SetResolution))
+        .and(command_to_mouse(HostToMouseCommandOrData::MouseResolution(value)))
+        .map_err(|_| {
+            warn!("command set mouse resolution is not accepted");
+            "failed to set the keyboard scancode set"
+        })
 }
 
 /// set LED status of the keyboard
-pub fn keyboard_led(value: LEDState) {
-    if let Err(_e) = command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(SetLEDStatus)) {
-        warn!("failed to set the keyboard led");
-    } else if let Err(_e) = command_to_keyboard(HostToKeyboardCommandOrData::LEDState(value)) {
-        warn!("failed to set the keyboard led");
-    }
+pub fn set_keyboard_led(value: LEDState) -> Result<(), &'static str> {
+    command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(SetLEDStatus))
+        .and(command_to_keyboard(HostToKeyboardCommandOrData::LEDState(value)))
+        .map_err(|_| "failed to set the keyboard led")
 }
 
 /// set the scancode set of the keyboard
 fn keyboard_scancode_set(value: ScancodeSet) -> Result<(), &'static str> {
-    if let Err(_e) = command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(SetScancodeSet)) {
-        return Err("failed to set the keyboard scancode set");
-    } else if let Err(_e) = command_to_keyboard(HostToKeyboardCommandOrData::ScancodeSet(value)) {
-        return Err("failed to set the keyboard scancode set");
-    }
-    Ok(())
+    command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(SetScancodeSet))
+        .and(command_to_keyboard(HostToKeyboardCommandOrData::ScancodeSet(value)))
+        .map_err(|_| "failed to set the keyboard scancode set")
 }
 
 pub enum KeyboardType {

--- a/kernel/window_manager/src/lib.rs
+++ b/kernel/window_manager/src/lib.rs
@@ -682,7 +682,7 @@ fn window_manager_loop(
                     keyboard_handle_application(key_input)?;
                 }
                 Event::MouseMovementEvent(ref mouse_event) => {
-                    //as isize probably because adding up mouse movements will overflow?
+                    //as isize to fit larger values
                     let mut x = mouse_event.movement.x_movement as isize;
                     let mut y = mouse_event.movement.y_movement as isize;
 
@@ -700,8 +700,8 @@ fn window_manager_loop(
                                         == mouse_event.buttons.fourth_button_hold
                                     && next_mouse_event.buttons.fifth_button_hold
                                         == mouse_event.buttons.fifth_button_hold {
-                                    x += next_mouse_event.movement.x_movement as isize;
-                                    y += next_mouse_event.movement.y_movement as isize;
+                                    x = x.saturating_add(next_mouse_event.movement.x_movement as isize);
+                                    y = y.saturating_add(next_mouse_event.movement.y_movement as isize);
                                 }
                             }
                             _ => {

--- a/kernel/window_manager/src/lib.rs
+++ b/kernel/window_manager/src/lib.rs
@@ -352,12 +352,12 @@ impl WindowManager {
         let mut event: MousePositionEvent = MousePositionEvent {
             coordinate: Coord::new(0, 0),
             gcoordinate: coordinate.clone(),
-            scrolling_up: mouse_event.mousemove.scroll_movement > 0, //TODO: might be more beneficial to save scroll_movement here
-            scrolling_down: mouse_event.mousemove.scroll_movement < 0, //FIXME: also might be the wrong way around
-            left_button_hold: mouse_event.buttonact.left_button_hold,
-            right_button_hold: mouse_event.buttonact.right_button_hold,
-            fourth_button_hold: mouse_event.buttonact.fourth_button_hold,
-            fifth_button_hold: mouse_event.buttonact.fifth_button_hold,
+            scrolling_up: mouse_event.movement.scroll_movement > 0, //TODO: might be more beneficial to save scroll_movement here
+            scrolling_down: mouse_event.movement.scroll_movement < 0, //FIXME: also might be the wrong way around
+            left_button_hold: mouse_event.buttons.left_button_hold,
+            right_button_hold: mouse_event.buttons.right_button_hold,
+            fourth_button_hold: mouse_event.buttons.fourth_button_hold,
+            fifth_button_hold: mouse_event.buttons.fifth_button_hold,
         };
 
         // TODO: FIXME:  improve this logic to just send the mouse event to the top-most window in the entire WM list,
@@ -683,25 +683,25 @@ fn window_manager_loop(
                 }
                 Event::MouseMovementEvent(ref mouse_event) => {
                     //as isize probably because adding up mouse movements will overflow?
-                    let mut x = mouse_event.mousemove.x_movement as isize;
-                    let mut y = mouse_event.mousemove.y_movement as isize;
+                    let mut x = mouse_event.movement.x_movement as isize;
+                    let mut y = mouse_event.movement.y_movement as isize;
 
                     // need to combine mouse events if there pending a lot
                     while let Some(next_event) = mouse_consumer.pop() {
                         match next_event {
                             Event::MouseMovementEvent(ref next_mouse_event) => {
-                                if next_mouse_event.mousemove.scroll_movement
-                                    == mouse_event.mousemove.scroll_movement
-                                    && next_mouse_event.buttonact.left_button_hold
-                                        == mouse_event.buttonact.left_button_hold
-                                    && next_mouse_event.buttonact.right_button_hold
-                                        == mouse_event.buttonact.right_button_hold
-                                    && next_mouse_event.buttonact.fourth_button_hold
-                                        == mouse_event.buttonact.fourth_button_hold
-                                    && next_mouse_event.buttonact.fifth_button_hold
-                                        == mouse_event.buttonact.fifth_button_hold {
-                                    x += next_mouse_event.mousemove.x_movement as isize;
-                                    y += next_mouse_event.mousemove.y_movement as isize;
+                                if next_mouse_event.movement.scroll_movement
+                                    == mouse_event.movement.scroll_movement
+                                    && next_mouse_event.buttons.left_button_hold
+                                        == mouse_event.buttons.left_button_hold
+                                    && next_mouse_event.buttons.right_button_hold
+                                        == mouse_event.buttons.right_button_hold
+                                    && next_mouse_event.buttons.fourth_button_hold
+                                        == mouse_event.buttons.fourth_button_hold
+                                    && next_mouse_event.buttons.fifth_button_hold
+                                        == mouse_event.buttons.fifth_button_hold {
+                                    x += next_mouse_event.movement.x_movement as isize;
+                                    y += next_mouse_event.movement.y_movement as isize;
                                 }
                             }
                             _ => {

--- a/kernel/window_manager/src/lib.rs
+++ b/kernel/window_manager/src/lib.rs
@@ -682,7 +682,6 @@ fn window_manager_loop(
                     keyboard_handle_application(key_input)?;
                 }
                 Event::MouseMovementEvent(ref mouse_event) => {
-                    info!("window_manager_loop: {mouse_event:?}");
                     //as isize probably because adding up mouse movements will overflow?
                     let mut x = mouse_event.mousemove.x_movement as isize;
                     let mut y = mouse_event.mousemove.y_movement as isize;

--- a/kernel/window_manager/src/lib.rs
+++ b/kernel/window_manager/src/lib.rs
@@ -354,10 +354,10 @@ impl WindowManager {
             gcoordinate: coordinate.clone(),
             scrolling_up: mouse_event.movement.scroll_movement > 0, //TODO: might be more beneficial to save scroll_movement here
             scrolling_down: mouse_event.movement.scroll_movement < 0, //FIXME: also might be the wrong way around
-            left_button_hold: mouse_event.buttons.left_button_hold,
-            right_button_hold: mouse_event.buttons.right_button_hold,
-            fourth_button_hold: mouse_event.buttons.fourth_button_hold,
-            fifth_button_hold: mouse_event.buttons.fifth_button_hold,
+            left_button_hold: mouse_event.buttons.left(),
+            right_button_hold: mouse_event.buttons.right(),
+            fourth_button_hold: mouse_event.buttons.fourth(),
+            fifth_button_hold: mouse_event.buttons.fifth(),
         };
 
         // TODO: FIXME:  improve this logic to just send the mouse event to the top-most window in the entire WM list,
@@ -692,14 +692,14 @@ fn window_manager_loop(
                             Event::MouseMovementEvent(ref next_mouse_event) => {
                                 if next_mouse_event.movement.scroll_movement
                                     == mouse_event.movement.scroll_movement
-                                    && next_mouse_event.buttons.left_button_hold
-                                        == mouse_event.buttons.left_button_hold
-                                    && next_mouse_event.buttons.right_button_hold
-                                        == mouse_event.buttons.right_button_hold
-                                    && next_mouse_event.buttons.fourth_button_hold
-                                        == mouse_event.buttons.fourth_button_hold
-                                    && next_mouse_event.buttons.fifth_button_hold
-                                        == mouse_event.buttons.fifth_button_hold {
+                                    && next_mouse_event.buttons.left()
+                                        == mouse_event.buttons.left()
+                                    && next_mouse_event.buttons.right()
+                                        == mouse_event.buttons.right()
+                                    && next_mouse_event.buttons.fourth()
+                                        == mouse_event.buttons.fourth()
+                                    && next_mouse_event.buttons.fifth()
+                                        == mouse_event.buttons.fifth() {
                                     x = x.saturating_add(next_mouse_event.movement.x_movement as isize);
                                     y = y.saturating_add(next_mouse_event.movement.y_movement as isize);
                                 }

--- a/libs/keycodes_ascii/Cargo.toml
+++ b/libs/keycodes_ascii/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+authors = ["Kevin Boos <kevinaboos@gmail.com>, Hecatia Elegua"]
 name = "keycodes_ascii"
 version = "0.1.0"
 keywords = ["keyboard", "ascii", "ps2", "scan codes", "scancode"]

--- a/libs/keycodes_ascii/Cargo.toml
+++ b/libs/keycodes_ascii/Cargo.toml
@@ -5,7 +5,11 @@ version = "0.1.0"
 keywords = ["keyboard", "ascii", "ps2", "scan codes", "scancode"]
 categories = ["no-std", "hardware-support"]
 license = "MIT"
+edition = "2021"
 
 [dependencies]
 bitflags = "1.1.0"
 
+[dependencies.num_enum]
+version = "0.5.7"
+default-features = false

--- a/libs/keycodes_ascii/src/lib.rs
+++ b/libs/keycodes_ascii/src/lib.rs
@@ -3,21 +3,6 @@
 use bitflags::bitflags;
 use num_enum::TryFromPrimitive;
 
-// TODO: use these tables and tips:
-// https://sourceforge.net/p/oszur11/code/ci/master/tree/Chapter_06_Shell/04_Makepp/arch/i386/arch/devices/i8042.c
-// ^link dead; https://stackoverflow.com/questions/219120/protected-mode-keyboard-access-on-x86-assembly
-
-// TODO: seems like we actually can use phf crates
-// we can use the "core" feature enables libcore instead of libstd
-// you can use number literals like so: 
-/*
-static MYMAP: phf::Map<u8, &'static Keycode> = phf_map! {
-    0u8 => Keycode::BLAH,
-    1u8 => Keycode::BLAH2,
-    ... etc ...
-}
-*/
-
 // the implementation here follows the rule of representation, 
 // which is to use complicated data structures to permit simpler logic. 
 
@@ -130,7 +115,8 @@ impl KeyEvent {
     }
 }
 
-// FIXME: this is only true for scancode set 1
+// FIXME: this is only true for scancode set 1, set 2 uses (0xF0, make-code),
+// set 3 uses single byte make-codes and (0xF0, make-code) everywhere, no extended codes
 /// The offset that a keyboard adds to the scancode
 /// to indicate that the key was released rather than pressed. 
 /// So if a scancode of `1` means a key `foo` was pressed,
@@ -256,10 +242,10 @@ impl Keycode {
         // handle shift key being pressed
         if modifiers.is_shift() {
             if modifiers.is_caps_lock() && self.is_letter() {
-            // if shift is pressed and caps lock is on, give a regular lowercase letter
+                // if shift is pressed and caps lock is on, give a regular lowercase letter
                 return self.as_ascii();
             } else {
-            // if shift is pressed and caps lock is not, give a regular shifted key
+                // if shift is pressed and caps lock is not, give a regular shifted key
                 return self.as_ascii_shifted();
             }
         }

--- a/libs/keycodes_ascii/src/lib.rs
+++ b/libs/keycodes_ascii/src/lib.rs
@@ -1,13 +1,11 @@
-#![allow(dead_code)]
 #![no_std]
 
-
-#[macro_use] extern crate bitflags;
-
-// use core::cell::RefCell;
+use bitflags::bitflags;
+use num_enum::TryFromPrimitive;
 
 // TODO: use these tables and tips:
 // https://sourceforge.net/p/oszur11/code/ci/master/tree/Chapter_06_Shell/04_Makepp/arch/i386/arch/devices/i8042.c
+// ^link dead; https://stackoverflow.com/questions/219120/protected-mode-keyboard-access-on-x86-assembly
 
 // TODO: seems like we actually can use phf crates
 // we can use the "core" feature enables libcore instead of libstd
@@ -22,7 +20,6 @@ static MYMAP: phf::Map<u8, &'static Keycode> = phf_map! {
 
 // the implementation here follows the rule of representation, 
 // which is to use complicated data structures to permit simpler logic. 
-
 
 bitflags! {
     /// The set of modifier keys that can be held down while other keys are pressed.
@@ -124,7 +121,7 @@ pub struct KeyEvent {
 }
 
 impl KeyEvent {
-    pub fn new(keycode: Keycode, action: KeyAction, modifiers: KeyboardModifiers,) -> KeyEvent {
+    pub fn new(keycode: Keycode, action: KeyAction, modifiers: KeyboardModifiers) -> KeyEvent {
         KeyEvent {
             keycode, 
             action,
@@ -133,6 +130,7 @@ impl KeyEvent {
     }
 }
 
+// FIXME: this is only true for scancode set 1
 /// The offset that a keyboard adds to the scancode
 /// to indicate that the key was released rather than pressed. 
 /// So if a scancode of `1` means a key `foo` was pressed,
@@ -141,11 +139,14 @@ pub const KEY_RELEASED_OFFSET: u8 = 128;
 
 /// convenience function for obtaining the ascii value for a raw scancode under the given modifiers
 pub fn scancode_to_ascii(modifiers: KeyboardModifiers, scan_code: u8) -> Option<char> {
-	Keycode::from_scancode(scan_code).and_then(|k| k.to_ascii(modifiers))
+    scan_code
+        .try_into()
+        .ok()
+        .and_then(|k: Keycode| k.to_ascii(modifiers))
 }
 
-
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
 pub enum Keycode {
     OverflowError = 0,
     Escape,
@@ -218,19 +219,19 @@ pub enum Keycode {
     F10,
     NumLock,
     ScrollLock,
-    Home, // Also Pad7
-    Up, // Also Pad8
+    Home,   // Also Pad7
+    Up,     // Also Pad8
     PageUp, // Also Pad9
     PadMinus,
     Left, // Also Pad4
     Pad5,
     Right, // Also Pad6
     PadPlus,
-    End, // Also Pad1
-    Down, // Also Pad2
+    End,      // Also Pad1
+    Down,     // Also Pad2
     PageDown, // Also Pad3
-    Insert, // Also Pad0
-    Delete, // Also PadDecimal
+    Insert,   // Also Pad0
+    Delete,   // Also PadDecimal
     Unknown1,
     Unknown2,
     NonUsBackslash,
@@ -241,127 +242,25 @@ pub enum Keycode {
     SuperKeyLeft,
     SuperKeyRight,
     Menu,
+    ControlReleased = Keycode::Control as u8 + KEY_RELEASED_OFFSET,
+    AltReleased = Keycode::Alt as u8 + KEY_RELEASED_OFFSET,
+    LeftShiftReleased = Keycode::LeftShift as u8 + KEY_RELEASED_OFFSET,
+    RightShiftReleased = Keycode::RightShift as u8 + KEY_RELEASED_OFFSET,
+    SuperKeyLeftReleased = Keycode::SuperKeyLeft as u8 + KEY_RELEASED_OFFSET,
+    SuperKeyRightReleased = Keycode::SuperKeyRight as u8 + KEY_RELEASED_OFFSET,
 } 
 
-
-
-
 impl Keycode {
-
-    pub fn from_scancode(scancode: u8)  -> Option<Keycode> {
-        match scancode {
-            0 => Some(Keycode::OverflowError),
-            1 => Some(Keycode::Escape),
-            2 => Some(Keycode::Num1),
-            3 => Some(Keycode::Num2),
-            4 => Some(Keycode::Num3),
-            5 => Some(Keycode::Num4),
-            6 => Some(Keycode::Num5),
-            7 => Some(Keycode::Num6),
-            8 => Some(Keycode::Num7),
-            9 => Some(Keycode::Num8),
-            10 => Some(Keycode::Num9),
-            11 => Some(Keycode::Num0),
-            12 => Some(Keycode::Minus),
-            13 => Some(Keycode::Equals),
-            14 => Some(Keycode::Backspace),
-            15 => Some(Keycode::Tab),
-            16 => Some(Keycode::Q),
-            17 => Some(Keycode::W),
-            18 => Some(Keycode::E),
-            19 => Some(Keycode::R),
-            20 => Some(Keycode::T),
-            21 => Some(Keycode::Y),
-            22 => Some(Keycode::U),
-            23 => Some(Keycode::I),
-            24 => Some(Keycode::O),
-            25 => Some(Keycode::P),
-            26 => Some(Keycode::LeftBracket),
-            27 => Some(Keycode::RightBracket),
-            28 => Some(Keycode::Enter),
-            29 => Some(Keycode::Control),
-            30 => Some(Keycode::A),
-            31 => Some(Keycode::S),
-            32 => Some(Keycode::D),
-            33 => Some(Keycode::F),
-            34 => Some(Keycode::G),
-            35 => Some(Keycode::H),
-            36 => Some(Keycode::J),
-            37 => Some(Keycode::K),
-            38 => Some(Keycode::L),
-            39 => Some(Keycode::Semicolon),
-            40 => Some(Keycode::Quote),
-            41 => Some(Keycode::Backtick),
-            42 => Some(Keycode::LeftShift),
-            43 => Some(Keycode::Backslash),
-            44 => Some(Keycode::Z),
-            45 => Some(Keycode::X),
-            46 => Some(Keycode::C),
-            47 => Some(Keycode::V),
-            48 => Some(Keycode::B),
-            49 => Some(Keycode::N),
-            50 => Some(Keycode::M),
-            51 => Some(Keycode::Comma),
-            52 => Some(Keycode::Period),
-            53 => Some(Keycode::Slash),
-            54 => Some(Keycode::RightShift),
-            55 => Some(Keycode::PadMultiply), // Also PrintScreen
-            56 => Some(Keycode::Alt),
-            57 => Some(Keycode::Space),
-            58 => Some(Keycode::CapsLock),
-            59 => Some(Keycode::F1),
-            60 => Some(Keycode::F2),
-            61 => Some(Keycode::F3),
-            62 => Some(Keycode::F4),
-            63 => Some(Keycode::F5),
-            64 => Some(Keycode::F6),
-            65 => Some(Keycode::F7),
-            66 => Some(Keycode::F8),
-            67 => Some(Keycode::F9),
-            68 => Some(Keycode::F10),
-            69 => Some(Keycode::NumLock),
-            70 => Some(Keycode::ScrollLock),
-            71 => Some(Keycode::Home), // Also Pad7
-            72 => Some(Keycode::Up), // Also Pad8
-            73 => Some(Keycode::PageUp), // Also Pad9
-            74 => Some(Keycode::PadMinus),
-            75 => Some(Keycode::Left), // Also Pad4
-            76 => Some(Keycode::Pad5),
-            77 => Some(Keycode::Right), // Also Pad6
-            78 => Some(Keycode::PadPlus),
-            79 => Some(Keycode::End), // Also Pad1
-            80 => Some(Keycode::Down), // Also Pad2
-            81 => Some(Keycode::PageDown), // Also Pad3
-            82 => Some(Keycode::Insert), // Also Pad0
-            83 => Some(Keycode::Delete), // Also PadDecimal
-            84 => Some(Keycode::Unknown1),
-            85 => Some(Keycode::Unknown2),
-            86 => Some(Keycode::NonUsBackslash),
-            87 => Some(Keycode::F11),
-            88 => Some(Keycode::F12),
-            89 => Some(Keycode::Pause),
-            90 => Some(Keycode::Unknown3),
-            91 => Some(Keycode::SuperKeyLeft),
-            92 => Some(Keycode::SuperKeyRight),
-            93 => Some(Keycode::Menu),
-
-            _ => None,
-        }
-    }
-
-
-
     /// Obtains the ascii value for a keycode under the given modifiers
     pub fn to_ascii(&self, modifiers: KeyboardModifiers) -> Option<char> {
         // handle shift key being pressed
         if modifiers.is_shift() {
-            // if shift is pressed and caps lock is on, give a regular lowercase letter
             if modifiers.is_caps_lock() && self.is_letter() {
+            // if shift is pressed and caps lock is on, give a regular lowercase letter
                 return self.as_ascii();
-            }
+            } else {
             // if shift is pressed and caps lock is not, give a regular shifted key
-            else {
-                return self.as_ascii_shifted()
+                return self.as_ascii_shifted();
             }
         }
         
@@ -369,10 +268,9 @@ impl Keycode {
         // (we already covered the shift && caps_lock scenario above)
         if modifiers.is_caps_lock() {
             if self.is_letter() {
-                return self.as_ascii_shifted()
-            }
-            else {
-                return self.as_ascii()
+                return self.as_ascii_shifted();
+            } else {
+                return self.as_ascii();
             }
         }
 
@@ -381,8 +279,6 @@ impl Keycode {
         
         // TODO: handle numlock
     }
-
-
 
     /// returns true if this keycode was a letter from A-Z
     pub fn is_letter(&self) -> bool {
@@ -417,8 +313,6 @@ impl Keycode {
             _ => false,
         }
     }
-
-
 
     /// maps a Keycode to ASCII char values without any "shift" modifiers.
     fn as_ascii(&self) -> Option<char> {
@@ -479,11 +373,9 @@ impl Keycode {
             Keycode::PadMinus => Some('-'),
             Keycode::PadPlus => Some('+'),
             // PadSlash / PadDivide?? 
-
             _ => None,
         }
     }
-
 
     /// same as as_ascii, but adds the effect of the "shift" modifier key. 
     /// If a Keycode's ascii value doesn't change when shifted,
@@ -542,37 +434,3 @@ impl Keycode {
         }
     }
 }
-
-
-
-
-// // I cant get TryFrom to work with core library
-// use try_from::Err;
-
-// #[derive(Debug)]
-// pub struct TryFromKeycodeError { 
-//     scan_code: u8,
-// }
-
-// impl Err for TryFromKeycodeError {
-//     fn description(&self) -> &str {
-//         "out of range integral type conversion attempted"
-//     }
-// }
-
-// impl fmt::Display for TryFromKeycodeError {
-//     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-//         fmt.write_str(self.description())
-//     }
-// }
-
-// impl TryFrom<u8> for Keycode {
-//     type Err = TryFromKeycodeError;
-//     fn try_from(original: u8) -> Result<Keycode, TryFromKeycodeError> {
-//         let kc = get_keycode(original);
-//         match kc {
-//             Some(x) => Ok(x),
-//             fail => Err(TryFromKeycodeError{ scan_code: original }),
-//         }
-//     }
-// }

--- a/libs/mouse_data/Cargo.toml
+++ b/libs/mouse_data/Cargo.toml
@@ -4,7 +4,7 @@ name = "mouse_data"
 version = "0.1.0"
 keywords = ["mouse"]
 categories = ["no-std", "hardware-support"]
-
+edition = "2021"
 
 [dependencies]
 

--- a/libs/mouse_data/Cargo.toml
+++ b/libs/mouse_data/Cargo.toml
@@ -7,3 +7,4 @@ categories = ["no-std", "hardware-support"]
 edition = "2021"
 
 [dependencies]
+modular-bitfield = "0.11.2"

--- a/libs/mouse_data/Cargo.toml
+++ b/libs/mouse_data/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Bowen Liu <liubowenbob@hotmail.com>"]
+authors = ["Bowen Liu <liubowenbob@hotmail.com>, Hecatia Elegua"]
 name = "mouse_data"
 version = "0.1.0"
 keywords = ["mouse"]
@@ -7,5 +7,3 @@ categories = ["no-std", "hardware-support"]
 edition = "2021"
 
 [dependencies]
-
-

--- a/libs/mouse_data/src/lib.rs
+++ b/libs/mouse_data/src/lib.rs
@@ -94,49 +94,44 @@ impl MouseMovement {
         let third_byte = ((readdata & 0xff0000) >> 16) as u8;
         let fourth_byte = ((readdata & 0xff000000) >> 24) as u8;
 
-        if first_byte & 0x80 == 0x80 || first_byte & 0x40 == 0x40 {
-
+        if third_byte == 0 {
+            self.down = false;
+            self.up = false;
         } else {
-            if third_byte == 0 {
-                self.down = false;
+            if first_byte & 0x20 == 0x20 {
+                self.down = true;
                 self.up = false;
             } else {
-                if first_byte & 0x20 == 0x20 {
-                    self.down = true;
-                    self.up = false;
-                } else {
-                    self.up = true;
-                    self.down = false;
-                }
+                self.up = true;
+                self.down = false;
             }
+        }
 
-            if second_byte == 0 {
-                self.left = false;
+        if second_byte == 0 {
+            self.left = false;
+            self.right = false;
+        } else {
+            if first_byte & 0x10 == 0x10 {
+                self.left = true;
                 self.right = false;
             } else {
-                if first_byte & 0x10 == 0x10 {
-                    self.left = true;
-                    self.right = false;
-                } else {
-                    self.right = true;
-                    self.left = false;
-                }
+                self.right = true;
+                self.left = false;
             }
-            if fourth_byte == 0 {
-                self.scrolling_up = false;
+        }
+        if fourth_byte == 0 {
+            self.scrolling_up = false;
+            self.scrolling_down = false;
+        } else {
+            if fourth_byte & 0x0F == 0x0F {
+                self.scrolling_down = true;
+            } else if fourth_byte & 0x0F != 0x0F {
                 self.scrolling_down = false;
-            } else {
-                if fourth_byte & 0x0F == 0x0F {
-                    self.scrolling_down = true;
-                } else if fourth_byte & 0x0F != 0x0F {
-                    self.scrolling_down = false;
-                    if fourth_byte & 0x01 == 0x01 {
-                        self.scrolling_up = true;
-                    } else if fourth_byte & 0x01 == 0x0 {
-                        self.scrolling_up = false;
-                    }
+                if fourth_byte & 0x01 == 0x01 {
+                    self.scrolling_up = true;
+                } else if fourth_byte & 0x01 == 0x0 {
+                    self.scrolling_up = false;
                 }
-
             }
         }
     }

--- a/libs/mouse_data/src/lib.rs
+++ b/libs/mouse_data/src/lib.rs
@@ -11,14 +11,11 @@ pub struct Displacement {
 }
 
 impl Displacement {
-    pub const fn default() -> Displacement {
-        Displacement { x: 0, y: 0 }
-    }
-    pub fn read_from_data(&mut self, readdata: u32) {
-        let x_dis: u8 = ((readdata & 0x0000ff00) >> 8) as u8;
-        let y_dis: u8 = ((readdata & 0x00ff0000) >> 16) as u8;
-        self.x = x_dis;
-        self.y = y_dis;
+    pub fn read_from_data(readdata: u32) -> Self {
+        Self {
+            x: ((readdata & 0x0000ff00) >> 8) as u8,
+            y: ((readdata & 0x00ff0000) >> 16) as u8
+        }
     }
 }
 #[derive(Debug, Copy, Clone)]
@@ -30,38 +27,12 @@ pub struct ButtonAction {
 }
 
 impl ButtonAction {
-    pub const fn default() -> ButtonAction {
-        ButtonAction {
-            left_button_hold: false,
-            right_button_hold: false,
-            fourth_button_hold: false,
-            fifth_button_hold: false,
-        }
-    }
-
-    pub fn read_from_data(&mut self, readdata: u32) {
-        if readdata & 0x01 == 0x01 {
-            self.left_button_hold = true;
-        } else {
-            self.left_button_hold = false;
-        }
-
-        if readdata & 0x02 == 0x02 {
-            self.right_button_hold = true;
-        } else {
-            self.right_button_hold = false;
-        }
-
-        if readdata & 0x10000000 == 0x10000000 {
-            self.fourth_button_hold = true;
-        } else {
-            self.fourth_button_hold = false;
-        }
-
-        if readdata & 0x20000000 == 0x20000000 {
-            self.fifth_button_hold = true;
-        } else {
-            self.fifth_button_hold = false;
+    pub fn read_from_data(readdata: u32) -> Self {
+        Self {
+            left_button_hold: readdata & 0x01 == 0x01,
+            right_button_hold: readdata & 0x02 == 0x02,
+            fourth_button_hold: readdata & 0x10000000 == 0x10000000,
+            fifth_button_hold: readdata & 0x20000000 == 0x20000000,
         }
     }
 }
@@ -77,63 +48,59 @@ pub struct MouseMovement {
 }
 
 impl MouseMovement {
-    pub const fn default() -> MouseMovement {
-        MouseMovement {
-            right: false,
-            left: false,
-            down: false,
-            up: false,
-            scrolling_up: false,
-            scrolling_down: false,
-        }
-    }
-
-    pub fn read_from_data(&mut self, readdata: u32) {
+    pub fn read_from_data(readdata: u32) -> Self {
         let first_byte = (readdata & 0xff) as u8;
         let second_byte = ((readdata & 0xff00) >> 8) as u8;
         let third_byte = ((readdata & 0xff0000) >> 16) as u8;
         let fourth_byte = ((readdata & 0xff000000) >> 24) as u8;
+        let mut right = false;
+        let mut left = false;
+        let mut down = false;
+        let mut up = false;
+        let mut scrolling_up = false;
+        let mut scrolling_down = false;
 
         if third_byte == 0 {
-            self.down = false;
-            self.up = false;
+            down = false;
+            up = false;
         } else {
             if first_byte & 0x20 == 0x20 {
-                self.down = true;
-                self.up = false;
+                down = true;
+                up = false;
             } else {
-                self.up = true;
-                self.down = false;
+                up = true;
+                down = false;
             }
         }
 
         if second_byte == 0 {
-            self.left = false;
-            self.right = false;
+            left = false;
+            right = false;
         } else {
             if first_byte & 0x10 == 0x10 {
-                self.left = true;
-                self.right = false;
+                left = true;
+                right = false;
             } else {
-                self.right = true;
-                self.left = false;
+                right = true;
+                left = false;
             }
         }
         if fourth_byte == 0 {
-            self.scrolling_up = false;
-            self.scrolling_down = false;
+            scrolling_up = false;
+            scrolling_down = false;
         } else {
             if fourth_byte & 0x0F == 0x0F {
-                self.scrolling_down = true;
+                scrolling_down = true;
             } else if fourth_byte & 0x0F != 0x0F {
-                self.scrolling_down = false;
+                scrolling_down = false;
                 if fourth_byte & 0x01 == 0x01 {
-                    self.scrolling_up = true;
+                    scrolling_up = true;
                 } else if fourth_byte & 0x01 == 0x0 {
-                    self.scrolling_up = false;
+                    scrolling_up = false;
                 }
             }
         }
+        return Self { right, left, down, up, scrolling_up, scrolling_down }
     }
 }
 

--- a/libs/mouse_data/src/lib.rs
+++ b/libs/mouse_data/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+use modular_bitfield::{bitfield, specifiers::B3};
+
 //NOTE: could be reduced to 9+9+4=22-bit, +2-bit padding = 3*8-bit
 #[derive(Debug, Clone)]
 pub struct MouseMovementRelative {
@@ -18,32 +20,15 @@ impl MouseMovementRelative {
     }
 }
 
-//NOTE: could be reduced to 8-bit
+#[bitfield(bits = 8)]
 #[derive(Debug, Clone)]
 pub struct MouseButtons {
-    pub left_button_hold: bool,
-    pub right_button_hold: bool,
-    pub middle_button_hold: bool,
-    pub fourth_button_hold: bool,
-    pub fifth_button_hold: bool,
-}
-
-impl MouseButtons {
-    pub fn new(
-        left_button_hold: bool,
-        right_button_hold: bool,
-        middle_button_hold: bool,
-        fourth_button_hold: bool,
-        fifth_button_hold: bool,
-    ) -> Self {
-        Self {
-            left_button_hold,
-            right_button_hold,
-            middle_button_hold,
-            fourth_button_hold,
-            fifth_button_hold,
-        }
-    }
+    pub left: bool,
+    pub right: bool,
+    pub middle: bool,
+    pub fourth: bool,
+    pub fifth: bool,
+    #[skip] __: B3
 }
 
 #[derive(Debug, Clone)]

--- a/libs/mouse_data/src/lib.rs
+++ b/libs/mouse_data/src/lib.rs
@@ -20,7 +20,7 @@ impl MouseMovementRelative {
 
 //NOTE: could be reduced to 8-bit
 #[derive(Debug, Clone)]
-pub struct ButtonAction {
+pub struct MouseButtons {
     pub left_button_hold: bool,
     pub right_button_hold: bool,
     pub middle_button_hold: bool,
@@ -28,7 +28,7 @@ pub struct ButtonAction {
     pub fifth_button_hold: bool,
 }
 
-impl ButtonAction {
+impl MouseButtons {
     pub fn new(
         left_button_hold: bool,
         right_button_hold: bool,
@@ -48,15 +48,15 @@ impl ButtonAction {
 
 #[derive(Debug, Clone)]
 pub struct MouseEvent {
-    pub buttonact: ButtonAction,
-    pub mousemove: MouseMovementRelative,
+    pub buttons: MouseButtons,
+    pub movement: MouseMovementRelative,
 }
 
 impl MouseEvent {
-    pub fn new(buttonact: ButtonAction, mousemove: MouseMovementRelative) -> MouseEvent {
+    pub fn new(buttons: MouseButtons, movement: MouseMovementRelative) -> MouseEvent {
         MouseEvent {
-            buttonact,
-            mousemove,
+            buttons,
+            movement,
         }
     }
 }


### PR DESCRIPTION
No more magic values, less errors, more docs, simpler functions, structs for all the response-bits, so no bit ops.
In general, saner code.

Some notes/questions:
- error handling is still not very good, this seems to be because the Error trait is not no_std and some other problems, so for now we have strings, which ~~I would still like to improve a bit~~ I have improved a bit
- why is there a pattern of `.map_err(|_| { warn!("..."); "disable mouse streaming failed"})`? it might make sense because it shows a kind of backtrace-like route up the error stack, but still seems/feels bad? I have read the recommended [reading](https://blog.burntsushi.net/rust-error-handling/), but maybe I should look into some error-handling/logging crates (though I dislike the topic) -> some map_err calls were obsolete, but I'm still not comfortable with some of the error handling, again because we can't impl Error and I wonder in what cases we should just shutdown the system or reset the device/s
- how should I improve my commit messages?
- I chose modular-bitfield because it comes closest to what I would want, [this](https://internals.rust-lang.org/t/pre-rfc-arbitrary-bit-width-integers/15603), or [this](https://therealprof.github.io/blog/roadmap-2021-arbitrary-size-primitives/) -> feedback: I think this is more approachable than bitflags and some others
- not sure if I did `KBD_MODIFIERS` right -> there is a note about "remove unsafe static mut" on it, not sure what to do about it (access is unsafe but there also is a note on access like "it should never race"
- there's a lot of code in the ps2 crate now, any thoughts on where/how to split it up? some functions could also be enum/struct methods instead -> I wasted a lot of time scrolling up and down, still not sure how to divide it up (mod mouse, keyboard, controller?)

Feel free to critique!