### PR TITLE
Redesign `TaskRef`

### DIFF
--- a/applications/channel_eval/src/lib.rs
+++ b/applications/channel_eval/src/lib.rs
@@ -96,8 +96,8 @@ fn test_multiple(iterations: usize) -> Result<(), &'static str> {
         .spawn()?;
 
     info!("test_multiple(): Finished spawning the sender and receiver tasks");
-    t2.unblock().unwrap();
-    t1.unblock().unwrap();
+    let t2 = t2.unblock().unwrap();
+    let t1 = t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;

--- a/applications/channel_eval/src/lib.rs
+++ b/applications/channel_eval/src/lib.rs
@@ -96,7 +96,8 @@ fn test_multiple(iterations: usize) -> Result<(), &'static str> {
         .spawn()?;
 
     info!("test_multiple(): Finished spawning the sender and receiver tasks");
-    t2.unblock(); t1.unblock();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;

--- a/applications/rq_eval/src/lib.rs
+++ b/applications/rq_eval/src/lib.rs
@@ -157,7 +157,7 @@ fn run_single(iterations: usize) -> Result<(), &'static str> {
         |_, _| loop { }, // dummy failure function
     )?;
     task.name = String::from("rq_eval_single_task_unrunnable");
-    let taskref = TaskRef::new(task);
+    let taskref = task.init();
     
     let hpet = get_hpet().ok_or("couldn't get HPET timer")?;
     let start = hpet.get_counter();
@@ -168,13 +168,13 @@ fn run_single(iterations: usize) -> Result<(), &'static str> {
         #[cfg(runqueue_spillful)] {   
             if let Some(remove_from_runqueue) = task::RUNQUEUE_REMOVAL_FUNCTION.get() {
                 if let Some(rq) = taskref.on_runqueue() {
-                    remove_from_runqueue(&taskref, rq)?;
+                    remove_from_runqueue(&taskref.clone(), rq)?;
                 }
             }
         }
         #[cfg(not(runqueue_spillful))]
         {
-            runqueue::remove_task_from_all(&taskref)?;
+            runqueue::remove_task_from_all(&taskref.clone())?;
         }
     }
 

--- a/applications/rq_eval/src/lib.rs
+++ b/applications/rq_eval/src/lib.rs
@@ -36,7 +36,7 @@ use alloc::{
 };
 use getopts::{Matches, Options};
 use hpet::get_hpet;
-use task::{Task, TaskRef};
+use task::Task;
 use libtest::{hpet_timing_overhead, hpet_2_us};
 
 

