### PR TITLE
Remove `owning_ref`, `stable_deref_trait` impls from custom lock types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,10 +1950,8 @@ name = "mutex_preemption"
 version = "0.1.0"
 dependencies = [
  "lockable",
- "owning_ref",
  "preemption",
  "spin 0.9.0",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -1962,9 +1960,7 @@ version = "0.1.0"
 dependencies = [
  "lockable",
  "log",
- "owning_ref",
  "spin 0.9.0",
- "stable_deref_trait",
  "task",
  "wait_queue",
 ]
@@ -2162,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "owning_ref"
 version = "0.4.1"
-source = "git+https://github.com/theseus-os/owning-ref-rs.git#0d2dcdcffd75b80157d0e72fb82593a8696a9c49"
+source = "git+https://github.com/theseus-os/owning-ref-rs#0d2dcdcffd75b80157d0e72fb82593a8696a9c49"
 dependencies = [
  "spin 0.9.0",
  "stable_deref_trait",

--- a/kernel/mutex_preemption/Cargo.toml
+++ b/kernel/mutex_preemption/Cargo.toml
@@ -15,12 +15,3 @@ path = "../../libs/lockable"
 version = "0.9.0"
 default-features = false
 features = ["mutex", "spin_mutex", "rwlock", "once", "barrier"]
-
-[dependencies.stable_deref_trait]
-git = "https://github.com/theseus-os/stable_deref_trait.git"
-branch = "spin"
-default-features = false
-features = [ "alloc", "spin" ]
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"

--- a/kernel/mutex_preemption/src/lib.rs
+++ b/kernel/mutex_preemption/src/lib.rs
@@ -1,4 +1,4 @@
-//! Offers preemption-safe `Mutex` and `RwLock` types that auto-disable/re-enabled preemption
+//! Offers preemption-safe `Mutex` and `RwLock` types that auto-disable/re-enable preemption
 //! on a per-CPU core basis.
 
 #![no_std]

--- a/kernel/mutex_preemption/src/mutex_preempt.rs
+++ b/kernel/mutex_preemption/src/mutex_preempt.rs
@@ -1,8 +1,6 @@
 use core::{fmt, ops::{Deref, DerefMut}};
 use preemption::{PreemptionGuard, hold_preemption};
 use spin::{Mutex, MutexGuard};
-use stable_deref_trait::StableDeref;
-use owning_ref::{OwningRef, OwningRefMut};
 use lockable::{Lockable, LockableSized};
 
 /// A mutual exclusion wrapper based on [`spin::Mutex`] that ensures preemption
@@ -149,14 +147,6 @@ impl<'a, T: ?Sized> DerefMut for MutexPreemptGuard<'a, T> {
         &mut *(self.guard)
     }
 }
-
-// Implement the StableDeref trait for MutexPreempt guards, just like it's implemented for Mutex guards
-unsafe impl<'a, T: ?Sized> StableDeref for MutexPreemptGuard<'a, T> {}
-
-/// Typedef of a owning reference that uses a `MutexPreemptGuard` as the owner.
-pub type MutexPreemptGuardRef<'a, T, U = T> = OwningRef<MutexPreemptGuard<'a, T>, U>;
-/// Typedef of a mutable owning reference that uses a `MutexPreemptGuard` as the owner.
-pub type MutexPreemptGuardRefMut<'a, T, U = T> = OwningRefMut<MutexPreemptGuard<'a, T>, U>;
 
 /// Implement `Lockable` for [`MutexPreempt`].
 impl<'t, T> Lockable<'t, T> for MutexPreempt<T> where T: 't + ?Sized {

--- a/kernel/mutex_preemption/src/rwlock_preempt.rs
+++ b/kernel/mutex_preemption/src/rwlock_preempt.rs
@@ -1,8 +1,6 @@
 use core::{fmt, ops::{Deref, DerefMut}};
 use preemption::{PreemptionGuard, hold_preemption};
 use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use owning_ref::{OwningRef, OwningRefMut};
-use stable_deref_trait::StableDeref;
 use lockable::{Lockable, LockableSized};
 
 /// A multi-reader, single-writer mutual exclusion wrapper that ensures preemption
@@ -278,15 +276,6 @@ impl<'rwlock, T: ?Sized> DerefMut for RwLockPreemptWriteGuard<'rwlock, T> {
         &mut *(self.guard)
     }
 }
