### PR TITLE
Store a `LoadedSection`'s size separately from its address

### DIFF
--- a/applications/deps/src/lib.rs
+++ b/applications/deps/src/lib.rs
@@ -249,7 +249,7 @@ fn count_private_rodata_sections() -> Result<(), String> {
         let mut prv = 0;
         let mut publ = 0;
         let mut disc = 0;
-        for sec in crate_ref.lock_as_ref().sections.values().filter(|sec| sec.get_type() == mod_mgmt::SectionType::Rodata) {
+        for sec in crate_ref.lock_as_ref().sections.values().filter(|sec| sec.typ == mod_mgmt::SectionType::Rodata) {
             section_count += 1;
             let mut can_discard = true;
             if sec.global {

--- a/applications/loadc/src/lib.rs
+++ b/applications/loadc/src/lib.rs
@@ -459,7 +459,7 @@ fn overwrite_relocations(
                     relocation_entry,
                     target_segment_slice,
                     offset_into_target_segment,
-                    existing_source_sec.start_address(),
+                    existing_source_sec.virt_addr,
                     verbose_log
                 )?;
                 relocation_entry.offset = original_relocation_offset;

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -472,7 +472,7 @@ impl LoadedCrate {
                 new_sec_mapped_pages_ref,               // mapped_pages is different, points to the new duplicated one
                 new_sec_mapped_pages_offset,            // mapped_pages_offset is the same
                 new_sec_virt_addr,                      // virt_addr is different, based on the new mapped_pages
-                old_sec.size,                         // size is the same
+                old_sec.size,                           // size is the same
                 old_sec.global,                         // globalness is the same
                 new_crate_weak_ref.clone(),             // parent_crate is different, points to the newly-copied crate
                 old_sec_inner.sections_i_depend_on.clone(),   // dependencies are the same, but relocations need to be re-written

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -657,7 +657,7 @@ pub struct LoadedSection {
     pub mapped_pages: Arc<Mutex<MappedPages>>, 
     /// The offset into the `mapped_pages` where this section starts
     pub mapped_pages_offset: usize,
-    /// The starting `VirtualAddress` of by this section.
+    /// The starting `VirtualAddress` of this section.
     ///
     /// For TLS sections, this is *not* a `VirtualAddress`, but rather the offset
     /// (from the TLS base) into the TLS area where this section's data exists.

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -280,7 +280,7 @@ impl LoadedCrate {
     /// Only matches demangled names, e.g., "my_crate::foo".
     pub fn get_function_section(&self, func_name: &str) -> Option<&StrongSectionRef> {
         self.find_section(|sec| 
-            sec.get_type() == SectionType::Text &&
+            sec.typ == SectionType::Text &&
             sec.name.as_str() == func_name
         )
     }
@@ -472,7 +472,7 @@ impl LoadedCrate {
                 new_sec_mapped_pages_ref,               // mapped_pages is different, points to the new duplicated one
                 new_sec_mapped_pages_offset,            // mapped_pages_offset is the same
                 new_sec_virt_addr,                      // virt_addr is different, based on the new mapped_pages
-                old_sec.size(),                         // size is the same
+                old_sec.size,                         // size is the same
                 old_sec.global,                         // globalness is the same
                 new_crate_weak_ref.clone(),             // parent_crate is different, points to the newly-copied crate
                 old_sec_inner.sections_i_depend_on.clone(),   // dependencies are the same, but relocations need to be re-written
@@ -508,7 +508,7 @@ impl LoadedCrate {
             let new_sec_mapped_pages_offset = new_sec.mapped_pages_offset;
             let new_sec_slice: &mut [u8] = new_sec_mapped_pages.as_slice_mut(
                 0,
-                new_sec_mapped_pages_offset + new_sec.size(),
+                new_sec_mapped_pages_offset + new_sec.size,
             )?;
 
             // The newly-duplicated crate still depends on the same sections, so we keep those as is, 
@@ -657,15 +657,17 @@ pub struct LoadedSection {
     pub mapped_pages: Arc<Mutex<MappedPages>>, 
     /// The offset into the `mapped_pages` where this section starts
     pub mapped_pages_offset: usize,
-    /// The range of `VirtualAddress`es covered by this section, i.e., 
-    /// the starting (inclusive) and ending (exclusive) `VirtualAddress` of this section.
-    /// This can be used to calculate size, but is primarily a performance optimization
-    /// so we can avoid locking this section's `MappedPages` and avoid recalculating 
-    /// its bounds based on its offset and size. 
-    /// 
-    /// For TLS sections, this `address_range.start` holds the offset (from the TLS base)
-    /// into the TLS area where this section's data exists.
-    pub address_range: Range<VirtualAddress>, 
+    /// The starting `VirtualAddress` of by this section.
+    ///
+    /// For TLS sections, this is *not* a `VirtualAddress`, but rather the offset
+    /// (from the TLS base) into the TLS area where this section's data exists.
+    ///
+    /// For all other sections, this is simply a performance optimization that avoids
+    /// having to calculate its starting virtual address by invoking
+    /// `self.mapped_pages.address_at_offset(self.mapped_pages_offset)`.
+    pub virt_addr: VirtualAddress,
+    /// The size in bytes of this section.
+    pub size: usize,
     /// The `LoadedCrate` object that contains/owns this section
     pub parent_crate: WeakCrateRef,
     /// The inner contents of a section that could possibly change
@@ -720,7 +722,8 @@ impl LoadedSection {
             name,
             mapped_pages,
             mapped_pages_offset,
-            address_range: virt_addr .. (virt_addr + size),
+            virt_addr,
+            size,
             global,
             parent_crate,
             inner: RwLock::new(LoadedSectionInner {
@@ -732,28 +735,12 @@ impl LoadedSection {
         }
     }
 
-    /// Returns the starting `VirtualAddress` of where this section is loaded into memory. 
-    pub fn start_address(&self) -> VirtualAddress {
-        self.address_range.start
-    }
-
-    /// Returns the size in bytes of this section.
-    pub fn size(&self) -> usize {
-        self.address_range.end.value() - self.address_range.start.value()
-    }
-
-    /// Returns the type of this section.
-    pub fn get_type(&self) -> SectionType {
-        self.typ
-    }
-
     /// Returns the substring of this section's name that excludes the trailing hash. 
     /// 
     /// See the identical associated function [`section_name_without_hash()`](#fn.section_name_without_hash.html) for more. 
     pub fn name_without_hash(&self) -> &str {
         Self::section_name_without_hash(self.name.as_str())
     }
-
 
     /// Returns the substring of the given section's name that excludes the trailing hash,
     /// but includes the hash delimiter "`::h`". 
@@ -767,7 +754,6 @@ impl LoadedSection {
             .and_then(|end| sec_name.get(0 .. (end + SECTION_HASH_DELIMITER.len())))
             .unwrap_or(&sec_name)
     }
-
 
     /// Returns the index of the first `WeakDependent` object in this `LoadedSection`'s `sections_dependent_on_me` list
     /// in which the section matches the given `matching_section` 
@@ -791,20 +777,20 @@ impl LoadedSection {
     pub fn copy_section_data_to(&self, destination_section: &LoadedSection) -> Result<(), &'static str> {
 
         let mut dest_sec_mapped_pages = destination_section.mapped_pages.lock();
-        let dest_sec_data: &mut [u8] = dest_sec_mapped_pages.as_slice_mut(destination_section.mapped_pages_offset, destination_section.size())?;
+        let dest_sec_data: &mut [u8] = dest_sec_mapped_pages.as_slice_mut(destination_section.mapped_pages_offset, destination_section.size)?;
 
         let source_sec_mapped_pages = self.mapped_pages.lock();
-        let source_sec_data: &[u8] = source_sec_mapped_pages.as_slice(self.mapped_pages_offset, self.size())?;
+        let source_sec_data: &[u8] = source_sec_mapped_pages.as_slice(self.mapped_pages_offset, self.size)?;
 
         if dest_sec_data.len() == source_sec_data.len() {
             dest_sec_data.copy_from_slice(source_sec_data);
             // debug!("Copied data from source section {:?} {:?} ({:#X}) to dest section {:?} {:?} ({:#X})",
-            //     self.typ, self.name, self.size(), destination_section.typ, destination_section.name, destination_section.size());
+            //     self.typ, self.name, self.size, destination_section.typ, destination_section.name, destination_section.size);
             Ok(())
         }
         else {
             error!("This source section {:?}'s size ({:#X}) is different from the destination section {:?}'s size ({:#X})",
-                self.name, self.size(), destination_section.name, destination_section.size());
+                self.name, self.size, destination_section.name, destination_section.size);
             Err("this source section has a different length than the destination section")
         }
     }
@@ -853,7 +839,7 @@ impl LoadedSection {
         }
 
         // Check that the bounds of this entire section fit within its MappedPages
-        let end = self.mapped_pages_offset + self.size();
+        let end = self.mapped_pages_offset + self.size;
         if end > mp.size_in_bytes() {
             error!("Requested LoadedSection as function {:?}, but section's end offset ({:X?}) was beyond its MappedPages ({:X?})",
                 core::any::type_name::<F>(), end, mp.size_in_bytes()
@@ -880,8 +866,8 @@ impl fmt::Display for LoadedSection {
             "LoadedSection({:?}, typ: {:?}, vaddr: {:#X}, size: {})", 
             self.name,
             self.typ,
-            self.start_address(),
-            self.size(),
+            self.virt_addr,
+            self.size,
         )
     }
 }
@@ -907,8 +893,8 @@ impl fmt::Debug for LoadedSection {
         }
 
         // Add the rest of the typical fields
-        dbg.field("vaddr", &self.start_address())
-            .field("size", &self.size())
+        dbg.field("vaddr", &self.virt_addr)
+            .field("size", &self.size)
             .finish_non_exhaustive()
     }
 }

--- a/kernel/crate_swap/src/lib.rs
+++ b/kernel/crate_swap/src/lib.rs
@@ -433,9 +433,9 @@ pub fn swap_crates(
 
                         write_relocation(
                             relocation_entry, 
-                            target_sec_mapped_pages.as_slice_mut(0, target_sec.mapped_pages_offset + target_sec.size())?,
+                            target_sec_mapped_pages.as_slice_mut(0, target_sec.mapped_pages_offset + target_sec.size)?,
                             target_sec.mapped_pages_offset, 
-                            new_source_sec.start_address(),
+                            new_source_sec.virt_addr,
                             verbose_log
                         )?;
 

--- a/kernel/debug_info/src/lib.rs
+++ b/kernel/debug_info/src/lib.rs
@@ -730,14 +730,14 @@ impl DebugSymbols {
                     // trace!("             Entry name {} {:?} vis {:?} bind {:?} type {:?} shndx {} value {} size {}", 
                     //     source_sec_entry.name(), source_sec_entry.get_name(&elf_file), 
                     //     source_sec_entry.get_other(), source_sec_entry.get_binding(), source_sec_entry.get_type(), 
-                    //     source_sec_entry.shndx(), source_sec_entry.value(), source_sec_entry.size());
+                    //     source_sec_entry.shndx(), source_sec_entry.value(), source_sec_entry.size);
                 }
                 
                 let mut source_and_target_in_same_crate = false;
 
                 // We first check if the source section is another debug section, then check if its a local section from the given `loaded_crate`.
                 let (source_sec_vaddr, source_sec_dep) = match shndx_map.get(&source_sec_shndx).map(|s| (s.virt_addr, None))
-                    .or_else(|| loaded_crate.lock_as_ref().sections.get(&source_sec_shndx).map(|sec| (sec.address_range.start, Some(sec.clone()))))
+                    .or_else(|| loaded_crate.lock_as_ref().sections.get(&source_sec_shndx).map(|sec| (sec.virt_addr, Some(sec.clone()))))
                 {
                     // We found the source section in the local debug sections or the given loaded crate. 
                     Some(found) => {
@@ -764,7 +764,7 @@ impl DebugSymbols {
                             namespace.get_symbol_or_load(&demangled, None, kernel_mmi_ref, false)
                                 .upgrade()
                                 .ok_or("Couldn't get symbol for .debug section's foreign relocation entry, nor load its containing crate")
-                                .map(|sec| (sec.address_range.start, Some(sec)))
+                                .map(|sec| (sec.virt_addr, Some(sec)))
                         }
                         else {
                             let _source_sec_header = source_sec_entry

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -194,7 +194,7 @@ fn parse_nano_core_symbol_file_or_binary(
     
     // // Dump loaded sections for verification. See pull request #559 for more details:
     // for (_, section) in new_crate_mut.sections.iter() {
-    //     trace!("{:016x} {} {}", section.address_range.start.value(), section.name, section.mapped_pages_offset);
+    //     trace!("{:016x} {} {}", section.virt_addr.value(), section.name, section.mapped_pages_offset);
     // }
 
     drop(new_crate_mut);

--- a/kernel/mod_mgmt/src/replace_nano_core_crates.rs
+++ b/kernel/mod_mgmt/src/replace_nano_core_crates.rs
@@ -142,7 +142,7 @@ fn load_crate_using_nano_core_data_sections(
         // have already been added to the symbol map when the nano_core was originally parsed.
         _num_new_syms = namespace.add_symbols_filtered(
             new_crate.sections.values(), 
-            |sec| !sec.get_type().is_data_or_bss(),
+            |sec| !sec.typ.is_data_or_bss(),
             verbose_log,
         );
         _num_new_sections = new_crate.sections.len();

--- a/kernel/mod_mgmt/src/serde.rs
+++ b/kernel/mod_mgmt/src/serde.rs
@@ -65,7 +65,7 @@ pub(crate) fn into_loaded_crate(
     // // Dump loaded sections for verification. See pull request #542/#559 for more details:
     // let loaded_crate_ref = loaded_crate.lock_as_ref();
     // for (_, section) in loaded_crate_ref.sections.iter() {
-    //     trace!("{:016x} {} {}", section.address_range.start.value(), section.name, section.mapped_pages_offset);
+    //     trace!("{:016x} {} {}", section.virt_addr.value(), section.name, section.mapped_pages_offset);
     // }
     // drop(loaded_crate_ref);
 
@@ -104,7 +104,8 @@ fn into_loaded_section(
         global: serialized_section.global,
         mapped_pages_offset: serialized_section.offset,
         mapped_pages,
-        address_range: virtual_address..(virtual_address + serialized_section.size),
+        virt_addr: virtual_address,
+        size: serialized_section.size,
         parent_crate,
         inner: Default::default(),
     });

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -216,7 +216,7 @@ pub fn new_application_task_builder(
         let app_crate = app_crate_ref.lock_as_ref();
         let expected_main_section_name = format!("{}{}{}", app_crate.crate_name_as_prefix(), ENTRY_POINT_SECTION_NAME, SECTION_HASH_DELIMITER);
         app_crate.find_section(|sec| 
-            sec.get_type() == SectionType::Text && sec.name_without_hash() == &expected_main_section_name
+            sec.typ == SectionType::Text && sec.name_without_hash() == &expected_main_section_name
         ).cloned()
     };
     let main_func_sec = main_func_sec_opt.ok_or("spawn::new_application_task_builder(): couldn't find \"main\" function, expected function name like \"<crate_name>::main::<hash>\"\

--- a/kernel/state_transfer/src/lib.rs
+++ b/kernel/state_transfer/src/lib.rs
@@ -37,7 +37,7 @@ pub fn prio_sched(_old_namespace: &Arc<CrateNamespace>, _new_namespace: &CrateNa
         let krate = rq_rr_crate.lock_as_ref();
         for sec in krate.sections.values() {
             if sec.name.contains("RUNQUEUES") {
-                debug!("Section {}\n\ttype: {:?}\n\tvaddr: {:#X}\n\tsize: {}\n", sec.name, sec.typ, sec.start_address(), sec.size());
+                debug!("Section {}\n\ttype: {:?}\n\tvaddr: {:#X}\n\tsize: {}\n", sec.name, sec.typ, sec.virt_addr, sec.size);
             }
         }
         warn!("REPLACING LAZY_STATIC RUNQUEUES...");

--- a/kernel/unwind/src/lib.rs
+++ b/kernel/unwind/src/lib.rs
@@ -681,7 +681,7 @@ impl UnwindRowReference {
         match &self.eh_frame_sec {
             EhFrameReference::Section(sec) => {
                 let sec_pages = sec.mapped_pages.lock();
-                let eh_frame_slice: &[u8] = sec_pages.as_slice(sec.mapped_pages_offset, sec.size())?;
+                let eh_frame_slice: &[u8] = sec_pages.as_slice(sec.mapped_pages_offset, sec.size)?;
                 invoke_f_with_eh_frame_slice(eh_frame_slice)
             }
             EhFrameReference::External(uw_info) => {
@@ -709,7 +709,7 @@ fn get_eh_frame_info(crate_ref: &StrongCrateRef) -> Option<(StrongSectionRef, Ba
     let eh_frame_sec = krate.sections.values()
         .find(|s| s.typ == SectionType::EhFrame)?;
     
-    let eh_frame_vaddr = eh_frame_sec.start_address().value();
+    let eh_frame_vaddr = eh_frame_sec.virt_addr.value();
     let text_pages_vaddr = krate.text_pages.as_ref()?.1.start.value();
     let base_addrs = BaseAddresses::default()
         .set_eh_frame(eh_frame_vaddr as u64)
@@ -821,8 +821,8 @@ fn continue_unwinding(unwinding_context_ptr: *mut UnwindingContext) -> Result<()
                 #[cfg(not(downtime_eval))]
                 info!("  parsing LSDA section: {:?}", sec);
                 
-                let starting_offset = sec.mapped_pages_offset + (lsda.value() - sec.address_range.start.value());
-                let length_til_end_of_mp = sec.address_range.end.value() - lsda.value();
+                let starting_offset = sec.mapped_pages_offset + (lsda.value() - sec.virt_addr.value());
+                let length_til_end_of_mp = sec.virt_addr.value() + sec.size - lsda.value();
                 let sec_mp = sec.mapped_pages.lock();
                 let lsda_slice = sec_mp.as_slice::<u8>(starting_offset, length_til_end_of_mp)
                     .map_err(|_e| "continue_unwinding(): couldn't get LSDA pointer as a slice")?;


### PR DESCRIPTION
* It's actually faster and simpler to store size and address separately,
  and it doesn't change the memory usage of the `LoadedSection` struct.

* Plus, for TLS sections, an address range doesn't make sense. 
  These sections have a size that is unrelated to their address value,
  because that address value represents an offset into the TLS area.

* Also remove a few unnecessary "getter" functions from `LoadedSection`