### PR TITLE
Add simpler `new_default` method to `DerefsTo[Mut]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ source = "git+https://github.com/rust-lang/stdsimd#0711e11593e7d3ce7cffdb7bd9665
 name = "cow_arc"
 version = "0.1.0"
 dependencies = [
- "owning_ref",
+ "dereffer",
  "spin 0.9.0",
 ]
 

--- a/libs/cow_arc/Cargo.toml
+++ b/libs/cow_arc/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT"
 
 [dependencies]
 spin = "0.9.0"
-owning_ref = { git = "https://github.com/theseus-os/owning-ref-rs" }
+dereffer = { path = "../dereffer" }

--- a/libs/dereffer/src/lib.rs
+++ b/libs/dereffer/src/lib.rs
@@ -20,10 +20,7 @@ use core::ops::{Deref, DerefMut};
 ///
 /// This is also useful to prevent a caller from accessing all of `Inner`,
 /// rather only giving them access to `Ref`.
-pub struct DerefsTo<Inner, Ref>
-where
-    Ref: ?Sized,
-{
+pub struct DerefsTo<Inner, Ref: ?Sized> {
     /// The inner object that is used as the starting point to access
     /// the type `Ref`, and is thus passed into the below `deref_func`
     /// in order to return an `&Ref` in this struct's `Deref` impl.
@@ -32,18 +29,23 @@ where
     /// to actually access and return the `&Ref`.
     deref_func: fn(&Inner) -> &Ref,
 }
-impl<Inner, Ref> DerefsTo<Inner, Ref>
-where
-    Ref: ?Sized,
-{
+impl<Inner, Ref: ?Sized> DerefsTo<Inner, Ref> {
     pub const fn new(inner: Inner, deref_func: fn(&Inner) -> &Ref) -> Self {
         Self { inner, deref_func }
     }
 }
-impl<Inner, Ref> Deref for DerefsTo<Inner, Ref>
+impl<Inner, Ref> DerefsTo<Inner, Ref> 
 where
+    Inner: Deref<Target = Ref>,
     Ref: ?Sized,
 {
+    /// Creates a new wrapper with the default, simple deref function,
+    /// [`Deref::deref()`].
+    pub const fn new_default(inner: Inner) -> Self {
+        Self { inner, deref_func: Deref::deref }
+    }
+}
+impl<Inner, Ref: ?Sized> Deref for DerefsTo<Inner, Ref> {
     type Target = Ref;
     fn deref(&self) -> &Self::Target {
         (self.deref_func)(&self.inner)
@@ -55,17 +57,12 @@ where
 /// Because Ruse doesn't offer a way to abstract over mutability,
 /// i.e., accept both `&T` and `&mut T`, this struct must handle the
 /// `Deref` and `DerefMut` cases separately with individual functions.
-pub struct DerefsToMut<Inner, Ref>
-where
-    Ref: ?Sized,
-{
+pub struct DerefsToMut<Inner, Ref: ?Sized> {
     inner: DerefsTo<Inner, Ref>,
     deref_mut_func: fn(&mut Inner) -> &mut Ref,
 }
-impl<Inner, Ref> DerefsToMut<Inner, Ref>
-where
-    Ref: ?Sized,
-{
+impl<Inner, Ref: ?Sized> DerefsToMut<Inner, Ref> {
+    /// Creates a new wrapper with custom arbitrary deref functions.
     pub const fn new(
         inner: Inner,
         deref_func: fn(&Inner) -> &Ref,
@@ -77,20 +74,28 @@ where
         }
     }
 }
-impl<Inner, Ref> Deref for DerefsToMut<Inner, Ref>
+impl<Inner, Ref> DerefsToMut<Inner, Ref> 
 where
+    Inner: DerefMut<Target = Ref>,
     Ref: ?Sized,
 {
+    /// Creates a new wrapper with default, simple deref functions,
+    /// [`Deref::deref()`] and [`DerefMut::deref_mut()`].
+    pub const fn new_default(inner: Inner) -> Self {
+        Self {
+            inner: DerefsTo::new(inner, Deref::deref),
+            deref_mut_func: DerefMut::deref_mut,
+        }
+    }
+}
+impl<Inner, Ref: ?Sized> Deref for DerefsToMut<Inner, Ref> {
     type Target = Ref;
     fn deref(&self) -> &Self::Target {
         self.inner.deref()
     }
 }
 
-impl<Inner, Ref> DerefMut for DerefsToMut<Inner, Ref>
-where
-    Ref: ?Sized,
-{
+impl<Inner, Ref: ?Sized> DerefMut for DerefsToMut<Inner, Ref> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         (self.deref_mut_func)(&mut self.inner.inner)
     }


### PR DESCRIPTION
Use `DerefsTo` in `CowArc` to replace `owning_ref`

Towards #482 