### PR TITLE
Set initial sentry value for IA32_TSC_AUX MSR

### DIFF
--- a/kernel/acpi/madt/src/lib.rs
+++ b/kernel/acpi/madt/src/lib.rs
@@ -302,9 +302,12 @@ fn handle_bsp_lapic_entry(madt_iter: MadtIter, page_table: &mut PageTable) -> Re
     use pic::IRQ_BASE_OFFSET;
 
     let me = get_my_apic_id();
+    log::trace!("handle_bsp_lapic_entry(): me: {:#X}", me);
+    log::trace!("handle_bsp_lapic_entry(): before BSP id: {:#X?}", get_bsp_id());
 
     for madt_entry in madt_iter.clone() {
         if let MadtEntry::LocalApic(lapic_entry) = madt_entry { 
+            log::debug!("MadtLocalApic: {:#X?}", lapic_entry);
             if lapic_entry.apic_id == me {
                 let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(lapic_entry.processor, madt_iter.clone());
 
@@ -330,6 +333,8 @@ fn handle_bsp_lapic_entry(madt_iter: MadtIter, page_table: &mut PageTable) -> Re
             }
         }
     }
+
+    log::trace!("handle_bsp_lapic_entry(): BSP id: {:#X?}", get_bsp_id());
 
     let bsp_id = get_bsp_id().ok_or("handle_bsp_lapic_entry(): Couldn't find BSP LocalApic in Madt!")?;
 

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -89,7 +89,10 @@ pub fn get_my_apic_id() -> u8 {
 
 /// Returns a reference to the LocalApic for the currently executing CPU core.
 pub fn get_my_apic() -> Option<&'static RwLockIrqSafe<LocalApic>> {
-    LOCAL_APICS.get(&get_my_apic_id())
+    let apic_id = rdmsr(IA32_TSC_AUX);
+    log::warn!("get_my_apic(): {:#X}", apic_id);
+    let apic_id = apic_id as u8;
+    LOCAL_APICS.get(&apic_id)
 }
 
 
@@ -135,6 +138,8 @@ pub fn init(_page_table: &mut PageTable) -> Result<(), &'static str> {
         // Ensure the local apic is enabled in xapic mode, otherwise we'll get a General Protection fault
         unsafe { wrmsr(IA32_APIC_BASE, rdmsr(IA32_APIC_BASE) | IA32_APIC_XAPIC_ENABLE); }
     }
+
+    log::warn!("apic::init(): BSP apic id: {:#X}", rdmsr(IA32_TSC_AUX));
 
     Ok(())
 }

--- a/kernel/nano_core/src/boot/arch_x86_64/ap_boot.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/ap_boot.asm
@@ -142,6 +142,13 @@ start_high_ap:
 	mov fs, ax
 	mov gs, ax
 
+	; set the IA32_TSC_AUX MSR to a sentry value, in order to prevent
+	; invalid usage of its value before Theseus sets it to the CPU's APIC ID.
+	mov eax, 0xFFFFFFFF
+	mov edx, 0x0
+	mov ecx, 0xc0000103   ; IA32_TSC_AUX MSR
+	wrmsr
+
 	; clear out the FS/GS base MSRs
 	xor eax, eax          ; set to 0
 	xor edx, edx          ; set to 0
@@ -150,13 +157,6 @@ start_high_ap:
 	mov ecx, 0xc0000101   ; GS BASE MSR
 	wrmsr
 	mov ecx, 0xc0000102   ; GS KERNEL BASE MSR
-	wrmsr
-
-	; set the IA32_TSC_AUX MSR to a sentry value, in order to prevent
-	; invalid usage of its value before Theseus sets it to the CPU's APIC ID.
-	mov eax, 0xFFFFFFFF
-	mov edx, 0xFFFFFFFF
-	mov ecx, 0xc0000103   ; IA32_TSC_AUX MSR
 	wrmsr
 	
 	; each character is reversed in the dword cuz of little endianness

--- a/kernel/nano_core/src/boot/arch_x86_64/ap_boot.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/ap_boot.asm
@@ -151,6 +151,13 @@ start_high_ap:
 	wrmsr
 	mov ecx, 0xc0000102   ; GS KERNEL BASE MSR
 	wrmsr
+
+	; set the IA32_TSC_AUX MSR to a sentry value, in order to prevent
+	; invalid usage of its value before Theseus sets it to the CPU's APIC ID.
+	mov eax, 0xFFFFFFFF
+	mov edx, 0xFFFFFFFF
+	mov ecx, 0xc0000103   ; IA32_TSC_AUX MSR
+	wrmsr
 	
 	; each character is reversed in the dword cuz of little endianness
 	mov dword [0xb8048 + KERNEL_OFFSET], 0x4f2E4f2E ; ".."

--- a/kernel/nano_core/src/boot/arch_x86_64/boot.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/boot.asm
@@ -334,6 +334,12 @@ start_high:
 	mov ecx, 0xc0000102   ; GS KERNEL BASE MSR
 	wrmsr
 
+	; set the IA32_TSC_AUX MSR to a sentry value, in order to prevent
+	; invalid usage of its value before Theseus sets it to the CPU's APIC ID.
+	mov eax, 0xFFFFFFFF
+	mov edx, 0xFFFFFFFF
+	mov ecx, 0xc0000103   ; IA32_TSC_AUX MSR
+	wrmsr
 
 	; Save the multiboot address
 	push rdi

--- a/kernel/nano_core/src/boot/arch_x86_64/boot.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/boot.asm
@@ -324,6 +324,14 @@ start_high:
 	mov fs, ax
 	mov gs, ax
 
+	; set the IA32_TSC_AUX MSR to a sentry value, in order to prevent
+	; invalid usage of its value before Theseus sets it to the CPU's APIC ID.
+	mov eax, 0xFFFFFFFF
+	mov edx, 0x0
+	mov ecx, 0xc0000103   ; IA32_TSC_AUX MSR
+	wrmsr
+
+	
 	; clear out the FS/GS base MSRs
 	xor eax, eax          ; set to 0
 	xor edx, edx          ; set to 0
@@ -332,13 +340,6 @@ start_high:
 	mov ecx, 0xc0000101   ; GS BASE MSR
 	wrmsr
 	mov ecx, 0xc0000102   ; GS KERNEL BASE MSR
-	wrmsr
-
-	; set the IA32_TSC_AUX MSR to a sentry value, in order to prevent
-	; invalid usage of its value before Theseus sets it to the CPU's APIC ID.
-	mov eax, 0xFFFFFFFF
-	mov edx, 0xFFFFFFFF
-	mov ecx, 0xc0000103   ; IA32_TSC_AUX MSR
 	wrmsr
 
 	; Save the multiboot address


### PR DESCRIPTION
Ensures that it can't be misinterpreted as a valid APIC ID by early code before APIC initialization has occurred. 

Partial fix for #655; should trigger the issue on x2apic systems, but it's not completely addressed yet.