-
-// Implement the StableDeref trait for RwLockPreempt guards, just like it's implemented for RwLock guards
-unsafe impl<'a, T: ?Sized> StableDeref for RwLockPreemptReadGuard<'a, T> {}
-unsafe impl<'a, T: ?Sized> StableDeref for RwLockPreemptWriteGuard<'a, T> {}
-
-/// Typedef of a owning reference that uses a `RwLockPreemptSafeReadGuard` as the owner.
-pub type RwLockPreemptReadGuardRef<'a, T, U = T> = OwningRef<RwLockPreemptReadGuard<'a, T>, U>;
-/// Typedef of a mutable owning reference that uses a `RwLockPreemptWriteGuard` as the owner.
-pub type RwLockPreemptWriteGuardRefMut<'a, T, U = T> = OwningRefMut<RwLockPreemptWriteGuard<'a, T>, U>;
 
 /// Implement `Lockable` for [`RwLockPreempt`].
 impl<'t, T> Lockable<'t, T> for RwLockPreempt<T> where T: 't + ?Sized {

--- a/kernel/mutex_sleep/Cargo.toml
+++ b/kernel/mutex_sleep/Cargo.toml
@@ -7,22 +7,7 @@ edition = "2018"
 
 [dependencies]
 spin = "0.9.0"
-
-[dependencies.log]
-version = "0.4.8"
-
-
-[dependencies.stable_deref_trait]
-git = "https://github.com/theseus-os/stable_deref_trait.git"
-branch = "spin"
-default-features = false
-features = [ "alloc", "spin" ]
-
-[dependencies.owning_ref]
-# version = "0.3.3"
-# path = "../../libs/owning-ref-rs"
-git = "https://github.com/theseus-os/owning-ref-rs.git"
-
+log = "0.4.8"
 
 [dependencies.wait_queue]
 path = "../wait_queue"

--- a/kernel/mutex_sleep/src/mutex.rs
+++ b/kernel/mutex_sleep/src/mutex.rs
@@ -1,8 +1,6 @@
 use core::fmt;
 use core::ops::{Deref, DerefMut};
 use spin::{Mutex, MutexGuard};
-use owning_ref::{OwningRef, OwningRefMut};
-use stable_deref_trait::StableDeref;
 use wait_queue::WaitQueue;
 use lockable::{Lockable, LockableSized};
 
@@ -144,14 +142,6 @@ impl<'a, T: ?Sized> Drop for MutexSleepGuard<'a, T> {
         self.queue.notify_one();
     }
 }
-
-// Implement the StableDeref trait for MutexSleep guards, just like it's implemented for Mutex guards
-unsafe impl<'a, T: ?Sized> StableDeref for MutexSleepGuard<'a, T> {}
-
-/// Typedef of a owning reference that uses a `MutexSleepGuard` as the owner.
-pub type MutexSleepGuardRef<'a, T, U = T> = OwningRef<MutexSleepGuard<'a, T>, U>;
-/// Typedef of a mutable owning reference that uses a `MutexSleepGuard` as the owner.
-pub type MutexSleepGuardRefMut<'a, T, U = T> = OwningRefMut<MutexSleepGuard<'a, T>, U>;
 
 /// Implement `Lockable` for [`MutexSleep`].
 /// Because [`MutexSleep::lock()`] returns a `Result` and may fail,

--- a/kernel/mutex_sleep/src/rwlock.rs
+++ b/kernel/mutex_sleep/src/rwlock.rs
@@ -1,8 +1,6 @@
 use core::fmt;
 use core::ops::{Deref, DerefMut};
 use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use owning_ref::{OwningRef, OwningRefMut};
-use stable_deref_trait::StableDeref;
 use wait_queue::WaitQueue;
 use lockable::{Lockable, LockableSized};
 
@@ -305,15 +303,6 @@ impl<'rwlock, T: ?Sized> Drop for RwLockSleepWriteGuard<'rwlock, T> {
         self.queue.notify_one();
     }
 }
-
-// Implement the StableDeref trait for RwLockSleep guards, just like it's implemented for RwLock guards
-unsafe impl<'a, T: ?Sized> StableDeref for RwLockSleepReadGuard<'a, T> {}
-unsafe impl<'a, T: ?Sized> StableDeref for RwLockSleepWriteGuard<'a, T> {}
-
-/// Typedef of a owning reference that uses a `RwLockSleepSafeReadGuard` as the owner.
-pub type RwLockSleepReadGuardRef<'a, T, U = T> = OwningRef<RwLockSleepReadGuard<'a, T>, U>;
-/// Typedef of a mutable owning reference that uses a `RwLockSleepWriteGuard` as the owner.
-pub type RwLockSleepWriteGuardRefMut<'a, T, U = T> = OwningRefMut<RwLockSleepWriteGuard<'a, T>, U>;
 
 /// Implement `Lockable` for [`RwLockSleep`].
 /// Because [`RwLockSleep::read()`] and [`RwLockSleep::write()`] return `Result`s and may fail,


### PR DESCRIPTION
No longer needed since we're removing `owning_ref` usage/support in favor of `dereffer` and `BorrowedMappedPages`

Towards #482 