### PR TITLE
Use `NoDrop` type to ensure early code still runs after errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "kernel_config",
  "log",
  "memory",
+ "no_drop",
  "scheduler",
  "spawn",
  "stack",
@@ -323,6 +324,7 @@ dependencies = [
  "multicore_bringup",
  "multiple_heaps",
  "network_manager",
+ "no_drop",
  "ota_update_client",
  "print",
  "scheduler",
@@ -1696,6 +1698,7 @@ dependencies = [
  "memory_structs",
  "memory_x86_64",
  "multiboot2",
+ "no_drop",
  "page_allocator",
  "page_table_entry",
  "spin 0.9.0",
@@ -1715,6 +1718,7 @@ dependencies = [
  "log",
  "memory",
  "multiboot2",
+ "no_drop",
  "stack",
 ]
 
@@ -1986,6 +1990,7 @@ dependencies = [
  "memory_initialization",
  "mod_mgmt",
  "multiboot2",
+ "no_drop",
  "panic_entry",
  "serial_port_basic",
  "spin 0.9.0",
@@ -2057,6 +2062,10 @@ dependencies = [
  "nic_buffers",
  "owning_ref",
 ]
+
+[[package]]
+name = "no_drop"
+version = "0.1.0"
 
 [[package]]
 name = "ns"
@@ -3002,6 +3011,7 @@ dependencies = [
  "log",
  "memory",
  "mod_mgmt",
+ "no_drop",
  "path",
  "pause",
  "preemption",
@@ -3193,6 +3203,7 @@ dependencies = [
  "log",
  "memory",
  "mod_mgmt",
+ "no_drop",
  "preemption",
  "root",
  "spin 0.9.0",

--- a/kernel/ap_start/Cargo.toml
+++ b/kernel/ap_start/Cargo.toml
@@ -34,6 +34,9 @@ path = "../apic"
 [dependencies.tlb_shootdown]
 path = "../tlb_shootdown"
 
+[dependencies.no_drop]
+path = "../no_drop"
+
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -31,6 +31,9 @@ path = "../first_application"
 [dependencies.memory]
 path = "../memory"
 
+[dependencies.no_drop]
+path = "../no_drop"
+
 [dependencies.stack]
 path = "../stack"
 

--- a/kernel/memory/Cargo.toml
+++ b/kernel/memory/Cargo.toml
@@ -44,5 +44,8 @@ path = "../page_allocator"
 [dependencies.frame_allocator]
 path = "../frame_allocator"
 
+[dependencies.no_drop]
+path = "../no_drop"
+
 [lib]
 crate-type = ["rlib"]

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![feature(ptr_internals)]
 #![feature(unboxed_closures)]
+#![feature(result_option_inspect)]
 
 extern crate spin;
 extern crate multiboot2;
@@ -24,6 +25,7 @@ extern crate page_table_entry;
 extern crate page_allocator;
 extern crate frame_allocator;
 extern crate zerocopy;
+extern crate no_drop;
 
 
 #[cfg(not(mapper_spillful))]
@@ -52,6 +54,7 @@ use spin::Once;
 use irq_safety::MutexIrqSafe;
 use alloc::vec::Vec;
 use alloc::sync::Arc;
+use no_drop::NoDrop;
 use kernel_config::memory::KERNEL_OFFSET;
 pub use kernel_config::memory::PAGE_SIZE;
 
@@ -141,13 +144,13 @@ pub fn init(
     boot_info: &BootInformation
 ) -> Result<(
     PageTable,
+    NoDrop<MappedPages>,
+    NoDrop<MappedPages>,
+    NoDrop<MappedPages>,
+    (AllocatedPages, NoDrop<MappedPages>),
     MappedPages,
-    MappedPages,
-    MappedPages,
-    (AllocatedPages, MappedPages),
-    MappedPages,
-    [Option<MappedPages>; 32],
-    [Option<MappedPages>; 32]
+    [Option<NoDrop<MappedPages>>; 32],
+    [Option<NoDrop<MappedPages>>; 32],
 ), &'static str> {
     // Get the start and end addresses of the kernel, boot info, boot modules, etc.
     let (kernel_phys_start, kernel_phys_end, kernel_virt_end) = get_kernel_address(&boot_info)?;
@@ -212,59 +215,44 @@ pub fn init(
     page_allocator::dump_page_allocator_state();
 
     // Initialize paging, which creates a new page table and maps all of the current code/data sections into it.
-    let (
-        page_table,
-        text_mapped_pages,
-        rodata_mapped_pages,
-        data_mapped_pages,
-        (stack_guard_page, stack_pages),
-        boot_info_pages,
-        higher_half_mapped_pages,
-        identity_mapped_pages
-    ) = paging::init(
-        boot_info,
-        into_alloc_frames_fn,
-    )?;
-
-    debug!("Done with paging::init(). new page_table: {:?}", page_table);
-    Ok((
-        page_table,
-        text_mapped_pages,
-        rodata_mapped_pages,
-        data_mapped_pages,
-        (stack_guard_page, stack_pages),
-        boot_info_pages,
-        higher_half_mapped_pages,
-        identity_mapped_pages
-    ))
+    paging::init(boot_info, into_alloc_frames_fn)
+        .inspect(|(new_page_table, ..)| {
+            debug!("Done with paging::init(). new page table: {:?}", new_page_table);
+        })
 }
 
-/// Finishes initializing the virtual memory management system after the heap is initialized and returns a MemoryManagementInfo instance,
-/// which represents the initial (the kernel's) address space. 
+/// Finishes initializing the memory management system after the heap is ready.
 /// 
-/// Returns the following tuple, if successful:
-///  * The kernel's new MemoryManagementInfo
-///  * The kernel's list of identity-mapped MappedPages which should be dropped before starting the first userspace program. 
+/// Returns the following tuple:
+///  * The kernel's new [`MemoryManagementInfo`], representing the initial virtual address space,
+///  * The kernel's list of identity-mapped [`MappedPages`],
+///    which must not be dropped until all AP (additional CPUs) are fully booted,
+///    but *should* be dropped before starting the first user application. 
 pub fn init_post_heap(
     page_table: PageTable,
-    mut higher_half_mapped_pages: [Option<MappedPages>; 32],
-    mut identity_mapped_pages: [Option<MappedPages>; 32],
+    mut higher_half_mapped_pages: [Option<NoDrop<MappedPages>>; 32],
+    mut identity_mapped_pages: [Option<NoDrop<MappedPages>>; 32],
     heap_mapped_pages: MappedPages
-) -> Result<(MmiRef, Vec<MappedPages>), &'static str> {
-    // HERE: heap is initialized! Can now use alloc types.
-    // After this point, we must "forget" all of the above mapped_pages instances if an error occurs,
-    // because they will be auto-unmapped from the new page table upon return, causing all execution to stop.  
+) -> (MmiRef, NoDrop<Vec<MappedPages>>) {
+    // HERE: heap is initialized! We can now use `alloc` types.
 
     page_allocator::convert_to_heap_allocated();
     frame_allocator::convert_to_heap_allocated();
 
-    let mut higher_half_mapped_pages: Vec<MappedPages> = higher_half_mapped_pages.iter_mut().filter_map(|opt| opt.take()).collect();
+    let mut higher_half_mapped_pages: Vec<MappedPages> = higher_half_mapped_pages
+        .iter_mut()
+        .filter_map(|opt| opt.take().map(NoDrop::into_inner))
+        .collect();
     higher_half_mapped_pages.push(heap_mapped_pages);
-    let identity_mapped_pages: Vec<MappedPages> = identity_mapped_pages.iter_mut().filter_map(|opt| opt.take()).collect();
+    let identity_mapped_pages: Vec<MappedPages> = identity_mapped_pages
+        .iter_mut()
+        .filter_map(|opt| opt.take().map(NoDrop::into_inner))
+        .collect();
+    let identity_mapped_pages = NoDrop::new(identity_mapped_pages);
    
-    // return the kernel's memory info 
+    // Construct the kernel's memory mgmt info, i.e., its address space info
     let kernel_mmi = MemoryManagementInfo {
-        page_table: page_table,
+        page_table,
         extra_mapped_pages: higher_half_mapped_pages,
     };
 
@@ -272,5 +260,5 @@ pub fn init_post_heap(
         Arc::new(MutexIrqSafe::new(kernel_mmi))
     });
 
-    Ok( (kernel_mmi_ref.clone(), identity_mapped_pages) )
+    (kernel_mmi_ref.clone(), identity_mapped_pages)
 }

--- a/kernel/memory/src/paging/mod.rs
+++ b/kernel/memory/src/paging/mod.rs
@@ -29,7 +29,7 @@ use super::{Frame, FrameRange, PageRange, VirtualAddress, PhysicalAddress,
     AllocatedPages, allocate_pages, AllocatedFrames, EntryFlags,
     tlb_flush_all, tlb_flush_virt_addr, get_p4, find_section_memory_bounds,
     get_vga_mem_addr, KERNEL_OFFSET};
-
+use no_drop::NoDrop;
 use kernel_config::memory::{RECURSIVE_P4_INDEX};
 // use kernel_config::memory::{KERNEL_TEXT_P4_INDEX, KERNEL_HEAP_P4_INDEX, KERNEL_STACK_P4_INDEX};
 
@@ -207,13 +207,13 @@ pub fn init(
     into_alloc_frames_fn: fn(FrameRange) -> AllocatedFrames,
 ) -> Result<(
         PageTable,
+        NoDrop<MappedPages>,
+        NoDrop<MappedPages>,
+        NoDrop<MappedPages>,
+        (AllocatedPages, NoDrop<MappedPages>),
         MappedPages,
-        MappedPages,
-        MappedPages,
-        (AllocatedPages, MappedPages),
-        MappedPages,
-        [Option<MappedPages>; 32],
-        [Option<MappedPages>; 32]
+        [Option<NoDrop<MappedPages>>; 32],
+        [Option<NoDrop<MappedPages>>; 32],
     ), &'static str>
 {
     // Store the callback from `frame_allocator::init()` that allows the `Mapper` to convert
@@ -236,13 +236,13 @@ pub fn init(
     let new_p4_frame = frame_allocator::allocate_frames(1).ok_or("couldn't allocate frame for new page table")?; 
     let mut new_table = PageTable::new_table(&mut page_table, new_p4_frame, None)?;
 
-    let mut text_mapped_pages:        Option<MappedPages> = None;
-    let mut rodata_mapped_pages:      Option<MappedPages> = None;
-    let mut data_mapped_pages:        Option<MappedPages> = None;
-    let mut stack_page_group:         Option<(AllocatedPages, MappedPages)> = None;
+    let mut text_mapped_pages:        Option<NoDrop<MappedPages>> = None;
+    let mut rodata_mapped_pages:      Option<NoDrop<MappedPages>> = None;
+    let mut data_mapped_pages:        Option<NoDrop<MappedPages>> = None;
+    let mut stack_page_group:         Option<(AllocatedPages, NoDrop<MappedPages>)> = None;
     let mut boot_info_mapped_pages:   Option<MappedPages> = None;
-    let mut higher_half_mapped_pages: [Option<MappedPages>; 32] = Default::default();
-    let mut identity_mapped_pages:    [Option<MappedPages>; 32] = Default::default();
+    let mut higher_half_mapped_pages: [Option<NoDrop<MappedPages>>; 32] = Default::default();
+    let mut identity_mapped_pages:    [Option<NoDrop<MappedPages>>; 32] = Default::default();
 
     // Create and initialize a new page table with the same contents as the currently-executing kernel code/data sections.
     page_table.with(&mut new_table, |mapper| {
@@ -277,28 +277,28 @@ pub fn init(
         let text_pages = page_allocator::allocate_pages_by_bytes_at(text_start_virt, text_end_virt.value() - text_start_virt.value())?;
         let text_frames = frame_allocator::allocate_frames_by_bytes_at(text_start_phys, text_end_phys.value() - text_start_phys.value())?;
         let text_pages_identity = page_allocator::allocate_pages_by_bytes_at(text_start_virt - KERNEL_OFFSET, text_end_virt.value() - text_start_virt.value())?;
-        identity_mapped_pages[index] = Some( unsafe {
+        identity_mapped_pages[index] = Some(NoDrop::new( unsafe {
             Mapper::map_to_non_exclusive(mapper, text_pages_identity, &text_frames, text_flags)?
-        });
-        text_mapped_pages = Some(mapper.map_allocated_pages_to(text_pages, text_frames, text_flags)?);
+        }));
+        text_mapped_pages = Some(NoDrop::new(mapper.map_allocated_pages_to(text_pages, text_frames, text_flags)?));
         index += 1;
 
         let rodata_pages = page_allocator::allocate_pages_by_bytes_at(rodata_start_virt, rodata_end_virt.value() - rodata_start_virt.value())?;
         let rodata_frames = frame_allocator::allocate_frames_by_bytes_at(rodata_start_phys, rodata_end_phys.value() - rodata_start_phys.value())?;
         let rodata_pages_identity = page_allocator::allocate_pages_by_bytes_at(rodata_start_virt - KERNEL_OFFSET, rodata_end_virt.value() - rodata_start_virt.value())?;
-        identity_mapped_pages[index] = Some( unsafe {
+        identity_mapped_pages[index] = Some(NoDrop::new( unsafe {
             Mapper::map_to_non_exclusive(mapper, rodata_pages_identity, &rodata_frames, rodata_flags)?
-        });
-        rodata_mapped_pages = Some(mapper.map_allocated_pages_to(rodata_pages, rodata_frames, rodata_flags)?);
+        }));
+        rodata_mapped_pages = Some(NoDrop::new(mapper.map_allocated_pages_to(rodata_pages, rodata_frames, rodata_flags)?));
         index += 1;
 
         let data_pages = page_allocator::allocate_pages_by_bytes_at(data_start_virt, data_end_virt.value() - data_start_virt.value())?;
         let data_frames = frame_allocator::allocate_frames_by_bytes_at(data_start_phys, data_end_phys.value() - data_start_phys.value())?;
         let data_pages_identity = page_allocator::allocate_pages_by_bytes_at(data_start_virt - KERNEL_OFFSET, data_end_virt.value() - data_start_virt.value())?;
-        identity_mapped_pages[index] = Some( unsafe {
+        identity_mapped_pages[index] = Some(NoDrop::new( unsafe {
             Mapper::map_to_non_exclusive(mapper, data_pages_identity, &data_frames, data_flags)?
-        });
-        data_mapped_pages = Some(mapper.map_allocated_pages_to(data_pages, data_frames, data_flags)?);
+        }));
+        data_mapped_pages = Some(NoDrop::new(mapper.map_allocated_pages_to(data_pages, data_frames, data_flags)?));
         index += 1;
 
         // We don't need to do any mapping for the initial root (P4) page table stack (a separate data section),
@@ -318,7 +318,7 @@ pub fn init(
             stack_allocated_frames,
             data_flags,
         )?;
-        stack_page_group = Some((stack_guard_page, stack_mapped_pages));
+        stack_page_group = Some((stack_guard_page, NoDrop::new(stack_mapped_pages)));
 
         // Map the VGA display memory as writable. 
         // We do an identity mapping for the VGA display too, because the AP cores may access it while booting.
@@ -327,10 +327,10 @@ pub fn init(
         let vga_display_pages = page_allocator::allocate_pages_by_bytes_at(vga_virt_addr_identity + KERNEL_OFFSET, vga_size_in_bytes)?;
         let vga_display_frames = frame_allocator::allocate_frames_by_bytes_at(vga_phys_addr, vga_size_in_bytes)?;
         let vga_display_pages_identity = page_allocator::allocate_pages_by_bytes_at(vga_virt_addr_identity, vga_size_in_bytes)?;
-        identity_mapped_pages[index] = Some( unsafe {
+        identity_mapped_pages[index] = Some(NoDrop::new( unsafe {
             Mapper::map_to_non_exclusive(mapper, vga_display_pages_identity, &vga_display_frames, vga_flags)?
-        });
-        higher_half_mapped_pages[index] = Some(mapper.map_allocated_pages_to(vga_display_pages, vga_display_frames, vga_flags)?);
+        }));
+        higher_half_mapped_pages[index] = Some(NoDrop::new(mapper.map_allocated_pages_to(vga_display_pages, vga_display_frames, vga_flags)?));
         index += 1;
 
 

--- a/kernel/memory_initialization/Cargo.toml
+++ b/kernel/memory_initialization/Cargo.toml
@@ -5,6 +5,7 @@ description = "Initialization routine for the virtual memory subsystem."
 version = "0.1.0"
 
 [dependencies]
+log = "0.4.8"
 multiboot2 = "0.14.0"
 
 [dependencies.memory]
@@ -13,14 +14,14 @@ path = "../memory"
 [dependencies.stack]
 path = "../stack"
 
+[dependencies.no_drop]
+path = "../no_drop"
+
 [dependencies.kernel_config]
 path = "../kernel_config"
 
 [dependencies.bootloader_modules]
 path = "../bootloader_modules"
-
-[dependencies.log]
-version = "0.4.8"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"

--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -35,6 +35,9 @@ path = "../state_store"
 [dependencies.memory]
 path = "../memory"
 
+[dependencies.no_drop]
+path = "../no_drop"
+
 [dependencies.serial_port_basic]
 path = "../serial_port_basic"
 

--- a/kernel/no_drop/Cargo.toml
+++ b/kernel/no_drop/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "no_drop"
+description = "Simple wrapper type for preventing an object from being dropped"
+version = "0.1.0"

--- a/kernel/no_drop/src/lib.rs
+++ b/kernel/no_drop/src/lib.rs
@@ -3,7 +3,7 @@
 #![no_std]
 
 use core::{
-    // fmt,
+    fmt::{self, Debug},
     mem::ManuallyDrop,
     ops::{Deref, DerefMut}
 };
@@ -15,7 +15,6 @@ use core::{
 /// Auto-derefs to the inner object type `T`.
 ///
 /// To re-take ownership of the object, call [`Self::into_inner()`].
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct NoDrop<T>(ManuallyDrop<T>);
 
@@ -31,6 +30,11 @@ impl<T> NoDrop<T> {
     }
 }
 
+impl<T: Debug> Debug for NoDrop<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.0.deref(), f)
+    }
+}
 impl<T> Deref for NoDrop<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {

--- a/kernel/no_drop/src/lib.rs
+++ b/kernel/no_drop/src/lib.rs
@@ -1,0 +1,44 @@
+//! A simple wrapper that prevents the inner object from being dropped.
+
+#![no_std]
+
+use core::{
+    // fmt,
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut}
+};
+
+/// A wrapper for an inner object that ensures the inner object is never dropped.
+///
+/// This is effectively a safe version of `ManuallyDrop` with a restricted interface.
+/// 
+/// Auto-derefs to the inner object type `T`.
+///
+/// To re-take ownership of the object, call [`Self::into_inner()`].
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct NoDrop<T>(ManuallyDrop<T>);
+
+impl<T> NoDrop<T> {
+    /// Wraps the given `obj` in a `NoDrop` wrapper.
+    pub const fn new(obj: T) -> NoDrop<T> {
+        NoDrop(ManuallyDrop::new(obj))
+    }
+
+    /// Consumes this `NoDrop` wrapper and returns the inner object.
+    pub const fn into_inner(self) -> T {
+        ManuallyDrop::into_inner(self.0)
+    }
+}
+
+impl<T> Deref for NoDrop<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<T> DerefMut for NoDrop<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/kernel/spawn/Cargo.toml
+++ b/kernel/spawn/Cargo.toml
@@ -68,5 +68,8 @@ path = "../thread_local_macro"
 [dependencies.preemption]
 path = "../preemption"
 
+[dependencies.no_drop]
+path = "../no_drop"
+
 [lib]
 crate-type = ["rlib"]

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -33,6 +33,7 @@ use path::Path;
 use apic::get_my_apic_id;
 use fs_node::FileOrDir;
 use preemption::{hold_preemption, PreemptionGuard};
+use no_drop::NoDrop;
 
 #[cfg(simd_personality)]
 use task::SimdExt;
@@ -43,7 +44,7 @@ use task::SimdExt;
 pub fn init(
     kernel_mmi_ref: MmiRef,
     apic_id: u8,
-    stack: Stack,
+    stack: NoDrop<Stack>,
 ) -> Result<BootstrapTaskRef, &'static str> {
     runqueue::init(apic_id)?;
     

--- a/kernel/task/Cargo.toml
+++ b/kernel/task/Cargo.toml
@@ -44,6 +44,9 @@ path = "../environment"
 [dependencies.root]
 path = "../root"
 
+[dependencies.no_drop]
+path = "../no_drop"
+
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -1271,7 +1271,7 @@ pub fn bootstrap_task(
         error!("BUG: bootstrap_task(): failed to properly set the new boostrapped task as the current task on AP {}", apic_id);
         // Don't drop the bootstrap task upon error, because it contains the stack
         // used for the currently running code -- that would trigger an exception.
-        core::mem::forget(task_ref);
+        let _task_ref = NoDrop::new(task_ref);
         return Err("BUG: bootstrap_task(): failed to properly set the new bootstrapped task as the current task");
     }
 


### PR DESCRIPTION
Simplifies the error handling code such that we cannot possibly make the mistake of incorrectly dropping a key memory mapping that represents the currently-executing code/data/stack upon early return after an error.

Also includes various cleanup of said error handling code and documentation.