### PR TITLE
Add initial `aarch64` crates for basic boot-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.so
 *.rlib
 *.dll
+*.fd
 
 # Executables
 *.exe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ exclude = [
 	"build",
 	"target",
 
+	## Exclude the aarch64 experiment
+	"aarch64",
+
 	## Exclude configuration, tools, scripts, etc
 	"cfg",
 	"compiler_plugins",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 	"build",
 	"target",
 
-	## Exclude the aarch64 experiment
+	## Exclude the `aarch64` directory, which is a WIP port that currently must be built separately.
 	"aarch64",
 
 	## Exclude configuration, tools, scripts, etc

--- a/aarch64/Cargo.toml
+++ b/aarch64/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+resolver = "2"
+
+members = [
+    "kernel/[!.]*/",
+]
+
+exclude = [
+    "build",
+    "resources",
+]

--- a/aarch64/Cargo.toml
+++ b/aarch64/Cargo.toml
@@ -1,6 +1,10 @@
 [workspace]
 resolver = "2"
 
+default-members = [
+    "kernel/nano_core"
+]
+
 members = [
     "kernel/[!.]*/",
 ]

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -1,6 +1,6 @@
 TARGET=aarch64-unknown-uefi
 
-CARGOFLAGS += -p nano_core
+CARGOFLAGS += --workspace
 CARGOFLAGS += --release
 
 BUILD_STD_CARGOFLAGS += -Z unstable-options
@@ -41,7 +41,7 @@ create-build-structure:
 cargo-build: create-build-structure
 	@echo -e "\n=================== BUILDING ALL CRATES ==================="
 	@echo -e "\t TARGET: \"$(TARGET)\""
-	cargo +nightly build $(CARGOFLAGS) $(BUILD_STD_CARGOFLAGS) --target $(TARGET)
+	cargo build $(CARGOFLAGS) $(BUILD_STD_CARGOFLAGS) --target $(TARGET)
 
 ## This builds the nano_core binary itself, which is the fully-linked code that first runs right after the bootloader
 $(nano_core_binary): cargo-build

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -1,0 +1,53 @@
+TARGET=aarch64-unknown-uefi
+
+CARGOFLAGS += -p nano_core
+CARGOFLAGS += --release
+
+BUILD_STD_CARGOFLAGS += -Z unstable-options
+BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
+BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
+
+AARCH64_DIR = .
+BUILD_DIR = $(AARCH64_DIR)/build
+QEMU_EFI_FD = $(AARCH64_DIR)/resources/qemu-efi.fd
+NATIVE_OUTPUT = $(AARCH64_DIR)/target/aarch64-unknown-uefi/release/nano_core.efi
+nano_core_binary = $(BUILD_DIR)/efi
+
+# Configure the machine
+QEMU_FLAGS += -machine virt
+QEMU_FLAGS += -cpu cortex-a72
+QEMU_FLAGS += -smp 4
+QEMU_FLAGS += -m 1000
+QEMU_FLAGS += -net none
+# QEMU_FLAGS += -nographic
+
+# Include that file which enables efi support in qemu
+QEMU_FLAGS += -drive if=pflash,format=raw,file=$(QEMU_EFI_FD)
+
+# Include the build dir as an emulated fat drive
+QEMU_FLAGS += -drive file=fat:rw:$(BUILD_DIR)
+
+
+
+
+
+
+all: run
+
+create-build-structure:
+	mkdir -p $(BUILD_DIR)
+
+## This target invokes the actual Rust build process via `cargo`.
+cargo-build: create-build-structure
+	@echo -e "\n=================== BUILDING ALL CRATES ==================="
+	@echo -e "\t TARGET: \"$(TARGET)\""
+	cargo +nightly build $(CARGOFLAGS) $(BUILD_STD_CARGOFLAGS) --target $(TARGET)
+
+## This builds the nano_core binary itself, which is the fully-linked code that first runs right after the bootloader
+$(nano_core_binary): cargo-build
+	cp $(NATIVE_OUTPUT) $(nano_core_binary)
+
+### builds and runs Theseus in QEMU
+run: $(nano_core_binary)
+	cat resources/qemu-instructions.txt
+	qemu-system-aarch64 $(QEMU_FLAGS)

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -7,7 +7,7 @@ BUILD_STD_CARGOFLAGS += -Z unstable-options
 BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
 BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
 
-QEMU_EFI_FD_URL ?= https://l0.pm/qemu-efi.fd
+QEMU_EFI_ZIP_URL ?= https://github.com/theseus-os/prebuilt-resources/raw/main/qemu-efi.fd.zip
 
 AARCH64_DIR ?= .
 BUILD_DIR ?= $(AARCH64_DIR)/build
@@ -53,7 +53,10 @@ build: $(nano_core_binary)
 
 ## This downloads the binary blob making Qemu compatible with UEFI
 $(QEMU_EFI_FD):
-	wget $(QEMU_EFI_FD_URL) -O $(QEMU_EFI_FD)
+	wget $(QEMU_EFI_ZIP_URL) -O qemu-efi.zip
+	@# this will extract to ./resources/qemu-efi.fd
+	unzip qemu-efi.zip
+	rm qemu-efi.zip
 
 ### builds and runs Theseus in QEMU
 run: build $(QEMU_EFI_FD)

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -7,11 +7,13 @@ BUILD_STD_CARGOFLAGS += -Z unstable-options
 BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
 BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
 
-AARCH64_DIR = .
-BUILD_DIR = $(AARCH64_DIR)/build
-QEMU_EFI_FD = $(AARCH64_DIR)/resources/qemu-efi.fd
-NATIVE_OUTPUT = $(AARCH64_DIR)/target/aarch64-unknown-uefi/release/nano_core.efi
-nano_core_binary = $(BUILD_DIR)/efi
+QEMU_EFI_FD_URL ?= https://l0.pm/qemu-efi.fd
+
+AARCH64_DIR ?= .
+BUILD_DIR ?= $(AARCH64_DIR)/build
+QEMU_EFI_FD ?= $(AARCH64_DIR)/resources/qemu-efi.fd
+NATIVE_OUTPUT ?= $(AARCH64_DIR)/target/aarch64-unknown-uefi/release/nano_core.efi
+nano_core_binary ?= $(BUILD_DIR)/efi
 
 # Configure the machine
 QEMU_FLAGS += -machine virt
@@ -47,7 +49,10 @@ cargo-build: create-build-structure
 $(nano_core_binary): cargo-build
 	cp $(NATIVE_OUTPUT) $(nano_core_binary)
 
+$(QEMU_EFI_FD):
+	wget $(QEMU_EFI_FD_URL) -O $(QEMU_EFI_FD)
+
 ### builds and runs Theseus in QEMU
-run: $(nano_core_binary)
+run: $(nano_core_binary) $(QEMU_EFI_FD)
 	cat resources/qemu-instructions.txt
 	qemu-system-aarch64 $(QEMU_FLAGS)

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -49,10 +49,13 @@ cargo-build: create-build-structure
 $(nano_core_binary): cargo-build
 	cp $(NATIVE_OUTPUT) $(nano_core_binary)
 
+build: $(nano_core_binary)
+
+## This downloads the binary blob making Qemu compatible with UEFI
 $(QEMU_EFI_FD):
 	wget $(QEMU_EFI_FD_URL) -O $(QEMU_EFI_FD)
 
 ### builds and runs Theseus in QEMU
-run: $(nano_core_binary) $(QEMU_EFI_FD)
+run: build $(QEMU_EFI_FD)
 	cat resources/qemu-instructions.txt
 	qemu-system-aarch64 $(QEMU_FLAGS)

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -7,7 +7,7 @@ BUILD_STD_CARGOFLAGS += -Z unstable-options
 BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
 BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
 
-QEMU_EFI_ZIP_URL ?= https://github.com/theseus-os/prebuilt-resources/raw/main/qemu-efi.fd.zip
+QEMU_EFI_ZIP_URL ?= https://github.com/theseus-os/prebuilt-aavmf/raw/main/qemu-efi.fd.zip
 
 AARCH64_DIR ?= .
 BUILD_DIR ?= $(AARCH64_DIR)/build

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -7,7 +7,7 @@ BUILD_STD_CARGOFLAGS += -Z unstable-options
 BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
 BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
 
-QEMU_EFI_ZIP_URL ?= https://github.com/theseus-os/prebuilt-aavmf/raw/main/qemu-efi.fd.zip
+QEMU_EFI_ZIP_URL ?= https://github.com/theseus-os/prebuilt-aavmf/blob/2c7254d98ee98297ad0db243bb21ed5a631d2e50/qemu-efi.fd.zip
 
 AARCH64_DIR ?= .
 BUILD_DIR ?= $(AARCH64_DIR)/build

--- a/aarch64/README.md
+++ b/aarch64/README.md
@@ -1,0 +1,37 @@
+### Aarch64+UEFI port of Theseus OS
+
+This is an effort to port Theseus OS to Aarch64 (Arm).
+
+Only basic logging is currently implemented.
+
+This currently targets the "virt" Qemu virtual machine.
+It is not tested on any real-life machine at the moment.
+
+### Building and Running
+
+0. You will need
+
+- a Rust toolchain
+- `qemu-system-aarch64`
+- `wget`
+- make
+
+1. Build the UEFI app:
+
+```text
+$ make build
+```
+
+2. Run this app in Qemu:
+
+```text
+$ make run
+```
+
+3. Once Qemu has started:
+
+    a. Open the "View" menu
+    b. Click "Serial" to see the serial output
+    c. spam [enter] a few times until you see a prompt
+    d. write "fs0:\efi"
+    e. You should see the "Hello world" line among the other ones

--- a/aarch64/README.md
+++ b/aarch64/README.md
@@ -15,6 +15,7 @@ It is not tested on any real-life machine at the moment.
 - `qemu-system-aarch64`
 - `wget`
 - make
+- unzip
 
 1. Build the UEFI app:
 

--- a/aarch64/kernel/logger/Cargo.toml
+++ b/aarch64/kernel/logger/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "logger"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+log = "0.4.17"
+pl011_qemu = { git = "https://github.com/theseus-os/pl011/", branch = "aarch64-qemu-virt-test" }

--- a/aarch64/kernel/logger/lib.rs
+++ b/aarch64/kernel/logger/lib.rs
@@ -1,0 +1,37 @@
+#![no_std]
+
+use pl011_qemu::{PL011, UART1};
+use log::{Record, Metadata, Log, set_logger, set_max_level, STATIC_MAX_LEVEL};
+use core::{fmt::Write, mem::MaybeUninit};
+
+type QemuVirtUart = PL011<UART1>;
+
+pub struct Logger {
+    pub pl011: PL011<UART1>,
+}
+
+impl Log for Logger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        let mutable = unsafe { (self as *const Self).cast_mut().as_mut().unwrap() };
+
+        if self.enabled(record.metadata()) {
+            let _ = write!(&mut mutable.pl011, "{} - {}\r\n", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub static mut LOGGER: Logger = unsafe { MaybeUninit::uninit().assume_init() };
+
+pub fn init() {
+    unsafe {
+        LOGGER = Logger { pl011: QemuVirtUart::new(UART1::take().unwrap()) };
+        set_logger(&LOGGER).unwrap();
+        set_max_level(STATIC_MAX_LEVEL);
+    }
+}

--- a/aarch64/kernel/logger/lib.rs
+++ b/aarch64/kernel/logger/lib.rs
@@ -28,10 +28,10 @@ impl Log for Logger {
 
 pub static mut LOGGER: Logger = unsafe { MaybeUninit::uninit().assume_init() };
 
-pub fn init() {
+pub fn init() -> Result<(), &'static str> {
+    set_max_level(STATIC_MAX_LEVEL);
     unsafe {
         LOGGER = Logger { pl011: QemuVirtUart::new(UART1::take().unwrap()) };
-        set_logger(&LOGGER).unwrap();
-        set_max_level(STATIC_MAX_LEVEL);
+        set_logger(&LOGGER).map_err(|_| "logger::init - couldn't set logger")
     }
 }

--- a/aarch64/kernel/nano_core/Cargo.toml
+++ b/aarch64/kernel/nano_core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "nano_core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+uefi = { version = "0.16.1", features = [ "alloc", "exts", "logger" ] }
+uefi-services = "0.13.1"
+pl011_qemu = { git = "https://github.com/theseus-os/pl011/", branch = "aarch64-qemu-virt-test" }

--- a/aarch64/kernel/nano_core/Cargo.toml
+++ b/aarch64/kernel/nano_core/Cargo.toml
@@ -3,7 +3,22 @@ name = "nano_core"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "nano_core"
+path = "main.rs"
+
 [dependencies]
-uefi = { version = "0.16.1", features = [ "alloc", "exts", "logger" ] }
-uefi-services = "0.13.1"
-pl011_qemu = { git = "https://github.com/theseus-os/pl011/", branch = "aarch64-qemu-virt-test" }
+log = "0.4.17"
+logger = { path = "../logger" }
+
+[dependencies.uefi]
+git = "https://github.com/theseus-os/uefi-rs/"
+branch = "until-upstream-pr-merged"
+default-features = false
+features = [ "alloc", "exts" ]
+
+[dependencies.uefi-services]
+git = "https://github.com/theseus-os/uefi-rs/"
+branch = "until-upstream-pr-merged"
+default-features = false
+features = [ "panic_handler" ]

--- a/aarch64/kernel/nano_core/Cargo.toml
+++ b/aarch64/kernel/nano_core/Cargo.toml
@@ -9,16 +9,8 @@ path = "main.rs"
 
 [dependencies]
 log = "0.4.17"
+
 logger = { path = "../logger" }
 
-[dependencies.uefi]
-git = "https://github.com/theseus-os/uefi-rs/"
-branch = "until-upstream-pr-merged"
-default-features = false
-features = [ "alloc", "exts" ]
-
-[dependencies.uefi-services]
-git = "https://github.com/theseus-os/uefi-rs/"
-branch = "until-upstream-pr-merged"
-default-features = false
-features = [ "panic_handler" ]
+uefi = { version = "0.18", default-features = false, features = [ "alloc", "exts" ] }
+uefi-services = { version = "0.15", default-features = false, features = [ "panic_handler" ] }

--- a/aarch64/kernel/nano_core/main.rs
+++ b/aarch64/kernel/nano_core/main.rs
@@ -4,22 +4,18 @@
 #![no_main]
 
 extern crate alloc;
+extern crate logger;
 
 use alloc::vec;
-use core::fmt::Write;
 use core::arch::asm;
 
-use uefi_services::init;
 use uefi::prelude::entry;
 use uefi::Status;
 use uefi::Handle;
 use uefi::table::SystemTable;
 use uefi::table::Boot;
 
-use pl011_qemu::PL011;
-use pl011_qemu::UART1;
-
-pub type Pl011 = PL011<UART1>;
+use log::info;
 
 #[inline(never)]
 extern "C" fn inf_loop_0xbeef() -> ! {
@@ -32,7 +28,10 @@ fn main(
     handle: Handle,
     mut system_table: SystemTable<Boot>,
 ) -> Status {
-    init(&mut system_table).unwrap();
+    logger::init();
+    info!("Hello, World!");
+
+    uefi_services::init(&mut system_table).unwrap();
     let bootsvc = system_table.boot_services();
 
     let safety = 16;
@@ -42,10 +41,6 @@ fn main(
 
     let _ = system_table.exit_boot_services(handle, &mut mmap).unwrap();
 
-    let mut logger = PL011::new(UART1::take().unwrap());
-
-    let _ = logger.write_str("Hello, World!\r\n");
-
-    let _ = logger.write_str("Going to infinite loop now.\r\n");
+    info!("Going to infinite loop now.");
     inf_loop_0xbeef();
 }

--- a/aarch64/kernel/nano_core/main.rs
+++ b/aarch64/kernel/nano_core/main.rs
@@ -9,13 +9,9 @@ extern crate logger;
 use alloc::vec;
 use core::arch::asm;
 
-use uefi::prelude::entry;
-use uefi::Status;
-use uefi::Handle;
-use uefi::table::SystemTable;
-use uefi::table::Boot;
+use uefi::{prelude::entry, Status, Handle, table::{SystemTable, Boot}};
 
-use log::info;
+use log::{info, error};
 
 #[inline(never)]
 extern "C" fn inf_loop_0xbeef() -> ! {
@@ -23,15 +19,17 @@ extern "C" fn inf_loop_0xbeef() -> ! {
     loop {}
 }
 
-#[entry]
 fn main(
     handle: Handle,
     mut system_table: SystemTable<Boot>,
-) -> Status {
-    logger::init();
+) -> Result<(), &'static str> {
+
+    logger::init()?;
     info!("Hello, World!");
 
-    uefi_services::init(&mut system_table).unwrap();
+    uefi_services::init(&mut system_table)
+        .map_err(|_| "nano_core::main - couldn't init uefi services")?;
+
     let bootsvc = system_table.boot_services();
 
     let safety = 16;
@@ -39,8 +37,24 @@ fn main(
     let mmap_size = bootsvc.memory_map_size();
     let mut mmap = vec![0; mmap_size.map_size + safety * mmap_size.entry_size];
 
-    let _ = system_table.exit_boot_services(handle, &mut mmap).unwrap();
+    let _ = system_table.exit_boot_services(handle, &mut mmap)
+        .map_err(|_| "nano_core::main - couldn't exit uefi boot services")?;
 
     info!("Going to infinite loop now.");
     inf_loop_0xbeef();
+
+}
+
+#[entry]
+fn uefi_main(
+    handle: Handle,
+    system_table: SystemTable<Boot>,
+) -> Status {
+    match main(handle, system_table) {
+        Ok(()) => Status::SUCCESS,
+        Err(msg) => {
+            error!("{}", msg);
+            Status::ABORTED
+        },
+    }
 }

--- a/aarch64/kernel/nano_core/src/main.rs
+++ b/aarch64/kernel/nano_core/src/main.rs
@@ -1,0 +1,51 @@
+#![feature(naked_functions)]
+#![feature(abi_efiapi)]
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::vec;
+use core::fmt::Write;
+use core::arch::asm;
+
+use uefi_services::init;
+use uefi::prelude::entry;
+use uefi::Status;
+use uefi::Handle;
+use uefi::table::SystemTable;
+use uefi::table::Boot;
+
+use pl011_qemu::PL011;
+use pl011_qemu::UART1;
+
+pub type Pl011 = PL011<UART1>;
+
+#[inline(never)]
+extern "C" fn inf_loop_0xbeef() -> ! {
+    unsafe { asm!("mov x1, #0xbeef") };
+    loop {}
+}
+
+#[entry]
+fn main(
+    handle: Handle,
+    mut system_table: SystemTable<Boot>,
+) -> Status {
+    init(&mut system_table).unwrap();
+    let bootsvc = system_table.boot_services();
+
+    let safety = 16;
+
+    let mmap_size = bootsvc.memory_map_size();
+    let mut mmap = vec![0; mmap_size.map_size + safety * mmap_size.entry_size];
+
+    let _ = system_table.exit_boot_services(handle, &mut mmap).unwrap();
+
+    let mut logger = PL011::new(UART1::take().unwrap());
+
+    let _ = logger.write_str("Hello, World!\r\n");
+
+    let _ = logger.write_str("Going to infinite loop now.\r\n");
+    inf_loop_0xbeef();
+}

--- a/aarch64/resources/qemu-instructions.txt
+++ b/aarch64/resources/qemu-instructions.txt
@@ -1,0 +1,17 @@
+
+
+
+
+########################################
+#    RUNNING THE EFI IMAGE IN QEMU     #
+########################################
+
+1. Open the "View" menu
+2. Click "Serial" to see the serial output
+3. spam [enter] a few times until you see a prompt
+4. write "fs0:\efi"
+5. You should see the "Hello world" message
+
+
+
+

--- a/aarch64/resources/qemu-instructions.txt
+++ b/aarch64/resources/qemu-instructions.txt
@@ -10,7 +10,7 @@
 2. Click "Serial" to see the serial output
 3. spam [enter] a few times until you see a prompt
 4. write "fs0:\efi"
-5. You should see the "Hello world" message
+5. You should see the "Hello world" line among the other ones
 
 
 


### PR DESCRIPTION
This adds the `aarch64` directory, which contains code for Arm and has the same structure as the root directory.