### PR TITLE
Respawn restartable tasks before performing final task cleanup

### DIFF
--- a/applications/rq_eval/src/lib.rs
+++ b/applications/rq_eval/src/lib.rs
@@ -154,6 +154,7 @@ fn run_single(iterations: usize) -> Result<(), &'static str> {
     let overhead = hpet_timing_overhead()?;
     let mut task = Task::new(
         None,
+        None,
         |_, _| loop { }, // dummy failure function
     )?;
     task.name = String::from("rq_eval_single_task_unrunnable");


### PR DESCRIPTION
* Also, allow `TaskBuilder` to provide a `Stack` for the new `Task` and a new "parent" task for certain states to be inherited.

This is a necessary prerequisite before migrating to a TLS-based (`#[thread_local]`) implementation of acquiring the current task,
in order to ensure that we don't run TLS area destructors before respawning a restartable task, which requires the current task to still be obtainable.