### PR TITLE
Redesign Local APIC init to not assume the BSP's APIC ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,6 @@ dependencies = [
  "scheduler",
  "spawn",
  "stack",
- "tlb_shootdown",
 ]
 
 [[package]]
@@ -333,6 +332,7 @@ dependencies = [
  "stack",
  "task",
  "task_fs",
+ "tlb_shootdown",
  "tsc",
  "window_manager",
 ]

--- a/applications/cpu/src/lib.rs
+++ b/applications/cpu/src/lib.rs
@@ -30,7 +30,7 @@ pub fn main(args: Vec<String>) -> isize {
     for lapic in all_lapics.iter() {
         let lapic = lapic.1;
         let apic_id = lapic.read().apic_id();
-        let processor = lapic.read().processor();
+        let processor = lapic.read().processor_id();
         let is_bsp = lapic.read().is_bsp();
         let core_type = if is_bsp {"BSP Core"}
                         else {"AP Core"};

--- a/kernel/acpi/madt/Cargo.toml
+++ b/kernel/acpi/madt/Cargo.toml
@@ -3,6 +3,7 @@ name = "madt"
 version = "0.1.0"
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 description = "Support for ACPI MADT"
+edition = "2018"
 
 [dependencies]
 zerocopy = "0.5.0"

--- a/kernel/acpi/madt/src/lib.rs
+++ b/kernel/acpi/madt/src/lib.rs
@@ -300,7 +300,7 @@ fn handle_bsp_lapic_entry(madt_iter: MadtIter, page_table: &mut PageTable) -> Re
         if let MadtEntry::LocalApic(lapic_entry) = madt_entry { 
             let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(lapic_entry.processor, madt_iter.clone());
 
-            match LocalApic::init(
+            let lapic = match LocalApic::init(
                 page_table,
                 lapic_entry.processor,
                 None, // we don't know the hardware-assigned APIC ID of the BSP (this CPU) yet
@@ -311,10 +311,13 @@ fn handle_bsp_lapic_entry(madt_iter: MadtIter, page_table: &mut PageTable) -> Re
                 // this `lapic_entry` wasn't for the BSP, try the next one.
                 Err(LapicInitError::NotBSP) => continue,
                 Err(other_err) => return Err(Box::leak(format!("{:?}", other_err).into_boxed_str())),
-                Ok(()) => { } // fall through
-            }
+                Ok(lapic) => lapic, // fall through
+            };
 
             assert!(get_my_apic_id() == lapic_entry.apic_id);
+            if let Err(e) = lapic.finish_init() {
+                return Err(Box::leak(format!("{:?}", e).into_boxed_str()));
+            }
             let bsp_id = lapic_entry.apic_id;
 
             // redirect every IoApic's interrupts to the one BSP

--- a/kernel/acpi/madt/src/lib.rs
+++ b/kernel/acpi/madt/src/lib.rs
@@ -3,18 +3,13 @@
 
 #![no_std]
 
-#[macro_use] extern crate log;
-extern crate memory;
-extern crate ioapic;
-extern crate apic;
-extern crate pic;
-extern crate sdt;
-extern crate acpi_table;
-extern crate zerocopy;
+extern crate alloc;
 
 use core::mem::size_of;
+use alloc::{boxed::Box, format};
+use log::{error, warn, trace};
 use memory::{MappedPages, PageTable, PhysicalAddress}; 
-use apic::{LocalApic, get_my_apic_id, get_bsp_id};
+use apic::{LocalApic, get_bsp_id, LapicInitError, get_my_apic_id};
 use sdt::Sdt;
 use acpi_table::{AcpiSignature, AcpiTables};
 use zerocopy::FromBytes;
@@ -301,39 +296,49 @@ pub struct MadtLocalApicAddressOverride {
 fn handle_bsp_lapic_entry(madt_iter: MadtIter, page_table: &mut PageTable) -> Result<(), &'static str> {
     use pic::IRQ_BASE_OFFSET;
 
-    let me = get_my_apic_id();
-
     for madt_entry in madt_iter.clone() {
         if let MadtEntry::LocalApic(lapic_entry) = madt_entry { 
-            if lapic_entry.apic_id == me {
-                let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(lapic_entry.processor, madt_iter.clone());
+            let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(lapic_entry.processor, madt_iter.clone());
 
-                LocalApic::init(page_table, lapic_entry.processor, lapic_entry.apic_id, true, nmi_lint, nmi_flags)?;
-                let bsp_id = lapic_entry.apic_id;
-
-                // redirect every IoApic's interrupts to the one BSP
-                // TODO FIXME: I'm unsure if this is actually correct!
-                for ioapic in ioapic::get_ioapics().iter() {
-                    let mut ioapic_ref = ioapic.1.lock();
-
-                    // Set the BSP to receive regular PIC interrupts routed through the IoApic.
-                    // Skip irq 2, since in the PIC that's the chained one (cascade line from PIC2 to PIC1) that isn't used.
-                    for irq in (0x0 ..= 0x1).chain(0x3 ..= 0xF) {
-                        ioapic_ref.set_irq(irq, bsp_id, IRQ_BASE_OFFSET + irq);
-                    }
-
-                    // ioapic_ref.set_irq(0x1, 0xFF, IRQ_BASE_OFFSET + 0x1); 
-                    // FIXME: the above line does indeed send the interrupt to all cores, but then they all handle it, instead of just one. 
-                }
-                // there's only ever one BSP, so we can exit the loop here
-                break;
+            match LocalApic::init(
+                page_table,
+                lapic_entry.processor,
+                None, // we don't know the hardware-assigned APIC ID of the BSP (this CPU) yet
+                true,
+                nmi_lint,
+                nmi_flags,
+            ) {
+                // this `lapic_entry` wasn't for the BSP, try the next one.
+                Err(LapicInitError::NotBSP) => continue,
+                Err(other_err) => return Err(Box::leak(format!("{:?}", other_err).into_boxed_str())),
+                Ok(()) => { } // fall through
             }
+
+            assert!(get_my_apic_id() == lapic_entry.apic_id);
+            let bsp_id = lapic_entry.apic_id;
+
+            // redirect every IoApic's interrupts to the one BSP
+            // TODO FIXME: I'm unsure if this is actually correct!
+            for ioapic in ioapic::get_ioapics().iter() {
+                let mut ioapic_ref = ioapic.1.lock();
+
+                // Set the BSP to receive regular PIC interrupts routed through the IoApic.
+                // Skip irq 2, since in the PIC that's the chained one (cascade line from PIC2 to PIC1) that isn't used.
+                for irq in (0x0 ..= 0x1).chain(0x3 ..= 0xF) {
+                    ioapic_ref.set_irq(irq, bsp_id, IRQ_BASE_OFFSET + irq);
+                }
+
+                // ioapic_ref.set_irq(0x1, 0xFF, IRQ_BASE_OFFSET + 0x1); 
+                // FIXME: the above line does indeed send the interrupt to all cores, but then they all handle it, instead of just one. 
+            }
+            // there's only ever one BSP, so we can exit the loop here
+            break;
         }
     }
 
     let bsp_id = get_bsp_id().ok_or("handle_bsp_lapic_entry(): Couldn't find BSP LocalApic in Madt!")?;
 
-    // now that we've established the BSP,  go through the interrupt source override entries
+    // now that we've established the BSP, go through the interrupt source override entries
     for madt_entry in madt_iter {
         if let MadtEntry::IntSrcOverride(int_src) = madt_entry {
             let mut handled = false;

--- a/kernel/ap_start/Cargo.toml
+++ b/kernel/ap_start/Cargo.toml
@@ -31,9 +31,6 @@ path = "../kernel_config"
 [dependencies.apic]
 path = "../apic"
 
-[dependencies.tlb_shootdown]
-path = "../tlb_shootdown"
-
 [dependencies.no_drop]
 path = "../no_drop"
 

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -15,7 +15,6 @@ extern crate spawn;
 extern crate scheduler;
 extern crate kernel_config;
 extern crate apic;
-extern crate tlb_shootdown;
 extern crate no_drop;
 
 use alloc::collections::BTreeMap;
@@ -59,22 +58,12 @@ pub fn kstart_ap(
     // set a flag telling the BSP that this AP has entered Rust code
     AP_READY_FLAG.store(true, Ordering::SeqCst);
 
-    // Initialize this CPU's Local APIC such that we can use everything that depends on APIC IDs.
-    let kernel_mmi_ref = get_kernel_mmi_ref().expect("kstart_ap(): kernel_mmi ref was None");
-    LocalApic::init(
-        &mut kernel_mmi_ref.lock().page_table,
-        processor_id,
-        Some(apic_id),
-        false,
-        nmi_lint,
-        nmi_flags,
-    ).unwrap();
-
     // get the stack that was allocated for us (this AP) by the BSP.
     let this_ap_stack = AP_STACKS.lock().remove(&apic_id)
         .unwrap_or_else(|| panic!("BUG: kstart_ap(): couldn't get stack created for AP with apic_id: {}", apic_id));
 
     // initialize interrupts (including TSS/GDT) for this AP
+    let kernel_mmi_ref = get_kernel_mmi_ref().expect("kstart_ap(): kernel_mmi ref was None");
     let (double_fault_stack, privilege_stack) = {
         let mut kernel_mmi = kernel_mmi_ref.lock();
         (
@@ -87,18 +76,31 @@ pub fn kstart_ap(
     let _idt = interrupts::init_ap(apic_id, double_fault_stack.top_unusable(), privilege_stack.top_unusable())
         .expect("kstart_ap(): failed to initialize interrupts!");
 
-    let bootstrap_task = spawn::init(kernel_mmi_ref.clone(), apic_id, this_ap_stack).unwrap();
-    tlb_shootdown::init();
+    // Initialize this CPU's Local APIC such that we can use everything that depends on APIC IDs.
+    // This must be done before initializing task spawning, because that relies on the ability to
+    // enable/disable preemption, which is partially implemented by the Local APIC.
+    let lapic = LocalApic::init(
+        &mut kernel_mmi_ref.lock().page_table,
+        processor_id,
+        Some(apic_id),
+        false,
+        nmi_lint,
+        nmi_flags,
+    ).unwrap();
+    lapic.finish_init().unwrap();
 
-    info!("Initialization complete on AP core {}. Spawning idle task and enabling interrupts...", apic_id);
+    // Now that the Local APIC has been initialized for this CPU, we can initialize the
+    // task management subsystem and create the idle task for this CPU.
+    let bootstrap_task = spawn::init(kernel_mmi_ref.clone(), apic_id, this_ap_stack).unwrap();
+    spawn::create_idle_task().unwrap();
+
+    info!("Initialization complete on AP core {}. Enabling interrupts...", apic_id);
     // The following final initialization steps are important, and order matters:
     // 1. Drop any other local stack variables that still exist.
     // (currently nothing else needs to be dropped)
-    // 2. Create the idle task for this CPU.
-    spawn::create_idle_task().unwrap();
-    // 3. "Finish" this bootstrap task, indicating it has exited and no longer needs to run.
+    // 2. "Finish" this bootstrap task, indicating it has exited and no longer needs to run.
     bootstrap_task.finish();
-    // 4. Enable interrupts such that other tasks can be scheduled in.
+    // 3. Enable interrupts such that other tasks can be scheduled in.
     enable_interrupts();
     // ****************************************************
     // NOTE: nothing below here is guaranteed to run again!

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -79,7 +79,7 @@ pub fn kstart_ap(
     // Initialize this CPU's Local APIC such that we can use everything that depends on APIC IDs.
     // This must be done before initializing task spawning, because that relies on the ability to
     // enable/disable preemption, which is partially implemented by the Local APIC.
-    let lapic = LocalApic::init(
+    LocalApic::init(
         &mut kernel_mmi_ref.lock().page_table,
         processor_id,
         Some(apic_id),
@@ -87,7 +87,6 @@ pub fn kstart_ap(
         nmi_lint,
         nmi_flags,
     ).unwrap();
-    lapic.finish_init().unwrap();
 
     // Now that the Local APIC has been initialized for this CPU, we can initialize the
     // task management subsystem and create the idle task for this CPU.

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -125,9 +125,9 @@ impl LapicIpiDestination {
 }
 
 
-/// Initially maps the base APIC MMIO register frames so that we can know which LAPIC (core) we are.
-/// This only does something for apic/xapic systems, it does nothing for x2apic systems, as required.
-pub fn init(_page_table: &mut PageTable) -> Result<(), &'static str> {
+/// Determines whether this system contains an xapic or x2apic
+/// and enables the Local APIC hardware in the correct mode.
+pub fn init() {
     let is_x2apic = has_x2apic();
     debug!("is x2apic? {}. IA32_APIC_BASE (phys addr): {:X?}", is_x2apic, rdmsr(IA32_APIC_BASE));
 
@@ -135,8 +135,6 @@ pub fn init(_page_table: &mut PageTable) -> Result<(), &'static str> {
         // Ensure the local apic is enabled in xapic mode, otherwise we'll get a General Protection fault
         unsafe { wrmsr(IA32_APIC_BASE, rdmsr(IA32_APIC_BASE) | IA32_APIC_XAPIC_ENABLE); }
     }
-
-    Ok(())
 }
 
 
@@ -300,19 +298,37 @@ impl fmt::Debug for LapicType {
     }
 }
 
+/// The possible errors that can occur in [`LocalApic::init()`].
+#[derive(Debug)]
+pub enum LapicInitError {
+    /// This CPU wasn't the BSP, as expected.
+    NotBSP,
+    /// This CPU wasn't an AP, as expected.
+    NotAP,
+    /// Invalid NMI local interrupt pin value; given by the included `u8`.
+    InvalidNmiLint(u8),
+    UnexpectedApicID {
+        expected: u8,
+        actual: u8,
+    },
+    /// An error occurred while mapping the Local APIC's MMIO registers into memory.
+    MemoryMappingError(&'static str),
+    /// The Local APIC already existed (BUG), given by the included `u8` APIC ID.
+    AlreadyExisted(u8),
+}
 
-/// This structure represents a single APIC in the system, there is one per core. 
+
+/// This structure represents a single Local APIC in the system; there is one per CPU. 
 #[doc(alias = "lapic")]
 pub struct LocalApic {
     /// The inner lapic object that disambiguates between xapic and x2apic.
     inner: LapicType,
-    /// The processor id of this APIC,
-    /// obtained from the `MADT` ACPI table entry.
-    processor: u8,
-    /// The APIC system id of this APIC,
-    /// obtained from the `MADT` ACPI table entry.
+    /// The hardware-provided ID of this Local APIC.
     apic_id: u8,
-    /// Whether this `LocalApic` is the bootstrap processor (the first processor to boot up).
+    /// The processor ID of this APIC (from the `MADT` ACPI table entry).
+    /// This is currently not used for anything in Theseus.
+    processor_id: u8,
+    /// Whether this Local APIC is the BootStrap Processor (the first CPU to boot up).
     is_bsp: bool,
 }
 impl fmt::Debug for LocalApic {
@@ -320,7 +336,7 @@ impl fmt::Debug for LocalApic {
         f.debug_struct("LocalApic")
             .field("type", &self.inner)
             .field("apic_id", &self.apic_id)
-            .field("processor", &self.processor)
+            .field("processor_id", &self.processor_id)
             .field("is_bsp", &self.is_bsp)
             .finish()
     }
@@ -335,80 +351,116 @@ impl LocalApic {
     /// Creates and initializes a new `LocalApic` for the current CPU core
     /// and adds it to the global set of initialized local APICs.
     /// 
+    /// ## Arguments
+    /// * `page_table`: the page table used to map the APIC MMIO registers
+    ///    (only used for xapic, not x2apic).
+    /// * `processor_id`: the processor ID specified in the ACPI `Madt` table.
+    ///    This value is currently unused in Theseus.
+    /// * `expected_apic_id`: the expected APIC ID as specified in the ACPI `Madt` table.
+    ///    * If `Some`, the APIC's own ID (given by [`LocalApic::id()`]) *must* match this value,
+    ///      otherwise an error will be returned.
+    ///    * If `None`, the local APIC will determine its own ID value, and no check is performed.
+    /// * `should_be_bsp`: whether or not this CPU is expected to be the BSP.
+    ///    * If `true`, this CPU must be the BSP (bootstrap processor).
+    ///    * If `false`, this CPU must *not* be the BSP -- it must be an AP.
+    ///    * An error is returned if the above checks fail.
+    /// * `nmi_lint`: the local interrupt pin used for NMI. Must be `0` or `1`.
+    /// * `nmi_flags`: the flags used to configure the local NMI interrupt.
+    /// 
     /// ## Important Usage Note
-    /// This MUST be invoked from the AP core itself when it is booting up.
-    /// The BSP cannot invoke this for other APs (it can only invoke it for itself).
+    /// This MUST be invoked from each CPU itself when it is booting up, i.e.,
+    /// the BSP cannot invoke this for other APs.
     pub fn init(
         page_table: &mut PageTable,
-        processor: u8,
-        apic_id: u8,
-        is_bsp: bool,
+        processor_id: u8,
+        expected_apic_id: Option<u8>,
+        should_be_bsp: bool,
         nmi_lint: u8,
-        nmi_flags: u16
-    ) -> Result<(), &'static str> {
-
-        trace!("size of LocalApic: {}", core::mem::size_of::<LocalApic>());
+        nmi_flags: u16,
+    ) -> Result<(), LapicInitError> {
 
         let nmi_lint = match nmi_lint {
             0 => LvtLint::Pin0,
             1 => LvtLint::Pin1,
             _invalid => {
                 error!("BUG: invalid `nmi_lint` value (must be `0` or `1`) in \
-                    LocalApic::init(processor: {}, apic_id: {}, is_bsp: {}, nmi_lint: {}, nmi_flags: {}",
-                    processor, apic_id, is_bsp, nmi_lint, nmi_flags
+                    LocalApic::init(processor_id: {}, expected_apic_id: {:?}, should_be_bsp: {}, nmi_lint: {}, nmi_flags: {}",
+                    processor_id, expected_apic_id, should_be_bsp, nmi_lint, nmi_flags
                 );
-                return Err("BUG: invalid `nmi_lint` value, must be `0` or `1`");
+                return Err(LapicInitError::InvalidNmiLint(nmi_lint));
             }
         };
 
-        // Theseus uses this MSR to hold each CPU's ID (which is an OS-chosen value).
-        unsafe { wrmsr(IA32_TSC_AUX, apic_id as u64); }
-
-        if is_bsp {
-            BSP_PROCESSOR_ID.call_once(|| apic_id); 
+        // Check whether the caller's expectations about BSP vs AP were met.
+        let is_bsp = rdmsr(IA32_APIC_BASE) & IA32_APIC_BASE_MSR_IS_BSP == IA32_APIC_BASE_MSR_IS_BSP;
+        if should_be_bsp && !is_bsp {
+            return Err(LapicInitError::NotBSP);
+        }
+        if !should_be_bsp && is_bsp {
+            return Err(LapicInitError::NotAP);
         }
 
-        let inner = if has_x2apic() {
-            LapicType::X2Apic
+        // Next, before we can check other conditions, we have to enable the APIC hardware
+        // (which, if xapic, also requires mapping the Lapic MMIO registers).
+        let inner: LapicType;
+        let enable_bitmask: u64;
+        if has_x2apic() {
+            inner = LapicType::X2Apic;
+            enable_bitmask = IA32_APIC_XAPIC_ENABLE | IA32_APIC_X2APIC_ENABLE;
         } else {
-            LapicType::XApic(
-                BoxRefMut::new(Box::new(map_apic(page_table)?))
-                    .try_map_mut(|mp| mp.as_type_mut::<ApicRegisters>(0))?
-            )
+            let apic_regs = map_apic(page_table)
+                .map_err(|e| LapicInitError::MemoryMappingError(e))
+                .and_then(|apic_mp| 
+                    BoxRefMut::new(Box::new(apic_mp)).try_map_mut(|mp| mp
+                        .as_type_mut::<ApicRegisters>(0)
+                        .map_err(|e| LapicInitError::MemoryMappingError(e))
+                    )
+                )?;
+            inner = LapicType::XApic(apic_regs);
+            enable_bitmask = IA32_APIC_XAPIC_ENABLE;
         };
+
+        // Enable the xapic/x2apic hardware.
+        unsafe { wrmsr(IA32_APIC_BASE, rdmsr(IA32_APIC_BASE) | enable_bitmask); }
+
 		let mut lapic = LocalApic {
             inner,
-            processor,
-            apic_id,
+            processor_id,
+            apic_id: u8::MAX, // placeholder, is replaced below.
             is_bsp,
         };
 
-        lapic.enable();
+        // Now that the APIC hardware is enabled, we can safely obtain this Local APIC's ID.
+        let actual_apic_id = lapic.read_apic_id();
+        if let Some(expected) = expected_apic_id && expected != actual_apic_id {
+            return Err(LapicInitError::UnexpectedApicID { expected, actual: actual_apic_id });
+        }
+
+        lapic.apic_id = actual_apic_id;
+        lapic.clean_enable();
         lapic.init_lvt_timer();
         lapic.set_nmi(nmi_lint, nmi_flags);
-        info!("Found new processor core ({:?})", lapic);
+        info!("Initialized new CPU ({:?})", lapic);
 
-        let _existing = LOCAL_APICS.insert(apic_id, RwLockIrqSafe::new(lapic));
-        assert!(_existing.is_none(), "Local APIC should not already exist");
+        let _existing = LOCAL_APICS.insert(actual_apic_id, RwLockIrqSafe::new(lapic));
+        if _existing.is_some() {
+            return Err(LapicInitError::AlreadyExisted(actual_apic_id));
+        }
+
+        // Theseus uses this MSR to hold each CPU's ID (which is an OS-chosen value).
+        unsafe { wrmsr(IA32_TSC_AUX, actual_apic_id as u64); }
+        if is_bsp {
+            BSP_PROCESSOR_ID.call_once(|| actual_apic_id); 
+        }
         CPU_COUNT.fetch_add(1, Ordering::Relaxed);
 		Ok(())      
     }
 
-
-    /// Returns the APIC ID of this lapic.
+    /// Returns the "processor ID" of this local APIC, which is currently unused.
     /// 
     /// This value comes from the `MADT` ACPI table entry that was used
     /// to boot up this CPU core.
-    /// 
-    /// Currently this returns the same value as [`LocalApic::id()`].
-    pub fn apic_id(&self) -> u8 { self.apic_id }
-
-    /// Returns the "processor ID" of this lapic,
-    /// which is usually a meaningless value.
-    /// 
-    /// This value comes from the `MADT` ACPI table entry that was used
-    /// to boot up this CPU core.
-    pub fn processor(&self) -> u8 { self.processor }
+    pub fn processor_id(&self) -> u8 { self.processor_id }
 
     /// Returns `true` if this CPU core was the BootStrap Processor (BSP),
     /// i.e., the first CPU to boot and run the OS code.
@@ -416,19 +468,10 @@ impl LocalApic {
     /// There is only one BSP per system.
     pub fn is_bsp(&self) -> bool { self.is_bsp }
 
-    /// Enable this lapic by initializing it to a clean state
-    /// and enabling its spurious interrupt vector.
-    fn enable(&mut self) {
-        let is_bsp = rdmsr(IA32_APIC_BASE) & IA32_APIC_BASE_MSR_IS_BSP == IA32_APIC_BASE_MSR_IS_BSP;
-
-        // Globally enable the xapic/x2apic by setting the XAPIC_ENABLE (and optionally X2APIC_ENABLE) bits
-        let enable_bitmask = rdmsr(IA32_APIC_BASE) | match &mut self.inner {
-            LapicType::X2Apic   => IA32_APIC_XAPIC_ENABLE | IA32_APIC_X2APIC_ENABLE,
-            LapicType::XApic(_) => IA32_APIC_XAPIC_ENABLE
-        };
-        unsafe { wrmsr(IA32_APIC_BASE, enable_bitmask); }
-
-        let id = self.id();
+    /// Set this Local APIC to a known "clean state" and enable its spurious interrupt vector.
+    fn clean_enable(&mut self) {
+        let is_bsp = self.is_bsp;
+        let id = self.read_apic_id();
         let version = self.version();
 
         match &mut self.inner {
@@ -461,15 +504,12 @@ impl LocalApic {
                 }
             }
             LapicType::XApic(regs) => {
-                // Globally enable the apic by setting the XAPIC_ENABLE bit
-                let enable_bitmask = rdmsr(IA32_APIC_BASE) | IA32_APIC_XAPIC_ENABLE;
-                unsafe { wrmsr(IA32_APIC_BASE, enable_bitmask); }
                 info!("LAPIC ID {:#x}, version: {:#x}, is_bsp: {}", id, version, is_bsp);
                 if is_bsp {
                     INTERRUPT_CHIP.store(InterruptChip::APIC);
                 }
 
-                // Init APIC to a clean known state.
+                // Init xAPIC to a clean known state.
                 // See <http://wiki.osdev.org/APIC#Logical_Destination_Mode>
                 regs.destination_format.write(0xFFFF_FFFF);
                 regs.lvt_timer.write(APIC_DISABLE);
@@ -573,10 +613,13 @@ impl LocalApic {
         }
     }
 
-    /// Reads the hardware-provided ID of this lapic (from its registers).
+    /// Returns the ID of this Local APIC (fast).
     /// 
-    /// Currently, this matches the value returned by [`LocalApic::apic_id()`].
-    pub fn id(&self) -> u8 {
+    /// Unlike [`read_apic_id()`], this does not read any hardware registers.
+    pub fn apic_id(&self) -> u8 { self.apic_id }
+
+    /// Reads the hardware-provided ID of this Local APIC from its registers (slow).
+    pub fn read_apic_id(&self) -> u8 {
         match &self.inner {
             LapicType::X2Apic => rdmsr(IA32_X2APIC_APICID) as u32 as u8,
             LapicType::XApic(regs) => {

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -43,6 +43,9 @@ path = "../mod_mgmt"
 [dependencies.exceptions_full]
 path = "../exceptions_full"
 
+[dependencies.tlb_shootdown]
+path = "../tlb_shootdown"
+
 [dependencies.apic]
 path = "../apic"
 

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -44,6 +44,7 @@ extern crate first_application;
 extern crate exceptions_full;
 extern crate network_manager;
 extern crate window_manager;
+extern crate tlb_shootdown;
 extern crate multiple_heaps;
 extern crate console;
 #[cfg(simd_personality)] extern crate simd_personality;
@@ -132,6 +133,10 @@ pub fn init(
     let cpu_count = ap_count + 1;
     info!("Finished handling and booting up all {} AP cores; {} total CPUs are running.", ap_count, cpu_count);
 
+    // Now that other CPUs are fully booted, init TLB shootdowns,
+    // which rely on Local APICs to broadcast an IPI to all running CPUs.
+    tlb_shootdown::init();
+    
     // //initialize the per core heaps
     multiple_heaps::switch_to_multiple_heaps()?;
     info!("Initialized per-core heaps");

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -51,8 +51,9 @@ const DEFAULT_GATEWAY_IP: [u8; 4] = [10, 0, 2, 2]; // the default QEMU user-slir
 /// * local APICs ([`apic`]),
 /// * [`acpi`] tables for system configuration info, including the IOAPIC.
 pub fn early_init(kernel_mmi: &mut MemoryManagementInfo) -> Result<(), &'static str> {
-    // First, initialize the local apic info.
-    apic::init(&mut kernel_mmi.page_table)?;
+    // First, initialize the local APIC hardware such that we can populate
+    // and initialize each LocalAPIC discovered in the ACPI table initialization routine below.
+    apic::init();
     
     // Then, parse the ACPI tables to acquire system configuration info.
     acpi::init(&mut kernel_mmi.page_table)?;

--- a/kernel/nano_core/src/boot/arch_x86_64/ap_boot.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/ap_boot.asm
@@ -142,6 +142,13 @@ start_high_ap:
 	mov fs, ax
 	mov gs, ax
 
+	; set the IA32_TSC_AUX MSR to a sentry value, in order to prevent
+	; invalid usage of its value before Theseus sets it to the CPU's APIC ID.
+	mov eax, 0xFFFFFFFF
+	mov edx, 0x0
+	mov ecx, 0xc0000103   ; IA32_TSC_AUX MSR
+	wrmsr
+	
 	; clear out the FS/GS base MSRs
 	xor eax, eax          ; set to 0
 	xor edx, edx          ; set to 0

--- a/kernel/nano_core/src/boot/arch_x86_64/boot.asm
+++ b/kernel/nano_core/src/boot/arch_x86_64/boot.asm
@@ -324,6 +324,13 @@ start_high:
 	mov fs, ax
 	mov gs, ax
 
+	; set the IA32_TSC_AUX MSR to a sentry value, in order to prevent
+	; invalid usage of its value before Theseus sets it to the CPU's APIC ID.
+	mov eax, 0xFFFFFFFF
+	mov edx, 0x0
+	mov ecx, 0xc0000103   ; IA32_TSC_AUX MSR
+	wrmsr
+	
 	; clear out the FS/GS base MSRs
 	xor eax, eax          ; set to 0
 	xor edx, edx          ; set to 0

--- a/kernel/tlb_shootdown/src/lib.rs
+++ b/kernel/tlb_shootdown/src/lib.rs
@@ -37,7 +37,7 @@ pub fn init() {
 /// which will invoke it as needed (on remap/unmap operations).
 fn broadcast_tlb_shootdown(pages_to_invalidate: PageRange) {
     if let Some(my_lapic) = get_my_apic() {
-        // info!("broadcast_tlb_shootdown():  AP {}, vaddrs: {:?}", my_lapic.read().apic_id, virtual_addresses);
+        // log::info!("broadcast_tlb_shootdown():  AP {}, pages: {:?}", my_lapic.read().apic_id(), pages_to_invalidate);
         send_tlb_shootdown_ipi(&mut my_lapic.write(), pages_to_invalidate);
     }
 }
@@ -48,7 +48,7 @@ fn broadcast_tlb_shootdown(pages_to_invalidate: PageRange) {
 /// 
 /// There is no need to invoke this directly, it will be called by an IPI interrupt handler.
 pub fn handle_tlb_shootdown_ipi(pages_to_invalidate: PageRange) {
-    // trace!("handle_tlb_shootdown_ipi(): AP {}, pages: {:?}", apic::get_my_apic_id(), pages_to_invalidate);
+    // log::trace!("handle_tlb_shootdown_ipi(): AP {}, pages: {:?}", apic::get_my_apic_id(), pages_to_invalidate);
 
     for page in pages_to_invalidate {
         x86_64::instructions::tlb::flush(x86_64::VirtAddr::new(page.start_address().value() as u64));
@@ -66,7 +66,7 @@ pub fn send_tlb_shootdown_ipi(my_lapic: &mut LocalApic, pages_to_invalidate: Pag
         return;
     }
 
-    // trace!("send_tlb_shootdown_ipi(): from AP {}, cpu_count: {}, {:?}", my_lapic.apic_id, cpu_count, pages_to_invalidate);
+    // log::trace!("send_tlb_shootdown_ipi(): from AP {}, cpu_count: {}, {:?}", my_lapic.apic_id(), cpu_count, pages_to_invalidate);
 
     // interrupts must be disabled here, because this IPI sequence must be fully synchronous with other cores,
     // and we wouldn't want this core to be interrupted while coordinating IPI responses across multiple cores.


### PR DESCRIPTION
Part of the solution for #655, not yet complete.