--- a/applications/scheduler_eval/src/lib.rs
+++ b/applications/scheduler_eval/src/lib.rs
@@ -16,7 +16,7 @@ pub fn main(_args: Vec<String>) -> (){
         .pin_on_core(1)
         .spawn().expect("failed to initiate task");
 
-    if let Err(e) = scheduler::set_priority(&taskref1, 30) {
+    if let Err(e) = scheduler::set_priority(&taskref1.clone(), 30) {
         error!("scheduler_eval(): Could not set priority to taskref1: {}", e);
     }
 
@@ -27,7 +27,7 @@ pub fn main(_args: Vec<String>) -> (){
         .pin_on_core(1)
         .spawn().expect("failed to initiate task");
 
-    if let Err(e) = scheduler::set_priority(&taskref2, 20) {
+    if let Err(e) = scheduler::set_priority(&taskref2.clone(), 20) {
         error!("scheduler_eval(): Could not set priority to taskref2: {}", e);
     }
 
@@ -38,7 +38,7 @@ pub fn main(_args: Vec<String>) -> (){
         .pin_on_core(1)
         .spawn().expect("failed to initiate task");
 
-    if let Err(e) = scheduler::set_priority(&taskref3, 10) {
+    if let Err(e) = scheduler::set_priority(&taskref3.clone(), 10) {
         error!("scheduler_eval(): Could not set priority to taskref3: {}", e);
     }
 
@@ -46,9 +46,9 @@ pub fn main(_args: Vec<String>) -> (){
 
     debug!("Spawned all tasks");
 
-    let _priority1 = scheduler::get_priority(&taskref1);
-    let _priority2 = scheduler::get_priority(&taskref2);
-    let _priority3 = scheduler::get_priority(&taskref3);
+    let _priority1 = scheduler::get_priority(&taskref1.clone());
+    let _priority2 = scheduler::get_priority(&taskref2.clone());
+    let _priority3 = scheduler::get_priority(&taskref3.clone());
 
     #[cfg(priority_scheduler)]
     {

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -1419,9 +1419,11 @@ impl Shell {
             if let Ok(job_num) = job_num.parse::<isize>() {
                 if let Some(job) = self.jobs.get_mut(&job_num) {
                     for task_ref in &job.tasks {
-                        let _ = task_ref.unblock();
-                        // TODO: Do we want to set the job status of an exited task to running?
-                        job.status = JobStatus::Running;
+                        if let Err(_) = task_ref.unblock() {
+                            job.status = JobStatus::Stopped;
+                        } else {
+                            job.status = JobStatus::Running;
+                        }
                     }
                     self.clear_cmdline(false)?;
                     self.redisplay_prompt();
@@ -1451,9 +1453,11 @@ impl Shell {
                 if let Some(job) = self.jobs.get_mut(&job_num) {
                     self.fg_job_num = Some(job_num);
                     for task_ref in &job.tasks {
-                        let _ = task_ref.unblock();
-                        // TODO: Do we want to set the job status of an exited task to running?
-                        job.status = JobStatus::Running;
+                        if let Err(_) = task_ref.unblock() {
+                            job.status = JobStatus::Stopped;
+                        } else {
+                            job.status = JobStatus::Running;
+                        }
                     }
                     return Ok(());
                 }

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -28,7 +28,7 @@ extern crate libterm;
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate log;
 
-use event_types::{Event};
+use event_types::Event;
 use keycodes_ascii::{Keycode, KeyAction, KeyEvent};
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
@@ -109,7 +109,7 @@ pub fn main(_args: Vec<String>) -> isize {
     loop {
         // block this task, because it never needs to actually run again
         if let Some(my_task) = task::get_my_current_task() {
-            my_task.block();
+            my_task.block().unwrap();
         }
     }
 
@@ -462,8 +462,9 @@ impl Shell {
                 app_io::lock_and_execute(&|_flags_guard, _streams_guard| {
                     // Stop all tasks in the job.
                     for task_ref in task_refs {
-                        if task_ref.has_exited() { continue; }
-                        task_ref.block();
+                        if task_ref.block().is_err() {
+                            continue;
+                        }
 
                         // Here we must wait for the running application to stop before releasing the lock,
                         // because the previous `block` method will NOT stop the application immediately.
@@ -770,7 +771,7 @@ impl Shell {
 
                 // All IO streams have been set up for the new tasks. Safe to unblock them now.
                 for task_ref in &new_job.tasks {
-                    task_ref.unblock();
+                    task_ref.unblock().unwrap();
                 }
 
                 // Allocate a job number for the new job. It will start from 1 and choose the smallest number
@@ -1418,9 +1419,8 @@ impl Shell {
             if let Ok(job_num) = job_num.parse::<isize>() {
                 if let Some(job) = self.jobs.get_mut(&job_num) {
                     for task_ref in &job.tasks {
-                        if !task_ref.has_exited() {
-                            task_ref.unblock();
-                        }
+                        let _ = task_ref.unblock();
+                        // TODO: Do we want to set the job status of an exited task to running?
                         job.status = JobStatus::Running;
                     }
                     self.clear_cmdline(false)?;
@@ -1451,9 +1451,8 @@ impl Shell {
                 if let Some(job) = self.jobs.get_mut(&job_num) {
                     self.fg_job_num = Some(job_num);
                     for task_ref in &job.tasks {
-                        if !task_ref.has_exited() {
-                            task_ref.unblock();
-                        }
+                        let _ = task_ref.unblock();
+                        // TODO: Do we want to set the job status of an exited task to running?
                         job.status = JobStatus::Running;
                     }
                     return Ok(());

--- a/applications/test_channel/src/lib.rs
+++ b/applications/test_channel/src/lib.rs
@@ -182,7 +182,8 @@ fn rendezvous_test_oneshot() -> Result<(), &'static str> {
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("rendezvous_test_oneshot(): Finished spawning the sender and receiver tasks");
-    t2.unblock(); t1.unblock();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -213,7 +214,8 @@ fn rendezvous_test_multiple(send_count: usize, receive_count: usize, send_panic:
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("rendezvous_test_multiple(): Finished spawning the sender and receiver tasks");
-    t2.unblock(); t1.unblock();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -306,7 +308,8 @@ fn asynchronous_test_oneshot() -> Result<(), &'static str> {
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("asynchronous_test_oneshot(): Finished spawning the sender and receiver tasks");
-    t2.unblock(); t1.unblock();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -335,7 +338,8 @@ fn asynchronous_test_multiple(send_count: usize, receive_count: usize, send_pani
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("asynchronous_test_multiple(): Finished spawning the sender and receiver tasks");
-    t2.unblock(); t1.unblock();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;

--- a/applications/test_channel/src/lib.rs
+++ b/applications/test_channel/src/lib.rs
@@ -182,8 +182,8 @@ fn rendezvous_test_oneshot() -> Result<(), &'static str> {
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("rendezvous_test_oneshot(): Finished spawning the sender and receiver tasks");
-    t2.unblock().unwrap();
-    t1.unblock().unwrap();
+    let t2 = t2.unblock().unwrap();
+    let t1 = t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -214,8 +214,8 @@ fn rendezvous_test_multiple(send_count: usize, receive_count: usize, send_panic:
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("rendezvous_test_multiple(): Finished spawning the sender and receiver tasks");
-    t2.unblock().unwrap();
-    t1.unblock().unwrap();
+    let t2 = t2.unblock().unwrap();
+    let t1 = t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -308,8 +308,8 @@ fn asynchronous_test_oneshot() -> Result<(), &'static str> {
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("asynchronous_test_oneshot(): Finished spawning the sender and receiver tasks");
-    t2.unblock().unwrap();
-    t1.unblock().unwrap();
+    let t2 = t2.unblock().unwrap();
+    let t1 = t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -338,8 +338,8 @@ fn asynchronous_test_multiple(send_count: usize, receive_count: usize, send_pani
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
     warn!("asynchronous_test_multiple(): Finished spawning the sender and receiver tasks");
-    t2.unblock().unwrap();
-    t1.unblock().unwrap();
+    let t2 = t2.unblock().unwrap();
+    let t1 = t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;

--- a/applications/test_mutex_sleep/src/lib.rs
+++ b/applications/test_mutex_sleep/src/lib.rs
@@ -59,7 +59,9 @@ fn test_contention() -> Result<(), &'static str> {
 
     warn!("Finished spawning the 3 tasks");
 
-    t3.unblock(); t2.unblock(); t1.unblock();
+    t3.unblock().unwrap();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -115,7 +117,9 @@ fn test_lockstep() -> Result<(), &'static str> {
 
     warn!("Finished spawning the 3 tasks");
 
-    t3.unblock(); t2.unblock(); t1.unblock();
+    t3.unblock().unwrap();
+    t2.unblock().unwrap();
+    t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;

--- a/applications/test_mutex_sleep/src/lib.rs
+++ b/applications/test_mutex_sleep/src/lib.rs
@@ -59,9 +59,9 @@ fn test_contention() -> Result<(), &'static str> {
 
     warn!("Finished spawning the 3 tasks");
 
-    t3.unblock().unwrap();
-    t2.unblock().unwrap();
-    t1.unblock().unwrap();
+    let t3 = t3.unblock().unwrap();
+    let t2 = t2.unblock().unwrap();
+    let t1 = t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
@@ -117,9 +117,9 @@ fn test_lockstep() -> Result<(), &'static str> {
 
     warn!("Finished spawning the 3 tasks");
 
-    t3.unblock().unwrap();
-    t2.unblock().unwrap();
-    t1.unblock().unwrap();
+    let t3 = t3.unblock().unwrap();
+    let t2 = t2.unblock().unwrap();
+    let t1 = t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;

--- a/applications/test_realtime/src/lib.rs
+++ b/applications/test_realtime/src/lib.rs
@@ -42,7 +42,7 @@ pub fn main(_args: Vec<String>) -> isize {
         scheduler::set_periodicity(&periodic_task_1, 1000).unwrap();
 
         // start the tasks
-        periodic_task_1.unblock();
+        periodic_task_1.unblock().unwrap();
 
         0
     }

--- a/applications/test_realtime/src/lib.rs
+++ b/applications/test_realtime/src/lib.rs
@@ -57,6 +57,6 @@ fn _task_delay_tester(_arg: usize) {
         iter += 1;
 
         // This desk will sleep periodically for 1000 systicks
-        sleep::sleep_periodic(&start_time, 1000);
+        sleep::sleep_periodic(&start_time, 1000).unwrap();
     }
 }

--- a/applications/test_wait_queue/src/lib.rs
+++ b/applications/test_wait_queue/src/lib.rs
@@ -55,7 +55,7 @@ fn rmain() -> Result<(), &'static str> {
     let t3 = spawn::new_task_builder(
         |tref| {
             warn!("DeezNutz:  testing spurious wakeup on task {:?}", tref);
-            tref.unblock();
+            tref.unblock().unwrap();
         }, 
         t1.clone(),
         )
@@ -68,10 +68,10 @@ fn rmain() -> Result<(), &'static str> {
 
     // give the wait task (t1) a chance to run before the notify task
     for _ in 0..100 { scheduler::schedule(); }
-    t3.unblock();
+    t3.unblock().unwrap();
     
     for _ in 0..100 { scheduler::schedule(); }
-    t2.unblock();
+    t2.unblock().unwrap();
 
 
     t1.join()?;

--- a/applications/test_wait_queue/src/lib.rs
+++ b/applications/test_wait_queue/src/lib.rs
@@ -55,7 +55,8 @@ fn rmain() -> Result<(), &'static str> {
     let t3 = spawn::new_task_builder(
         |tref| {
             warn!("DeezNutz:  testing spurious wakeup on task {:?}", tref);
-            tref.unblock().unwrap();
+            // FIXME (tsoutsman): Unblock without a guard?
+            // tref.unblock().unwrap();
         }, 
         t1.clone(),
         )
@@ -68,10 +69,10 @@ fn rmain() -> Result<(), &'static str> {
 
     // give the wait task (t1) a chance to run before the notify task
     for _ in 0..100 { scheduler::schedule(); }
-    t3.unblock().unwrap();
+    let t3 = t3.unblock().unwrap();
     
     for _ in 0..100 { scheduler::schedule(); }
-    t2.unblock().unwrap();
+    let t2 = t2.unblock().unwrap();
 
 
     t1.join()?;

--- a/kernel/console/src/lib.rs
+++ b/kernel/console/src/lib.rs
@@ -18,7 +18,7 @@ extern crate text_terminal;
 
 use core::{marker::PhantomData, sync::atomic::{AtomicU16, Ordering}};
 use alloc::string::String;
-use task::JoinableTaskRef;
+use task::TaskRef;
 use async_channel::Receiver;
 use serial_port::{SerialPort, SerialPortAddress, get_serial_port, DataChunk};
 use io::LockableIo;
@@ -40,7 +40,7 @@ pub fn ignore_serial_port_input(serial_port_address: u16) {
 /// by waiting for new data to be received on serial ports.
 ///
 /// Returns the newly-spawned detection task.
-pub fn start_connection_detection() -> Result<JoinableTaskRef, &'static str> {
+pub fn start_connection_detection() -> Result<TaskRef<true>, &'static str> {
 	let (sender, receiver) = async_channel::new_channel(4);
 	serial_port::set_connection_listener(sender);
 

--- a/kernel/deferred_interrupt_tasks/src/lib.rs
+++ b/kernel/deferred_interrupt_tasks/src/lib.rs
@@ -171,7 +171,10 @@ fn deferred_task_entry_point<DIA, Arg, Success, Failure>(
             Err(failure) => error!("Deferred interrupt action returned failure: {:?}", debugit!(failure)),
         }
 
-        curr_task.block().expect("BUG: deffered_task_entry_point: couldn't block task");
+        if curr_task.block().is_err() {
+            error!("deffered_task_entry_point: couldn't block task");
+        }
+
         scheduler::schedule();
     }
 }

--- a/kernel/deferred_interrupt_tasks/src/lib.rs
+++ b/kernel/deferred_interrupt_tasks/src/lib.rs
@@ -171,7 +171,7 @@ fn deferred_task_entry_point<DIA, Arg, Success, Failure>(
             Err(failure) => error!("Deferred interrupt action returned failure: {:?}", debugit!(failure)),
         }
 
-        curr_task.block();
+        curr_task.block().expect("BUG: deffered_task_entry_point: couldn't block task");
         scheduler::schedule();
     }
 }

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -187,7 +187,8 @@ impl SerialPort {
                     Ok(SerialPortAddress::COM1 | SerialPortAddress::COM3) => {
                         INTERRUPT_ACTION_COM1_COM3.call_once(|| 
                             Box::new(move || {
-                                deferred_task.unblock()
+                                // FIXME
+                                unsafe { deferred_task.clone().into_kind::<false, true>().unblock() }
                                     .expect("BUG: com_1_com3_interrupt_handler: couldn't unblock deferred task");
                             })
                         );
@@ -195,7 +196,8 @@ impl SerialPort {
                     Ok(SerialPortAddress::COM2 | SerialPortAddress::COM4) => {
                         INTERRUPT_ACTION_COM2_COM4.call_once(|| 
                             Box::new(move || {
-                                deferred_task.unblock()
+                                // FIXME
+                                unsafe { deferred_task.clone().into_kind::<false, true>().unblock() }
                                     .expect("BUG: com_2_com4_interrupt_handler: couldn't unblock deferred task");
                             })
                         );

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -187,8 +187,7 @@ impl SerialPort {
                     Ok(SerialPortAddress::COM1 | SerialPortAddress::COM3) => {
                         INTERRUPT_ACTION_COM1_COM3.call_once(|| 
                             Box::new(move || {
-                                deferred_task
-                                    .unblock()
+                                deferred_task.unblock()
                                     .expect("BUG: com_1_com3_interrupt_handler: couldn't unblock deferred task");
                             })
                         );
@@ -196,8 +195,7 @@ impl SerialPort {
                     Ok(SerialPortAddress::COM2 | SerialPortAddress::COM4) => {
                         INTERRUPT_ACTION_COM2_COM4.call_once(|| 
                             Box::new(move || {
-                                deferred_task
-                                    .unblock()
+                                deferred_task.unblock()
                                     .expect("BUG: com_2_com4_interrupt_handler: couldn't unblock deferred task");
                             })
                         );

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -186,12 +186,20 @@ impl SerialPort {
                 match SerialPortAddress::try_from(base_port) {
                     Ok(SerialPortAddress::COM1 | SerialPortAddress::COM3) => {
                         INTERRUPT_ACTION_COM1_COM3.call_once(|| 
-                            Box::new(move || { deferred_task.unblock(); })
+                            Box::new(move || {
+                                deferred_task
+                                    .unblock()
+                                    .expect("BUG: com_1_com3_interrupt_handler: couldn't unblock deferred task");
+                            })
                         );
                     }
                     Ok(SerialPortAddress::COM2 | SerialPortAddress::COM4) => {
                         INTERRUPT_ACTION_COM2_COM4.call_once(|| 
-                            Box::new(move || { deferred_task.unblock(); })
+                            Box::new(move || {
+                                deferred_task
+                                    .unblock()
+                                    .expect("BUG: com_2_com4_interrupt_handler: couldn't unblock deferred task");
+                            })
                         );
                     }
                     Err(_) => warn!("Registering interrupt handler for unknown serial port at {:#X}", base_port),

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -88,7 +88,7 @@ fn add_to_delayed_tasklist(new_node: SleepingTaskNode) {
 fn remove_next_task_from_delayed_tasklist() {
     let mut delayed_tasklist = DELAYED_TASKLIST.lock();
     if let Some(SleepingTaskNode { taskref, .. }) = delayed_tasklist.pop() {
-        let _ = taskref.unblock();
+        taskref.unblock().expect("failed to unblock sleeping task");
 
         match delayed_tasklist.peek() {
             Some(SleepingTaskNode { resume_time, .. }) => 

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -18,7 +18,7 @@ extern crate scheduler;
 use core::sync::atomic::{Ordering, AtomicUsize};
 use alloc::collections::binary_heap::BinaryHeap;
 use irq_safety::MutexIrqSafe;
-use task::{get_my_current_task, TaskRef};
+use task::{get_my_current_task, TaskRef, RunState};
 
 /// Contains the `TaskRef` and the associated wakeup time for an entry in DELAYED_TASKLIST.
 #[derive(Clone, Eq, PartialEq)]
@@ -108,29 +108,38 @@ pub fn unblock_sleeping_tasks() {
 }
 
 /// Blocks the current task by putting it to sleep for `duration` ticks.
-pub fn sleep(duration: usize) {
+///
+/// Returns the current task's run state if it can't be blocked.
+pub fn sleep(duration: usize) -> Result<(), RunState> {
     let current_tick_count = TICK_COUNT.load(Ordering::SeqCst);
     let resume_time = current_tick_count + duration;
 
     let current_task = get_my_current_task().unwrap().clone();
     // Add the current task to the delayed tasklist and then block it.
     add_to_delayed_tasklist(SleepingTaskNode{taskref: current_task.clone(), resume_time});
-    current_task.block().unwrap();
+    current_task.block()?;
     scheduler::schedule();
+    Ok(())
 }
 
 /// Blocks the current task by putting it to sleep until a specific tick count is reached,
 /// given by `resume_time`.
-pub fn sleep_until(resume_time: usize) {
+///
+/// Returns the current task's run state if it can't be blocked.
+pub fn sleep_until(resume_time: usize) -> Result<(), RunState> {
     let current_tick_count = TICK_COUNT.load(Ordering::SeqCst);
 
     if resume_time > current_tick_count {
-        sleep(resume_time - current_tick_count);
+        sleep(resume_time - current_tick_count)?;
     }
+    
+    Ok(())
 }
 
 /// Blocks the current task for a fixed time `period`, which starts from the given `last_resume_time`.
-pub fn sleep_periodic(last_resume_time: &AtomicUsize, period: usize) {
+///
+/// Returns the current task's run state if it can't be blocked.
+pub fn sleep_periodic(last_resume_time: &AtomicUsize, period: usize) -> Result<(), RunState> {
     let new_resume_time = last_resume_time.fetch_add(period, Ordering::SeqCst) + period;
-    sleep_until(new_resume_time);
+    sleep_until(new_resume_time)
 }

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -119,15 +119,14 @@ pub fn sleep(duration: usize) -> Result<(), ()> {
     // condition present because we do not hold the lock on DELAYED_TASKLIST for
     // the duration of run_and_block. However, this is ok as unblock_sleeping_tasks
     // is called at regular intervals by the LAPIC timer interrupt handler.
-    unsafe {
-        current_task.run_and_block(|taskref| {
+    current_task
+        .run_and_block(|taskref| {
             add_to_delayed_tasklist(SleepingTaskNode {
                 taskref,
                 resume_time,
             });
         })
-    }
-    .map_err(|_| ())?;
+        .map_err(|_| ())?;
     scheduler::schedule();
     Ok(())
 }

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -115,8 +115,10 @@ pub fn sleep(duration: usize) -> Result<(), ()> {
     let resume_time = current_tick_count + duration;
 
     let current_task = get_my_current_task().unwrap().clone();
-    // Add the current task to the delayed tasklist and then block it.
-    // SAFETY: add_to_delayed_tasklist doesn't drop taskref.
+    // SAFETY: add_to_delayed_tasklist doesn't drop taskref. There is a race
+    // condition present because we do not hold the lock on DELAYED_TASKLIST for
+    // the duration of run_and_block. However, this is ok as unblock_sleeping_tasks
+    // is called at regular intervals by the LAPIC timer interrupt handler.
     unsafe {
         current_task.run_and_block(|taskref| {
             add_to_delayed_tasklist(SleepingTaskNode {

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -88,7 +88,7 @@ fn add_to_delayed_tasklist(new_node: SleepingTaskNode) {
 fn remove_next_task_from_delayed_tasklist() {
     let mut delayed_tasklist = DELAYED_TASKLIST.lock();
     if let Some(SleepingTaskNode { taskref, .. }) = delayed_tasklist.pop() {
-        taskref.unblock();
+        let _ = taskref.unblock();
 
         match delayed_tasklist.peek() {
             Some(SleepingTaskNode { resume_time, .. }) => 
@@ -115,7 +115,7 @@ pub fn sleep(duration: usize) {
     let current_task = get_my_current_task().unwrap().clone();
     // Add the current task to the delayed tasklist and then block it.
     add_to_delayed_tasklist(SleepingTaskNode{taskref: current_task.clone(), resume_time});
-    current_task.block();
+    current_task.block().unwrap();
     scheduler::schedule();
 }
 

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -356,9 +356,9 @@ impl<F, A, R> TaskBuilder<F, A, R>
 
         // The new task is ready to be scheduled in, now that its stack trampoline has been set up.
         if self.blocked {
-            new_task.block();
+            new_task.block().unwrap();
         } else {
-            new_task.unblock();
+            new_task.unblock().unwrap();
         }
 
         // The new task is marked as idle

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -356,9 +356,9 @@ impl<F, A, R> TaskBuilder<F, A, R>
 
         // The new task is ready to be scheduled in, now that its stack trampoline has been set up.
         if self.blocked {
-            new_task.block().unwrap();
+            new_task.block_initing_task().unwrap();
         } else {
-            new_task.unblock().unwrap();
+            new_task.unblock_initing_task().unwrap();
         }
 
         // The new task is marked as idle

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -373,10 +373,10 @@ impl<F, A, R, const BLOCKED: bool> TaskBuilder<F, A, R, BLOCKED>
         // blocked variant. The type system isn't smart enough to recognise it.
         let task_ref: TaskRef<true, BLOCKED> = if BLOCKED {
             let task_ref: TaskRef<true, true> = new_task.init();
-            unsafe { task_ref.into_kind() }
+            task_ref.into_kind()
         } else {
             let task_ref: TaskRef<true, false> = new_task.init().unblock().map_err(|_| "BUG: TaskBuilder::spawn() couldn't unblock new_task")?;
-            unsafe { task_ref.into_kind() }
+            task_ref.into_kind()
         };
 
         let _existing_task = TASKLIST.lock().insert(task_ref.id, task_ref.clone());

--- a/kernel/task/src/block.rs
+++ b/kernel/task/src/block.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+pub struct BlockGuard {
+    task: TaskRef,
+}
+
+impl BlockGuard {
+    pub(crate) fn new(task: TaskRef) -> Self {
+        Self {
+            task
+        }
+    }
+
+    #[must_use]
+    pub fn drop(self) -> bool {
+        use RunState::{Blocked, Runnable};
+
+        if self.task.runstate.compare_exchange(Blocked, Runnable).is_ok() {
+            true
+        } else if self.task.runstate.compare_exchange(Runnable, Runnable).is_ok() {
+            warn!("Task::unblock(): unblocked an already unblocked task");
+            true
+        } else {
+            false
+        }
+    }
+}
+

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -47,6 +47,8 @@ extern crate spin;
 extern crate kernel_config;
 extern crate crossbeam_utils;
 
+mod rref;
+pub use rref::TaskRef;
 
 use core::{
     any::Any,
@@ -63,7 +65,7 @@ use alloc::{
     sync::Arc,
 };
 use crossbeam_utils::atomic::AtomicCell;
-use irq_safety::{MutexIrqSafe, interrupts_enabled, hold_interrupts};
+use irq_safety::{MutexIrqSafe, hold_interrupts};
 use memory::MmiRef;
 use stack::Stack;
 use kernel_config::memory::KERNEL_STACK_SIZE_IN_PAGES;
@@ -1105,6 +1107,3 @@ pub fn get_my_current_task() -> Option<&'static TaskRef> {
 pub fn get_my_current_task_id() -> Option<usize> {
     get_task_local_data().map(|tld| tld.task_id)
 }
-
-pub mod rref;
-pub use rref::*;

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -5,7 +5,7 @@
 //! 
 //! # Examples
 //! How to wait for a `Task` to complete (using `join()`) and get its exit value.
-//! ```
+//! ```no_compile // FIXME
 //! taskref.join(); // taskref is the task that we're waiting on
 //! if let Some(exit_result) = taskref.take_exit_value() {
 //!     match exit_result {

--- a/kernel/task/src/rref.rs
+++ b/kernel/task/src/rref.rs
@@ -1,0 +1,296 @@
+use super::*;
+
+// /// Represents a joinable [`TaskRef`], created by [`TaskRef::new()`].
+// /// Auto-derefs into a [`TaskRef`].
+// ///
+// /// This allows another task to:
+// /// * [`join`] this task, i.e., wait for this task to finish executing,
+// /// * to obtain its [exit value] after it has completed.
+// ///
+// /// ## [`Drop`]-based Behavior
+// /// The contained [`Task`] is joinable until this object is dropped.
+// /// When dropped, this task will be marked as non-joinable and treated as an "orphan" task.
+// /// This means that there is no way for another task to wait for it to complete
+// /// or obtain its exit value.
+// /// As such, this task will be auto-reaped after it exits (in order to avoid zombie tasks).
+// ///
+// /// ## Not `Clone`-able
+// /// Due to the above drop-based behavior, this type must not implement `Clone`
+// /// because it assumes there is only ever one `JoinableTaskRef` per task.
+// ///
+// /// However, this type auto-derefs into an inner [`TaskRef`], which *can* be cloned.
+// ///
+// // /// Note: this type is considered an internal implementation detail.
+// // /// Instead, use the `TaskJoiner` type from the `spawn` crate,
+// // /// which is intended to be the public-facing interface for joining a task.
+
+/// A shareable, cloneable reference to a `Task` that exposes more methods
+/// for task management and auto-derefs into an immutable `&Task` reference.
+///
+/// The `TaskRef` type is necessary because in many places across Theseus,
+/// a reference to a Task is used.
+/// For example, task lists, task spawning, task management, scheduling, etc.
+///
+/// ## Equality comparisons
+/// `TaskRef` implements the [`PartialEq`] and [`Eq`] traits to ensure that
+/// two `TaskRef`s are considered equal if they point to the same underlying `Task`.
+#[derive(Debug)]
+pub struct TaskRef<const JOINABLE: bool = false, const UNBLOCKABLE: bool = false> {
+    pub(crate) task: Arc<Task>,
+}
+
+assert_not_impl_any!(TaskRef<true, false>: Clone);
+assert_not_impl_any!(TaskRef<true, true>: Clone);
+
+impl<const JOINABLE: bool, const UNBLOCKABLE: bool> PartialEq for TaskRef<JOINABLE, UNBLOCKABLE> {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.task, &other.task)
+    }
+}
+
+impl<const JOINABLE: bool, const UNBLOCKABLE: bool> Eq for TaskRef<JOINABLE, UNBLOCKABLE> {}
+
+impl<const JOINABLE: bool, const UNBLOCKABLE: bool> Hash for TaskRef<JOINABLE, UNBLOCKABLE> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.task).hash(state);
+    }
+}
+
+impl<const JOINABLE: bool, const UNBLOCKABLE: bool> Deref for TaskRef<JOINABLE, UNBLOCKABLE> {
+    type Target = Task;
+
+    fn deref(&self) -> &Self::Target {
+        self.task.deref()
+    }
+}
+
+// There is one impostor among us.
+impl<const JOINABLE: bool, const UNBLOCKABLE: bool> TaskRef<JOINABLE, UNBLOCKABLE> {
+    pub fn clone(&self) -> TaskRef<false, false> {
+        TaskRef {
+            task: self.task.clone(),
+        }
+    }
+}
+
+impl Clone for TaskRef<false, false> {
+    fn clone(&self) -> Self {
+        Self {
+            task: self.task.clone(),
+        }
+    }
+}
+
+// / Creates a new `TaskRef`, a shareable wrapper around the given `Task`.
+// /
+// / This function also initializes the given `Task`'s `TaskLocalData` struct,
+// / which will be used to determine the current `Task` on each CPU.
+// /
+// / It does *not* add this task to the system-wide task list or any runqueues,
+// / nor does it schedule this task in.
+// /
+// / ## Return
+// / Returns a [`JoinableTaskRef`], which derefs into the newly-created `TaskRef`
+// / and can be used to "join" this task (wait for it to exit) and obtain its exit value.
+
+impl<const JOINABLE: bool, const UNBLOCKABLE: bool> TaskRef<JOINABLE, UNBLOCKABLE> {
+    // FIXME: Why can non-joinable task refs join??
+
+    /// Blocks until this task has exited or has been killed.
+    ///
+    /// Returns `Ok()` once this task has exited,
+    /// and `Err()` if there is a problem or interruption while waiting for it to exit.
+    ///
+    /// # Note
+    /// * You cannot call `join()` on the current thread, because a thread cannot wait for itself to finish running.
+    ///   This will result in an `Err()` being immediately returned.
+    /// * You cannot call `join()` with interrupts disabled, because it will result in permanent deadlock
+    ///   (well, this is only true if the requested `task` is running on the same cpu...  but good enough for now).
+    pub fn join(&self) -> Result<(), &'static str> {
+        let curr_task =
+            get_my_current_task().ok_or("join(): failed to check what current task is")?;
+        if Arc::ptr_eq(&self.task, &curr_task.task) {
+            return Err("BUG: cannot call join() on yourself (the current task).");
+        }
+
+        if !interrupts_enabled() {
+            return Err(
+                "BUG: cannot call join() with interrupts disabled; it will cause deadlock.",
+            );
+        }
+
+        // First, wait for this Task to be marked as Exited (no longer runnable).
+        while !self.task.has_exited() {}
+
+        // Then, wait for it to actually stop running on any CPU core.
+        while self.task.is_running() {}
+
+        Ok(())
+    }
+
+    /// Call this function to indicate that this task has successfully ran to completion,
+    /// and that it has returned the given `exit_value`.
+    ///
+    /// This should only be used within task cleanup functions to indicate
+    /// that the current task has cleanly exited.
+    ///
+    /// # Locking / Deadlock
+    /// This method obtains a writable lock on the underlying Task's inner state.
+    ///
+    /// # Return
+    /// * Returns `Ok` if the exit status was successfully set.     
+    /// * Returns `Err` if this `Task` was already exited, and does not overwrite the existing exit status.
+    ///  
+    /// # Note
+    /// The `Task` will not be halted immediately --
+    /// it will finish running its current timeslice, and then never be run again.
+    #[doc(hidden)]
+    pub fn mark_as_exited(&self, exit_value: Box<dyn Any + Send>) -> Result<(), &'static str> {
+        self.internal_exit(ExitValue::Completed(exit_value))
+    }
+
+    /// Call this function to indicate that this task has been cleaned up (e.g., by unwinding)
+    /// and it is ready to be marked as killed, i.e., it will never run again.
+    /// This task (`self`) must be the currently executing task,
+    /// you cannot invoke `mark_as_killed()` on a different task.
+    ///
+    /// If you want to kill another task, use the [`kill()`](method.kill) method instead.
+    ///
+    /// This should only be used within task cleanup functions (e.g., after unwinding) to indicate
+    /// that the current task has crashed or failed and has been killed by the system.
+    ///
+    /// # Locking / Deadlock
+    /// This method obtains a writable lock on the underlying Task's inner state.
+    ///
+    /// # Return
+    /// * Returns `Ok` if the exit status was successfully set.     
+    /// * Returns `Err` if this `Task` was already exited, and does not overwrite the existing exit status.
+    ///  
+    /// # Note
+    /// The `Task` will not be halted immediately --
+    /// it will finish running its current timeslice, and then never be run again.
+    #[doc(hidden)]
+    pub fn mark_as_killed(&self, reason: KillReason) -> Result<(), &'static str> {
+        let curr_task =
+            get_my_current_task().ok_or("mark_as_exited(): failed to check the current task")?;
+        if curr_task == self.to_simple() {
+            self.internal_exit(ExitValue::Killed(reason))
+        } else {
+            Err("`mark_as_exited()` can only be invoked on the current task, not on another task.")
+        }
+    }
+
+    /// Kills this `Task` (not a clean exit) without allowing it to run to completion.
+    /// The provided `KillReason` indicates why it was killed.
+    ///
+    /// **
+    /// Currently this immediately kills the task without performing any unwinding cleanup.
+    /// In the near future, the task will be unwound such that its resources are freed/dropped
+    /// to ensure proper cleanup before the task is actually fully killed.
+    /// **
+    ///
+    /// # Locking / Deadlock
+    /// This method obtains a writable lock on the underlying Task's inner state.
+    ///
+    /// # Return
+    /// * Returns `Ok` if the exit status was successfully set to the given `KillReason`.     
+    /// * Returns `Err` if this `Task` was already exited, and does not overwrite the existing exit status.
+    ///
+    /// # Note
+    /// The `Task` will not be halted immediately --
+    /// it will finish running its current timeslice, and then never be run again.
+    pub fn kill(&self, reason: KillReason) -> Result<(), &'static str> {
+        // TODO FIXME: cause a panic in this Task such that it will start the unwinding process
+        // instead of immediately causing it to exit
+        self.internal_exit(ExitValue::Killed(reason))
+    }
+
+    /// The internal routine that actually exits or kills a Task.
+    ///
+    /// # Locking / Deadlock
+    /// Obtains the lock on this `Task`'s inner state in order to mutate it.
+    fn internal_exit(&self, val: ExitValue) -> Result<(), &'static str> {
+        if self.task.has_exited() {
+            return Err(
+                "BUG: task was already exited! (did not overwrite its existing exit value)",
+            );
+        }
+        {
+            let mut inner = self.task.inner.lock();
+            inner.exit_value = Some(val);
+            self.task.runstate.store(RunState::Exited);
+
+            // Corner case: if the task isn't currently running (as with killed tasks),
+            // we must clean it up now rather than in `task_switch()`, as it will never be scheduled in again.
+            if !self.task.is_running() {
+                trace!(
+                    "internal_exit(): dropping TaskLocalData for non-running task {}",
+                    &*self.task
+                );
+                drop(inner.task_local_data.take());
+            }
+        }
+
+        #[cfg(runqueue_spillful)]
+        {
+            if let Some(remove_from_runqueue) = RUNQUEUE_REMOVAL_FUNCTION.get() {
+                if let Some(rq) = self.on_runqueue() {
+                    remove_from_runqueue(self, rq)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn to_simple(&self) -> &TaskRef<false, false> {
+        // FIXME: Double check that this is ok.
+        unsafe { core::mem::transmute(self) }
+    }
+}
+
+impl<const JOINABLE: bool> TaskRef<JOINABLE, true> {
+    pub fn unblock(self) -> (TaskRef<JOINABLE, false>, bool) {
+        let result = self
+            .task
+            .runstate
+            .compare_exchange(RunState::Blocked, RunState::Runnable);
+        (unsafe { core::mem::transmute(self) }, result.is_ok())
+    }
+}
+
+impl<const JOINABLE: bool> TaskRef<JOINABLE, false> {
+    pub fn block(self) -> Result<TaskRef<JOINABLE, true>, TaskRef<JOINABLE, false>> {
+        if self
+            .task
+            .runstate
+            .compare_exchange(RunState::Runnable, RunState::Blocked)
+            .is_ok()
+        {
+            Ok(unsafe { core::mem::transmute(self) })
+        } else {
+            Err(self)
+        }
+    }
+}
+
+impl<const JOINABLE: bool, const UNBLOCKABLE: bool> Drop for TaskRef<JOINABLE, UNBLOCKABLE> {
+    /// Marks the inner [`Task`] as not joinable, meaning that it is an orphaned task
+    /// that will be auto-reaped after exiting.
+    fn drop(&mut self) {
+        if JOINABLE {
+            self.task.joinable.store(false, Ordering::Relaxed);
+        }
+
+        if UNBLOCKABLE {
+            if self
+                .task
+                .runstate
+                .compare_exchange(RunState::Blocked, RunState::Runnable)
+                .is_err()
+            {
+                warn!("TaskRef::drop(): failed to block task");
+            }
+        }
+    }
+}

--- a/kernel/task/src/rref.rs
+++ b/kernel/task/src/rref.rs
@@ -1,4 +1,12 @@
-use super::*;
+use crate::{get_my_current_task, ExitValue, KillReason, RunState, Task};
+use alloc::{boxed::Box, sync::Arc};
+use core::{
+    any::Any,
+    hash::{Hash, Hasher},
+    ops::Deref,
+    sync::atomic::Ordering,
+};
+use irq_safety::interrupts_enabled;
 
 // FIXME Document.
 #[derive(Debug)]

--- a/kernel/wait_queue/src/lib.rs
+++ b/kernel/wait_queue/src/lib.rs
@@ -9,7 +9,7 @@ extern crate scheduler;
 
 use alloc::collections::VecDeque;
 use irq_safety::MutexIrqSafe;
-use task::TaskRef;
+use task::{TaskRef, RunState};
 
 
 /// An object that holds a blocked `Task` 
@@ -20,17 +20,23 @@ pub struct WaitGuard {
 impl WaitGuard {
     /// Blocks the given `Task` and returns a new `WaitGuard` object
     /// that will automatically unblock that Task when it is dropped. 
-    pub fn new(task: TaskRef) -> WaitGuard {
-        task.block().unwrap();
-        WaitGuard {
+    ///
+    /// Returns an error if the task cannot be blocked. See [`Task::block`] for
+    ///  more details.
+    pub fn new(task: TaskRef) -> Result<WaitGuard, RunState> {
+        task.block()?;
+        Ok(WaitGuard {
             task,
-        }
+        })
     }
 
     /// Blocks the task guarded by this waitguard,
     /// which is useful to re-block a task after it spuriously woke up. 
-    pub fn block_again(&self) {
-        self.task.block().unwrap();
+    ///
+    /// Returns an error if the task cannot be blocked. See [`Task::block`] for
+    ///  more details.
+    pub fn block_again(&self) -> Result<RunState, RunState> {
+        self.task.block()
     }
 
     /// Returns a reference to the `Task` being blocked in this `WaitGuard`.

--- a/kernel/wait_queue/src/lib.rs
+++ b/kernel/wait_queue/src/lib.rs
@@ -91,16 +91,14 @@ impl WaitQueue {
                     return Ok(ret);
                 }
                 // trace!("WaitQueue::wait_until():  putting task to sleep: {:?}\n    --> WQ: {:?}", curr_task, &*wq_locked);
-                unsafe {
-                    curr_task.clone().run_and_block(|taskref| {
-                        // This is only necessary because we're using a non-Set waitqueue collection that allows duplicates
-                        if !wq_locked.contains(&taskref) {
-                            wq_locked.push_back(taskref);
-                        } else {
-                            panic!("WaitQueue::wait_until():  task was already on waitqueue (potential spurious wakeup?). {:?}", curr_task);
-                        }
-                    })
-                }
+                curr_task.clone().run_and_block(|taskref| {
+                    // This is only necessary because we're using a non-Set waitqueue collection that allows duplicates
+                    if !wq_locked.contains(&taskref) {
+                        wq_locked.push_back(taskref);
+                    } else {
+                        panic!("WaitQueue::wait_until():  task was already on waitqueue (potential spurious wakeup?). {:?}", curr_task);
+                    }
+                })
                 .map_err(|_| WaitError::CantBlockCurrentTask)?;
             }
             scheduler::schedule();
@@ -129,16 +127,14 @@ impl WaitQueue {
                     return Ok(ret);
                 }
                 // trace!("WaitQueue::wait_until_mut():  putting task to sleep: {:?}\n    --> WQ: {:?}", curr_task, &*wq_locked);
-                unsafe {
-                    curr_task.clone().run_and_block(|taskref| {
-                        // This is only necessary because we're using a non-Set waitqueue collection that allows duplicates
-                        if !wq_locked.contains(&taskref) {
-                            wq_locked.push_back(taskref);
-                        } else {
-                            panic!("WaitQueue::wait_until_mut():  task was already on waitqueue (potential spurious wakeup?). {:?}", curr_task);
-                        }
-                    })
-                }
+                curr_task.clone().run_and_block(|taskref| {
+                    // This is only necessary because we're using a non-Set waitqueue collection that allows duplicates
+                    if !wq_locked.contains(&taskref) {
+                        wq_locked.push_back(taskref);
+                    } else {
+                        panic!("WaitQueue::wait_until_mut():  task was already on waitqueue (potential spurious wakeup?). {:?}", curr_task);
+                    }
+                })
                 .map_err(|_| WaitError::CantBlockCurrentTask)?;
             }
             scheduler::schedule();


### PR DESCRIPTION
This builds on #657 to ensure blocked tasks are unblocked during the unwinding of the blocker. As a side effect, it makes spurious wakeups impossible, as a task can only be unblocked by the `TaskRef` that blocked it in the first place.

However, rather than use a conventional guard, I've implemented this using generics on `TaskRef`. I also merged `TaskRef` and `JoinableTaskRef`.

There are three unavoidable problems that arise from using guards, be that in the form of generics or a conventional guard struct:
The `run_and_block` shenanigans. `sleep` and `wait_queue` both need to add the guard to their internal queues before blocking the task to avoid race conditions.
The shell enum needing to store different variants. In the case of a conventional guard, the guard struct would need to be optionally stored in the list of tasks.
`serial_port` having to recreate the guard. The task is blocked either on creation or in `deferred_interrupt_tasks::deferred_task_entry_point()`, but it must be unblocked by the interrupt handler. Unlike the preemption guard stored across context switches, there isn't a good place to store the unblockable `TaskRef`. I currently recreate the unblockable `TaskRef` in the interrupt handler, but this is obviously an awful solution.

An issue specific to generics is the `TaskRefKind::Temp` enum variant found in `shell`. It's a workaround for a common problem with APIs that consume `self` in their methods. Moving out of a mutable reference without replacing it with some value is impossible, even if temporary. `*self = f(self)` does not work; if `f` panics, `self' will have an invalid value during unwinding as it has been moved out of but not reassigned to.

Having said that, I feel the benefits outweigh the costs compared to a conventional guard. Not having to store two separate structs (both of which would be an `Arc` pointing to the same task) is convenient. For example, spawning a task with conventional guards would require `spawn()` to return either a `TaskRef` or `(TaskRef, BlockGuard)`, depending on whether the task was initially blocked. The additional compile-time information granted by generics is very powerful, as I'll describe below.

As a side note, I'm not a big fan of using const generic booleans the way I did. I think expressing the generic parameters using sealed marker types would be better, i.e. `Joinable`/`Unjoinable` and `Blockable`/`Unblockable`, as they are more descriptive and let us expand the potential states (e.g. `Killed`).

Const generics cannot accurately track the run state of the task as they are a compile-time concept. However, they let us reduce the set of possible run states as we know the set of all possible state transitions, encoded as methods on `TaskRef`.

Using the sealed types I suggested above for clarity, if we have a `TaskRef<_, Unblockable>` (created by `task.block()`), we know that the task is either blocked (as only we can unblock it), killed, or reaped.

Similarly, if we were to add a `Killed` variant, we know that a `TaskRef<_, Killed>` could only be killed or reaped as no state transition would turn a killed task back into a runnable or blocked one.

`TaskRef<_, Unblockable>` does not have a `block` method because the `TaskRef`'s existence guarantees that it is not in the `Runnable` state. Currently, there is a way to get a `TaskRef<_, Blockable>` from a `TaskRef<_, Unblockable>` through `clone`, but that's for ergonomic reasons to avoid requiring generics in the scheduler. Ideally, we would prevent this state transition, but even as it is, it requires an additional function call to suggest to the consumer that what they are doing does not make sense. And, even though this invalid state transition is possible, performing it at runtime and trying to block the task will result in an error.

The generics are just additional compile-time information that can be used to better restrict interfaces.

I haven't added much documentation yet because I'm not sure if this is something we would want to merge in, but obviously, everything will be documented if we do decide to go ahead.