### PR TITLE
Introduce `dereffer::DerefsTo` wrapper type to replace `owning_ref`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "dereffer"
+version = "0.1.0"
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4027,6 +4031,7 @@ name = "window"
 version = "0.1.0"
 dependencies = [
  "color",
+ "dereffer",
  "event_types",
  "framebuffer",
  "framebuffer_drawer",

--- a/kernel/window/Cargo.toml
+++ b/kernel/window/Cargo.toml
@@ -39,7 +39,10 @@ path = "../spawn"
 path = "../mouse"
 
 [dependencies.path]
-path = "../../kernel/path"
+path = "../path"
+
+[dependencies.dereffer]
+path = "../../libs/dereffer"
 
 [lib]
 crate-type = ["rlib"]

--- a/libs/dereffer/Cargo.toml
+++ b/libs/dereffer/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "dereffer"
+description = "Type wrappers for deref-ing the inner value in arbitrary ways"
+version = "0.1.0"

--- a/libs/dereffer/src/lib.rs
+++ b/libs/dereffer/src/lib.rs
@@ -3,8 +3,9 @@
 //!
 //! These types can be used as a purely-safe alternative to replace some of the
 //! typical use cases for self-referential types.
-//! They can also be used to limit access to and visibility of an inner type
-//! by acting as wrappers that restrict callers to only accessing their deref target type.
+//! They can also be used to limit access to and visibility of an inner type by
+//! acting as wrappers that restrict callers to only accessing its `Deref::Target` type,
+//! which we call `Ref` in this crate.
 
 #![no_std]
 #![feature(const_mut_refs)]
@@ -13,10 +14,10 @@ use core::ops::{Deref, DerefMut};
 
 /// A struct that holds an inner value and a function
 /// that is used deref the `Inner` value into a `&Ref`.
-/// 
+///
 /// As with [`Deref`], the dereffer function must not fail.
 /// It typically just accesses an arbitrary field reachable from `Inner`.
-/// 
+///
 /// This is also useful to prevent a caller from accessing all of `Inner`,
 /// rather only giving them access to `Ref`.
 pub struct DerefsTo<Inner, Ref>
@@ -49,9 +50,8 @@ where
     }
 }
 
-
 /// Similar to [`DerefsTo`], but supports mutable dereferencing too.
-/// 
+///
 /// Because Ruse doesn't offer a way to abstract over mutability,
 /// i.e., accept both `&T` and `&mut T`, this struct must handle the
 /// `Deref` and `DerefMut` cases separately with individual functions.
@@ -71,7 +71,10 @@ where
         deref_func: fn(&Inner) -> &Ref,
         deref_mut_func: fn(&mut Inner) -> &mut Ref,
     ) -> Self {
-        Self { inner: DerefsTo::new(inner, deref_func), deref_mut_func }
+        Self {
+            inner: DerefsTo::new(inner, deref_func),
+            deref_mut_func,
+        }
     }
 }
 impl<Inner, Ref> Deref for DerefsToMut<Inner, Ref>

--- a/libs/dereffer/src/lib.rs
+++ b/libs/dereffer/src/lib.rs
@@ -1,0 +1,94 @@
+//! Convenience types that immutably and mutably deref into an arbitrary type
+//! reachable from their owned inner type.
+//!
+//! These types can be used as a purely-safe alternative to replace some of the
+//! typical use cases for self-referential types.
+//! They can also be used to limit access to and visibility of an inner type
+//! by acting as wrappers that restrict callers to only accessing their deref target type.
+
+#![no_std]
+#![feature(const_mut_refs)]
+
+use core::ops::{Deref, DerefMut};
+
+/// A struct that holds an inner value and a function
+/// that is used deref the `Inner` value into a `&Ref`.
+/// 
+/// As with [`Deref`], the dereffer function must not fail.
+/// It typically just accesses an arbitrary field reachable from `Inner`.
+/// 
+/// This is also useful to prevent a caller from accessing all of `Inner`,
+/// rather only giving them access to `Ref`.
+pub struct DerefsTo<Inner, Ref>
+where
+    Ref: ?Sized,
+{
+    /// The inner object that is used as the starting point to access
+    /// the type `Ref`, and is thus passed into the below `deref_func`
+    /// in order to return an `&Ref` in this struct's `Deref` impl.
+    inner: Inner,
+    /// The function that is called within the `Deref` impl
+    /// to actually access and return the `&Ref`.
+    deref_func: fn(&Inner) -> &Ref,
+}
+impl<Inner, Ref> DerefsTo<Inner, Ref>
+where
+    Ref: ?Sized,
+{
+    pub const fn new(inner: Inner, deref_func: fn(&Inner) -> &Ref) -> Self {
+        Self { inner, deref_func }
+    }
+}
+impl<Inner, Ref> Deref for DerefsTo<Inner, Ref>
+where
+    Ref: ?Sized,
+{
+    type Target = Ref;
+    fn deref(&self) -> &Self::Target {
+        (self.deref_func)(&self.inner)
+    }
+}
+
+
+/// Similar to [`DerefsTo`], but supports mutable dereferencing too.
+/// 
+/// Because Ruse doesn't offer a way to abstract over mutability,
+/// i.e., accept both `&T` and `&mut T`, this struct must handle the
+/// `Deref` and `DerefMut` cases separately with individual functions.
+pub struct DerefsToMut<Inner, Ref>
+where
+    Ref: ?Sized,
+{
+    inner: DerefsTo<Inner, Ref>,
+    deref_mut_func: fn(&mut Inner) -> &mut Ref,
+}
+impl<Inner, Ref> DerefsToMut<Inner, Ref>
+where
+    Ref: ?Sized,
+{
+    pub const fn new(
+        inner: Inner,
+        deref_func: fn(&Inner) -> &Ref,
+        deref_mut_func: fn(&mut Inner) -> &mut Ref,
+    ) -> Self {
+        Self { inner: DerefsTo::new(inner, deref_func), deref_mut_func }
+    }
+}
+impl<Inner, Ref> Deref for DerefsToMut<Inner, Ref>
+where
+    Ref: ?Sized,
+{
+    type Target = Ref;
+    fn deref(&self) -> &Self::Target {
+        self.inner.deref()
+    }
+}
+
+impl<Inner, Ref> DerefMut for DerefsToMut<Inner, Ref>
+where
+    Ref: ?Sized,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        (self.deref_mut_func)(&mut self.inner.inner)
+    }
+}


### PR DESCRIPTION
* Offers a generic wrapper to arbitrarily deref an inner type into any reference type reachable from that inner type.

Part of #482 