### PR TITLE
Use native TLS to store the current task for each task

### DIFF
--- a/cfg/Config.mk
+++ b/cfg/Config.mk
@@ -83,6 +83,13 @@ export override RUSTFLAGS += -Z merge-functions=disabled
 ## As far as I can tell, this does not have a significant impact on object code size or performance.
 export override RUSTFLAGS += -Z share-generics=no
 
+## This forces all code to use the simplest (and most efficient) model
+## for Thread-Local Storage (TLS): the "Local Exec" model.
+## We don't currently support the three other forms, as some of them
+## (e.g., "Initial Exec") require support for a Global Offset Table (GOT).
+## If we support GOT in the future, we can remove this.
+export override RUSTFLAGS += -Z tls-model=local-exec
+
 ## This forces frame pointers to be generated, i.e., the stack base pointer (RBP register on x86_64)
 ## will be used to store the starting address of the current stack frame.
 ## This can be used for obtaining a backtrace/stack trace,

--- a/kernel/context_switch/Cargo.toml
+++ b/kernel/context_switch/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "context_switch"
 description = "Top-level wrapper crate for managing all possible configurations for context switching routines and structs"
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 cfg-if = "0.1.6"

--- a/kernel/context_switch_avx/src/lib.rs
+++ b/kernel/context_switch_avx/src/lib.rs
@@ -10,6 +10,7 @@ extern crate zerocopy;
 use context_switch_regular::ContextRegular;
 use zerocopy::FromBytes;
 
+pub use context_switch_regular::read_first_register;
 
 /// The registers saved before a context switch and restored after a context switch
 /// for AVX-enabled Tasks.
@@ -66,9 +67,9 @@ impl ContextAVX {
     /// Sets the value of the first regular (non-AVX) register to the given `value`.
     /// 
     /// This is useful for storing a value (e.g., task ID) in that register
-    /// and then recovering it later with [`ContextRegular::read_first_reg()`].
+    /// and then recovering it later with [`read_first_register()`].
     /// 
-    /// On x86_64, this is the `r15` register.
+    /// On x86_64, this sets the `r15` register.
     pub fn set_first_register(&mut self, value: usize) {
         self.regular.set_first_register(value);
     }

--- a/kernel/context_switch_avx/src/lib.rs
+++ b/kernel/context_switch_avx/src/lib.rs
@@ -62,6 +62,16 @@ impl ContextAVX {
             regular: ContextRegular::new(rip),
         }
     }
+
+    /// Sets the value of the first regular (non-AVX) register to the given `value`.
+    /// 
+    /// This is useful for storing a value (e.g., task ID) in that register
+    /// and then recovering it later with [`ContextRegular::read_first_reg()`].
+    /// 
+    /// On x86_64, this is the `r15` register.
+    pub fn set_first_register(&mut self, value: usize) {
+        self.regular.set_first_register(value);
+    }
 }
 
 

--- a/kernel/context_switch_regular/src/lib.rs
+++ b/kernel/context_switch_regular/src/lib.rs
@@ -51,7 +51,7 @@ impl ContextRegular {
     /// This is useful for storing a value (e.g., task ID) in that register
     /// and then recovering it later with [`ContextRegular::read_first_reg()`].
     /// 
-    /// On x86_64, this is the `r15` register.
+    /// On x86_64, this sets the `r15` register.
     pub fn set_first_register(&mut self, value: usize) {
         self.r15 = value;
     }
@@ -66,9 +66,10 @@ impl ContextRegular {
 /// `ContextRegular` has been used for switching to a new task for the first time.
 /// 
 /// Returns the current value held in the specified CPU register.
-/// On x86_64, this is the `r15` register.
+/// On x86_64, this reads the `r15` register.
 #[naked]
 pub extern "C" fn read_first_register() -> usize {
+    // SAFE: simply reads and returns the value of `r15`.
     unsafe {
         core::arch::asm!(
             "mov rax, r15", // rax is used for return values on x86_64

--- a/kernel/context_switch_regular/src/lib.rs
+++ b/kernel/context_switch_regular/src/lib.rs
@@ -45,6 +45,37 @@ impl ContextRegular {
             rip,
         }
     }
+
+    /// Sets the value of the first register to the given `value`.
+    /// 
+    /// This is useful for storing a value (e.g., task ID) in that register
+    /// and then recovering it later with [`ContextRegular::read_first_reg()`].
+    /// 
+    /// On x86_64, this is the `r15` register.
+    pub fn set_first_register(&mut self, value: usize) {
+        self.r15 = value;
+    }
+}
+
+/// Reads the value of the first register from the actual CPU register hardware.
+/// 
+/// This can be called at any time, but is intended for use as the second half
+/// of "saving and restoring" a register value.
+/// The first half was a previous call to [`ContextRegular::set_first_reg()`],
+/// and the second half is a call to this function immediately after the original
+/// `ContextRegular` has been used for switching to a new task for the first time.
+/// 
+/// Returns the current value held in the specified CPU register.
+/// On x86_64, this is the `r15` register.
+#[naked]
+pub extern "C" fn read_first_register() -> usize {
+    unsafe {
+        core::arch::asm!(
+            "mov rax, r15", // rax is used for return values on x86_64
+            "ret",
+            options(noreturn)
+        )
+    }
 }
 
 

--- a/kernel/context_switch_sse/src/lib.rs
+++ b/kernel/context_switch_sse/src/lib.rs
@@ -10,6 +10,7 @@ extern crate zerocopy;
 use context_switch_regular::ContextRegular;
 use zerocopy::FromBytes;
 
+pub use context_switch_regular::read_first_register;
 
 /// The registers saved before a context switch and restored after a context switch
 /// for SSE-enabled Tasks.
@@ -66,9 +67,9 @@ impl ContextSSE {
     /// Sets the value of the first regular (non-SSE) register to the given `value`.
     /// 
     /// This is useful for storing a value (e.g., task ID) in that register
-    /// and then recovering it later with [`ContextRegular::read_first_reg()`].
+    /// and then recovering it later with [`read_first_register()`].
     /// 
-    /// On x86_64, this is the `r15` register.
+    /// On x86_64, this sets the `r15` register.
     pub fn set_first_register(&mut self, value: usize) {
         self.regular.set_first_register(value);
     }

--- a/kernel/context_switch_sse/src/lib.rs
+++ b/kernel/context_switch_sse/src/lib.rs
@@ -62,6 +62,16 @@ impl ContextSSE {
             regular: ContextRegular::new(rip),
         }
     }
+
+    /// Sets the value of the first regular (non-SSE) register to the given `value`.
+    /// 
+    /// This is useful for storing a value (e.g., task ID) in that register
+    /// and then recovering it later with [`ContextRegular::read_first_reg()`].
+    /// 
+    /// On x86_64, this is the `r15` register.
+    pub fn set_first_register(&mut self, value: usize) {
+        self.regular.set_first_register(value);
+    }
 }
 
 

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -1070,12 +1070,12 @@ pub fn write_relocation(
             if verbose_log { trace!("                    target_ptr: {:p}, source_val: {:#X} (from source_sec_vaddr {:#X})", target_ref.as_ptr(), source_val, source_sec_vaddr); }
             target_ref.copy_from_slice(&source_val.to_ne_bytes());
         }
-        R_X86_64_GOTTPOFF => {
-            // 32-bit signed PC-relative offset to the GOT entry for the IE (Initial Exec(utable) TLS model))
-            debug!("R_X86_64_GOTTPOFF: {:#X?}", relocation_entry);
-            debug!("R_X86_64_GOTTPOFF: target: {:#X}, source: {:#X}", target_sec_slice.as_ptr() as usize + target_sec_offset, source_sec_vaddr);
-            todo!("finish")
-        }
+        // R_X86_64_GOTTPOFF => {
+        //     // 32-bit signed PC-relative offset to the GOT entry for the IE (Initial Exec(utable) TLS model))
+        //     debug!("R_X86_64_GOTTPOFF: {:#X?}", relocation_entry);
+        //     debug!("R_X86_64_GOTTPOFF: target: {:#X}, source: {:#X}", target_sec_slice.as_ptr() as usize + target_sec_offset, source_sec_vaddr);
+        //     unimplemented!()
+        // }
         // R_X86_64_GOTPCREL => { 
         //     unimplemented!(); // if we stop using the large code model, we need to create a Global Offset Table
         // }

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -657,7 +657,7 @@ pub struct LoadedSection {
     pub mapped_pages: Arc<Mutex<MappedPages>>, 
     /// The offset into the `mapped_pages` where this section starts
     pub mapped_pages_offset: usize,
-    /// The starting `VirtualAddress` of this section.
+    /// The starting `VirtualAddress` of this section (except for TLS sections).
     ///
     /// For TLS sections, this is *not* a `VirtualAddress`, but rather the offset
     /// (from the TLS base) into the TLS area where this section's data exists.
@@ -1027,7 +1027,7 @@ pub fn write_relocation(
 
     // Perform the actual writing of relocation data here.
     // There is a great, succint table of relocation types here:
-    // <https://docs.rs/goblin/0.0.24/goblin/elf/reloc/index.html>
+    // <https://docs.rs/goblin/0.6.0/goblin/elf/reloc/index.html>
     match relocation_entry.typ {
         R_X86_64_32 => {
             let target_range = target_sec_offset .. (target_sec_offset + size_of::<u32>());
@@ -1059,19 +1059,34 @@ pub fn write_relocation(
             target_ref.copy_from_slice(&source_val.to_ne_bytes());
         }
         R_X86_64_TPOFF32 => {
-            let target_range = target_sec_offset .. (target_sec_offset + size_of::<u32>());
+            let target_range = target_sec_offset .. (target_sec_offset + size_of::<i32>());
             let target_ref = &mut target_sec_slice[target_range];
-            let source_val = u32::try_from(source_sec_vaddr.value())
-                .map_err(|_| "BUG: TLS relocation (R_X86_64_TPOFF32) source section value (TLS offset) cannot fit in a `u32`")?;
+            // Here we treat the `source_sec_vaddr` value as a signed value 
+            // by casting its bit value directly, i.e., `usize as isize`.
+            let offset_val = source_sec_vaddr.value() as isize;
+            // Now we must check that the signed `offset_val` fits in `i32`
+            let source_val = i32::try_from(offset_val)
+                .map_err(|_| "BUG: TLS relocation (R_X86_64_TPOFF32) source section value (TLS offset) cannot fit in a `i32`")?;
             if verbose_log { trace!("                    target_ptr: {:p}, source_val: {:#X} (from source_sec_vaddr {:#X})", target_ref.as_ptr(), source_val, source_sec_vaddr); }
             target_ref.copy_from_slice(&source_val.to_ne_bytes());
+        }
+        R_X86_64_GOTTPOFF => {
+            // 32-bit signed PC-relative offset to the GOT entry for the IE (Initial Exec(utable) TLS model))
+            debug!("R_X86_64_GOTTPOFF: {:#X?}", relocation_entry);
+            debug!("R_X86_64_GOTTPOFF: target: {:#X}, source: {:#X}", target_sec_slice.as_ptr() as usize + target_sec_offset, source_sec_vaddr);
+            todo!("finish")
         }
         // R_X86_64_GOTPCREL => { 
         //     unimplemented!(); // if we stop using the large code model, we need to create a Global Offset Table
         // }
         _ => {
-            error!("found unsupported relocation type {}\n  --> Are you compiling crates with 'code-model=large'?", relocation_entry.typ);
-            return Err("found unsupported relocation type. Are you compiling crates with 'code-model=large'?");
+            error!("found unsupported relocation type {}\n    \
+                --> Are you compiling crates with 'code-model=large' and 'tls-model=local-exec'?",
+                relocation_entry.typ
+            );
+            return Err("found unsupported relocation type. \
+                Are you compiling crates with 'code-model=large' and 'tls-model=local-exec'?"
+            );
         }
     }
 

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -229,8 +229,9 @@ fn parse_nano_core_symbol_file(
     let mut rodata_shndx:   Option<Shndx> = None;
     let mut data_shndx:     Option<Shndx> = None;
     let mut bss_shndx:      Option<Shndx> = None;
-    let mut tls_data_shndx: Option<(Shndx, VirtualAddress)> = None;
-    let mut tls_bss_shndx:  Option<(Shndx, VirtualAddress)> = None;
+    let mut tls_data_info:  Option<(Shndx, VirtualAddress)> = None;
+    let mut tls_bss_info:   Option<(Shndx, VirtualAddress)> = None;
+    let mut total_tls_size: usize = 0;
 
     /// An internal function that parses a section header's index (e.g., "[7]") out of the given str.
     /// Returns a tuple of the parsed `Shndx` and the rest of the unparsed str after the shndx.
@@ -287,14 +288,22 @@ fn parse_nano_core_symbol_file(
             rodata_shndx = parse_section_ndx(line).map(|(shndx, _)| shndx);
         }
         else if line.contains(".tdata ") && line.contains("PROGBITS") {
-            tls_data_shndx = parse_section_ndx(line).and_then(|(shndx, rest_of_line)| 
-                parse_section_vaddr_size(rest_of_line).map(|(vaddr, _)| (shndx, vaddr))
-            );
+            tls_data_info = parse_section_ndx(line)
+                .and_then(|(shndx, rest_of_line)| parse_section_vaddr_size(rest_of_line)
+                    .map(|(vaddr, size)| {
+                        total_tls_size += size;
+                        (shndx, vaddr)
+                    })
+                );
         }
         else if line.contains(".tbss ") && line.contains("NOBITS") {
-            tls_bss_shndx = parse_section_ndx(line).and_then(|(shndx, rest_of_line)| 
-                parse_section_vaddr_size(rest_of_line).map(|(vaddr, _)| (shndx, vaddr))
-            );
+            tls_bss_info = parse_section_ndx(line)
+                    .and_then(|(shndx, rest_of_line)| parse_section_vaddr_size(rest_of_line)
+                    .map(|(vaddr, size)| {
+                        total_tls_size += size;
+                        (shndx, vaddr)
+                    })
+                );
         }
         else if line.contains(".data ") && line.contains("PROGBITS") {
             data_shndx = parse_section_ndx(line).map(|(shndx, _)| shndx);
@@ -346,11 +355,14 @@ fn parse_nano_core_symbol_file(
         }
     }
 
-    let text_shndx   = text_shndx  .ok_or("parse_nano_core_symbol_file(): couldn't find .text section index")?;
-    let rodata_shndx = rodata_shndx.ok_or("parse_nano_core_symbol_file(): couldn't find .rodata section index")?;
-    let data_shndx   = data_shndx  .ok_or("parse_nano_core_symbol_file(): couldn't find .data section index")?;
-    let bss_shndx    = bss_shndx   .ok_or("parse_nano_core_symbol_file(): couldn't find .bss section index")?;
-    let shndxs = MainShndx { text_shndx, rodata_shndx, data_shndx, bss_shndx, tls_data_shndx, tls_bss_shndx };
+    let text_shndx    = text_shndx  .ok_or("parse_nano_core_symbol_file(): couldn't find .text section index")?;
+    let rodata_shndx  = rodata_shndx.ok_or("parse_nano_core_symbol_file(): couldn't find .rodata section index")?;
+    let data_shndx    = data_shndx  .ok_or("parse_nano_core_symbol_file(): couldn't find .data section index")?;
+    let bss_shndx     = bss_shndx   .ok_or("parse_nano_core_symbol_file(): couldn't find .bss section index")?;
+    let main_sec_info = MainSectionInfo {
+        text_shndx, rodata_shndx, data_shndx, bss_shndx,
+        tls_data_info, tls_bss_info, total_tls_size,
+    };
 
     // second, skip ahead to the start of the symbol table: a line which contains ".symtab" but does NOT contain "SYMTAB"
     let is_start_of_symbol_table = |line: &str| { line.contains(".symtab") && !line.contains("SYMTAB") };
@@ -434,7 +446,7 @@ fn parse_nano_core_symbol_file(
 
             add_new_section(
                 namespace,
-                &shndxs, 
+                &main_sec_info, 
                 &mut crate_items, 
                 text_pages, 
                 rodata_pages, 
@@ -483,14 +495,14 @@ fn parse_nano_core_binary(
         }
     };
     
-    // find the .text, .data, and .rodata sections
+    // Find info about the main sections: .text, .rodata, .data, .bss, and optionally TLS sections
     let mut text_shndx:     Option<Shndx> = None;
     let mut rodata_shndx:   Option<Shndx> = None;
     let mut data_shndx:     Option<Shndx> = None;
     let mut bss_shndx:      Option<Shndx> = None;
-    let mut tls_data_shndx: Option<(Shndx, VirtualAddress)> = None;
-    let mut tls_bss_shndx:  Option<(Shndx, VirtualAddress)> = None;
-
+    let mut tls_data_info:  Option<(Shndx, VirtualAddress)> = None;
+    let mut tls_bss_info:   Option<(Shndx, VirtualAddress)> = None;
+    let mut total_tls_size: usize = 0;
 
     // We will fill in these crate items while parsing the symbol file.
     let mut crate_items = ParsedCrateItems::empty();
@@ -534,7 +546,8 @@ fn parse_nano_core_binary(
                 }
                 let sec_vaddr = VirtualAddress::new(sec.address() as usize)
                     .ok_or("the nano_core .tdata section had an invalid virtual address")?;
-                tls_data_shndx = Some((shndx, sec_vaddr));
+                tls_data_info = Some((shndx, sec_vaddr));
+                total_tls_size += sec_size;
             }
             Ok(".tbss") => {
                 if sec.flags() & (SHF_ALLOC | SHF_WRITE | SHF_EXECINSTR | SHF_TLS) != (SHF_ALLOC | SHF_WRITE | SHF_TLS) {
@@ -542,7 +555,8 @@ fn parse_nano_core_binary(
                 }
                 let sec_vaddr = VirtualAddress::new(sec.address() as usize)
                     .ok_or("the nano_core .tbss section had an invalid virtual address")?;
-                tls_bss_shndx = Some((shndx, sec_vaddr));
+                    tls_bss_info = Some((shndx, sec_vaddr));
+                    total_tls_size += sec_size;
             }
             Ok(".gcc_except_table") => {
                 let sec_vaddr = VirtualAddress::new(sec.address() as usize)
@@ -592,11 +606,14 @@ fn parse_nano_core_binary(
         }
     }
 
-    let text_shndx   = text_shndx.ok_or("couldn't find .text section in nano_core ELF")?;
-    let rodata_shndx = rodata_shndx.ok_or("couldn't find .rodata section in nano_core ELF")?;
-    let data_shndx   = data_shndx.ok_or("couldn't find .data section in nano_core ELF")?;
-    let bss_shndx    = bss_shndx.ok_or("couldn't find .bss section in nano_core ELF")?;
-    let shndxs = MainShndx { text_shndx, rodata_shndx, data_shndx, bss_shndx, tls_data_shndx, tls_bss_shndx };
+    let text_shndx    = text_shndx.ok_or("couldn't find .text section in nano_core ELF")?;
+    let rodata_shndx  = rodata_shndx.ok_or("couldn't find .rodata section in nano_core ELF")?;
+    let data_shndx    = data_shndx.ok_or("couldn't find .data section in nano_core ELF")?;
+    let bss_shndx     = bss_shndx.ok_or("couldn't find .bss section in nano_core ELF")?;
+    let main_sec_info = MainSectionInfo {
+        text_shndx, rodata_shndx, data_shndx, bss_shndx,
+        tls_data_info, tls_bss_info, total_tls_size,
+    };
     
     {
         let text_pages_locked = text_pages.lock();
@@ -619,7 +636,7 @@ fn parse_nano_core_binary(
 
                     add_new_section(
                         namespace,
-                        &shndxs, 
+                        &main_sec_info, 
                         &mut crate_items, 
                         text_pages, 
                         rodata_pages, 
@@ -667,14 +684,15 @@ impl ParsedCrateItems {
 /// .text, .rodata, .data, and .bss.
 /// 
 /// If TLS sections are present, e.g., .tdata or .tbss, 
-/// their `shndx`s and starting virtul addresses are also included here.
-struct MainShndx {
+/// their `shndx` and virtual address are also included here.
+struct MainSectionInfo {
     text_shndx:      Shndx,
     rodata_shndx:    Shndx,
     data_shndx:      Shndx,
     bss_shndx:       Shndx,
-    tls_data_shndx:  Option<(Shndx, VirtualAddress)>,
-    tls_bss_shndx:   Option<(Shndx, VirtualAddress)>,
+    tls_data_info:   Option<(Shndx, VirtualAddress)>,
+    tls_bss_info:    Option<(Shndx, VirtualAddress)>,
+    total_tls_size:  usize,
 }
 
 /// A convenience function that separates out the logic 
@@ -682,7 +700,7 @@ struct MainShndx {
 /// after it has been parsed. 
 fn add_new_section(
     namespace:           &Arc<CrateNamespace>,
-    shndxs:              &MainShndx,
+    main_section_info:   &MainSectionInfo,
     crate_items:         &mut ParsedCrateItems,
     text_pages:          &Arc<Mutex<MappedPages>>,
     rodata_pages:        &Arc<Mutex<MappedPages>>,
@@ -699,7 +717,7 @@ fn add_new_section(
     sec_vaddr: usize,
     global: bool,
 ) -> Result<(), &'static str> {
-    let new_section = if sec_ndx == shndxs.text_shndx {
+    let new_section = if sec_ndx == main_section_info.text_shndx {
         let sec_vaddr = VirtualAddress::new(sec_vaddr)
             .ok_or("new text section had invalid virtual address")?;
         Some(Arc::new(LoadedSection::new(
@@ -713,7 +731,7 @@ fn add_new_section(
             new_crate_weak_ref.clone(), 
         )))
     }
-    else if sec_ndx == shndxs.rodata_shndx {
+    else if sec_ndx == main_section_info.rodata_shndx {
         let sec_vaddr = VirtualAddress::new(sec_vaddr)
             .ok_or("new rodata section had invalid virtual address")?;
         Some(Arc::new(LoadedSection::new(
@@ -727,7 +745,7 @@ fn add_new_section(
             new_crate_weak_ref.clone(),
         )))
     }
-    else if sec_ndx == shndxs.data_shndx {
+    else if sec_ndx == main_section_info.data_shndx {
         let sec_vaddr = VirtualAddress::new(sec_vaddr)
             .ok_or("new data section had invalid virtual address")?;
         Some(Arc::new(LoadedSection::new(
@@ -741,7 +759,7 @@ fn add_new_section(
             new_crate_weak_ref.clone(),
         )))
     }
-    else if sec_ndx == shndxs.bss_shndx {
+    else if sec_ndx == main_section_info.bss_shndx {
         let sec_vaddr = VirtualAddress::new(sec_vaddr)
             .ok_or("new bss section had invalid virtual address")?;
         Some(Arc::new(LoadedSection::new(
@@ -755,16 +773,16 @@ fn add_new_section(
             new_crate_weak_ref.clone(),
         )))
     }
-    else if shndxs.tls_data_shndx.map_or(false, |(shndx, _)| sec_ndx == shndx) {
+    else if main_section_info.tls_data_info.map_or(false, |(shndx, _)| sec_ndx == shndx) {
         // TLS sections encode their TLS offset in the virtual address field,
         // which is necessary to properly calculate relocation entries that depend upon them.
         let tls_offset = sec_vaddr;
         // We do need to calculate the real virtual address so we can use that 
         // to calculate the real mapped_pages_offset where its data exists.
         // so we can use that to calculate the real virtual address where it's loaded.
-        let tls_sec_data_vaddr = shndxs.tls_data_shndx.unwrap().1 + tls_offset; 
+        let tls_sec_data_vaddr = main_section_info.tls_data_info.unwrap().1 + tls_offset; 
 
-        let tls_section = Arc::new(LoadedSection::new(
+        let tls_section = LoadedSection::new(
             SectionType::TlsData,
             sec_name,
             Arc::clone(rodata_pages),
@@ -774,12 +792,16 @@ fn add_new_section(
             sec_size,
             global,
             new_crate_weak_ref.clone(),
-        ));
+        );
         // Add this new TLS section to this namespace's TLS area image.
-        namespace.tls_initializer.lock().add_existing_static_tls_section(tls_offset, Arc::clone(&tls_section)).unwrap();
-        Some(tls_section)
+        let tls_section_ref = namespace.tls_initializer.lock().add_existing_static_tls_section(
+            tls_section,
+            tls_offset,
+            main_section_info.total_tls_size,
+        ).map_err(|_| "BUG: failed to add static TLS section to the TLS area")?;
+        Some(tls_section_ref)
     }
-    else if shndxs.tls_bss_shndx.map_or(false, |(shndx, _)| sec_ndx == shndx) {
+    else if main_section_info.tls_bss_info.map_or(false, |(shndx, _)| sec_ndx == shndx) {
         // TLS sections encode their TLS offset in the virtual address field,
         // which is necessary to properly calculate relocation entries that depend upon them.
         let tls_offset = sec_vaddr;
@@ -789,7 +811,7 @@ fn add_new_section(
         // as that value should never be used anyway.
         let mapped_pages_offset = usize::MAX;
 
-        let tls_section = Arc::new(LoadedSection::new(
+        let tls_section = LoadedSection::new(
             SectionType::TlsBss,
             sec_name,
             Arc::clone(rodata_pages),
@@ -798,10 +820,14 @@ fn add_new_section(
             sec_size,
             global,
             new_crate_weak_ref.clone(),
-        ));
+        );
         // Add this new TLS section to this namespace's TLS area image.
-        namespace.tls_initializer.lock().add_existing_static_tls_section(tls_offset, Arc::clone(&tls_section)).unwrap();
-        Some(tls_section)
+        let tls_section_ref = namespace.tls_initializer.lock().add_existing_static_tls_section(
+            tls_section,
+            tls_offset,
+            main_section_info.total_tls_size,
+        ).map_err(|_| "BUG: failed to add static TLS section to the TLS area initializer")?;
+        Some(tls_section_ref)
     }
     else {
         crate_items.init_symbols.insert(String::from(sec_name.as_str()), sec_vaddr);

--- a/kernel/mod_mgmt/src/serde.rs
+++ b/kernel/mod_mgmt/src/serde.rs
@@ -18,6 +18,12 @@ pub(crate) fn into_loaded_crate(
     verbose_log: bool,
 ) -> Result<(StrongCrateRef, BTreeMap<String, usize>, usize), &'static str> {
     let crate_name: StrRef = serialized_crate.crate_name.as_str().into();
+
+    let total_tls_size: usize = serialized_crate.tls_sections
+        .iter()
+        .filter_map(|shndx| serialized_crate.sections.get(shndx))
+        .map(|tls_sec| tls_sec.size)
+        .sum();
     
     // The sections need a weak reference back to the loaded_crate, and so we first create
     // the loaded_crate so we have something to reference when loading the sections.
@@ -46,6 +52,7 @@ pub(crate) fn into_loaded_crate(
                 text_pages,
                 rodata_pages,
                 data_pages,
+                total_tls_size,
             )?,
         );
     }
@@ -76,11 +83,12 @@ pub(crate) fn into_loaded_crate(
 /// Convert the given [`SerializedSection`] into a [`LoadedSection`].
 fn into_loaded_section(
     serialized_section: SerializedSection,
-    parent_crate: WeakCrateRef,
-    namespace: &Arc<CrateNamespace>,
-    text_pages: &Arc<Mutex<MappedPages>>,
-    rodata_pages: &Arc<Mutex<MappedPages>>,
-    data_pages: &Arc<Mutex<MappedPages>>,
+    parent_crate:       WeakCrateRef,
+    namespace:          &Arc<CrateNamespace>,
+    text_pages:         &Arc<Mutex<MappedPages>>,
+    rodata_pages:       &Arc<Mutex<MappedPages>>,
+    data_pages:         &Arc<Mutex<MappedPages>>,
+    total_tls_size:     usize,
 ) -> Result<Arc<LoadedSection>, &'static str> {
     let mapped_pages = match serialized_section.ty {
         SectionType::Text => Arc::clone(text_pages),
@@ -89,12 +97,13 @@ fn into_loaded_section(
         | SectionType::TlsBss
         | SectionType::GccExceptTable
         | SectionType::EhFrame => Arc::clone(rodata_pages),
-        SectionType::Data | SectionType::Bss => Arc::clone(data_pages),
+        SectionType::Data
+        | SectionType::Bss => Arc::clone(data_pages),
     };
     let virtual_address = VirtualAddress::new(serialized_section.virtual_address)
         .ok_or("SerializedSection::into_loaded_section(): invalid virtual address")?;
 
-    let loaded_section = Arc::new(LoadedSection {
+    let loaded_section = LoadedSection {
         name: match serialized_section.ty {
             SectionType::EhFrame
             | SectionType::GccExceptTable => crate::section_name_str_ref(&serialized_section.ty),
@@ -108,17 +117,17 @@ fn into_loaded_section(
         size: serialized_section.size,
         parent_crate,
         inner: Default::default(),
-    });
+    };
 
     if let SectionType::TlsData | SectionType::TlsBss = serialized_section.ty {
         namespace.tls_initializer.lock().add_existing_static_tls_section(
+            loaded_section,
             // TLS sections encode their TLS offset in the virtual address field,
             // which is necessary to properly calculate relocation entries that depend upon them.
             serialized_section.virtual_address,
-            Arc::clone(&loaded_section),
-        )
-        .unwrap();
+            total_tls_size,
+        ).map_err(|_| "BUG: failed to add deserialized static TLS section to the TLS area")
+    } else {
+        Ok(Arc::new(loaded_section))
     }
-
-    Ok(loaded_section)
 }

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -655,8 +655,6 @@ where
         // We cannot do until this task is actually running, because it uses thread-local storage.
         let current_task = task::init_current_task(current_task_id, None)
             .expect("BUG: task_wrapper: couldn't init this task as the current task");
-        assert!(current_task_id == current_task.id);
-        assert!(get_current_task().unwrap() == get_my_current_task().unwrap().clone());
 
         // The first time that a task runs, its entry function `task_wrapper()` is jumped to
         // from the `task_switch()` function, right after the end of `context_switch`().

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -627,7 +627,8 @@ pub fn setup_context_trampoline(
     Ok(())
 }
 
-/// Internal code of `task_wrapper` shared by `task_wrapper` and `task_wrapper_restartable`.
+/// Internal routine that runs when a task is first switched to,
+/// shared by `task_wrapper` and `task_wrapper_restartable`.
 fn task_wrapper_internal<F, A, R>() -> Result<R, task::KillReason>
 where
     A: Send + 'static,

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -11,6 +11,7 @@
 
 #![no_std]
 #![feature(stmt_expr_attributes)]
+#![feature(naked_functions)]
 
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate log;
@@ -27,7 +28,7 @@ use spin::Mutex;
 use irq_safety::enable_interrupts;
 use memory::{get_kernel_mmi_ref, MmiRef};
 use stack::Stack;
-use task::{Task, TaskRef, get_my_current_task, RestartInfo, TASKLIST, JoinableTaskRef};
+use task::{Task, TaskRef, get_my_current_task, RestartInfo, TASKLIST, JoinableTaskRef, RunState, get_current_task};
 use mod_mgmt::{CrateNamespace, SectionType, SECTION_HASH_DELIMITER};
 use path::Path;
 use apic::get_my_apic_id;
@@ -278,8 +279,8 @@ impl<F, A, R> TaskBuilder<F, A, R>
     /// that will be passed the argument `arg` when spawned. 
     fn new(func: F, argument: A) -> TaskBuilder<F, A, R> {
         TaskBuilder {
-            argument: argument,
-            func: func,
+            argument,
+            func,
             _return_type: PhantomData,
             name: None,
             stack: None,
@@ -365,25 +366,18 @@ impl<F, A, R> TaskBuilder<F, A, R>
 
         setup_context_trampoline(&mut new_task, task_wrapper::<F, A, R>)?;
 
-        // Currently we're using the very bottom of the kstack for kthread arguments. 
-        // This is probably stupid (it'd be best to put them directly where they need to go towards the top of the stack),
-        // but it simplifies type safety in the `task_wrapper` entry point and removes uncertainty from assumed calling conventions.
+        // We use the bottom of the new task's stack for its entry function and arguments. 
+        // This is a bit inefficient; it'd be optimal to put them directly where they need to go
+        // (in registers or at the top of the stack).
+        // However, it vastly simplifies type safety since we don't need to mess with pointers,
+        // and it removes uncertainty associated with assuming different calling conventions.
         let bottom_of_stack: &mut usize = new_task.inner_mut().kstack.as_type_mut(0)?;
         let box_ptr = Box::into_raw(Box::new(TaskFuncArg::<F, A, R> {
             arg:  self.argument,
             func: self.func,
-            _rettype: PhantomData,
+            _ret: PhantomData,
         }));
         *bottom_of_stack = box_ptr as usize;
-
-        // The new task is ready to be scheduled in, now that its stack trampoline has been set up.
-        if self.blocked {
-            new_task.block_initing_task()
-                .map_err(|_| "BUG: newly-spawned blocked task was not in the Initing runstate")?;
-        } else {
-            new_task.make_inited_task_runnable()
-                .map_err(|_| "BUG: newly-spawned task was not in the Initing runstate")?;
-        }
 
         // The new task is marked as idle
         if self.idle {
@@ -396,9 +390,17 @@ impl<F, A, R> TaskBuilder<F, A, R>
             pb_func(&mut new_task)?;
         }
 
-        let new_task_id = new_task.id;
+        // Now that it has been fully initialized, mark the task as no longer `Initing`.
+        if self.blocked {
+            new_task.block_initing_task()
+                .map_err(|_| "BUG: newly-spawned blocked task was not in the Initing runstate")?;
+        } else {
+            new_task.make_inited_task_runnable()
+                .map_err(|_| "BUG: newly-spawned task was not in the Initing runstate")?;
+        }
+
         let task_ref = TaskRef::new(new_task);
-        let _existing_task = TASKLIST.lock().insert(new_task_id, task_ref.clone());
+        let _existing_task = TASKLIST.lock().insert(task_ref.id, task_ref.clone());
         // insert should return None, because that means there was no existing task with the same ID 
         if let Some(_existing_task) = _existing_task {
             error!("BUG: TaskBuilder::spawn(): Fatal Error: TASKLIST already contained a task with the new task's ID! {:?}", _existing_task);
@@ -535,34 +537,68 @@ impl<F, A, R> TaskBuilder<F, A, R>
 struct TaskFuncArg<F, A, R> {
     func: F,
     arg:  A,
-    // not necessary, just for consistency in "<F, A, R>" signatures.
-    _rettype: PhantomData<*const R>,
+    _ret: PhantomData<*const R>,
 }
 
 
-/// This function sets up the given new `Task`'s kernel stack pointer to properly jump
-/// to the given entry point function when the new `Task` is first scheduled in. 
-/// 
-/// When a new task is first scheduled in, a `Context` struct will be popped off the stack,
-/// and at the end of that struct is the address of the next instruction that will be popped off as part of the "ret" instruction, 
-/// i.e., the entry point into the new task. 
-/// 
-/// So, this function allocates space for the saved context registers to be popped off when this task is first switched to.
-/// It also sets the given `new_task`'s `saved_sp` (its saved stack pointer, which holds the Context for task switching).
-/// 
-fn setup_context_trampoline(new_task: &mut Task, entry_point_function: fn() -> !) -> Result<(), &'static str> {
+/// This function sets up the given new task's kernel stack contents to properly jump
+/// to the given `entry_point_function` when the new `Task` is first switched to. 
+///
+/// The `entry_point_function` will be invoked with one argument, the new task's ID,
+/// in order to allow that new task to identify itself (and set itself as the current task).
+///
+/// This function can only be invoked on a new task that is being initialized,
+/// otherwise it will return an error.
+///
+/// ## How this works 
+/// When a new task is first switched to, a [`Context`] struct will be popped off the stack
+/// and its values used to populate the initial values of select CPU registers.
+/// The address of that `Context` struct is used to initialized the new task's `saved_sp`
+/// (saved stack pointer).
+///
+/// We also use one of the free registers in the new `Context` struct to store
+/// the ID of the new task, which enables the new task to identify itself and set up
+/// its TLS-based "current task" variable when it first runs (see [`task_wrapper`]).
+///
+/// During the final part of the context switch operation, the `ret` instruction will
+/// implicitly pop an address value off of the stack (the last item of that Context struct);
+/// that address represents the next instruction that will run right after
+/// the context switch completes, as control flow "returns" to that instruction address.
+/// This function sets that "return address" to the given `entry_point_function`.
+#[doc(hidden)]
+pub fn setup_context_trampoline(
+    new_task: &mut Task,
+    entry_point_function: fn() -> !
+) -> Result<(), &'static str> {
+    if new_task.runstate() != RunState::Initing {
+        return Err("`setup_context_trampoline()` can only be invoked on `Initing` tasks");
+    }
     
+    let new_task_id = new_task.id;
+    let new_task_inner = new_task.inner_mut();
+
     /// A private macro that actually creates the Context and sets it up in the `new_task`.
     /// We use a macro here so we can pass in the proper `ContextType` at runtime, 
     /// which is useful for both the simd_personality config and regular/SSE configs.
     macro_rules! set_context {
         ($ContextType:ty) => (
-            // We write the new Context struct at the top of the stack, which is at the end of the stack's MappedPages. 
-            // We subtract "size of usize" (8) bytes to ensure the new Context struct doesn't spill over past the top of the stack.
-            let mp_offset = new_task.inner_mut().kstack.size_in_bytes() - mem::size_of::<usize>() - mem::size_of::<$ContextType>();
-            let new_context_destination: &mut $ContextType = new_task.inner_mut().kstack.as_type_mut(mp_offset)?;
-            *new_context_destination = <$ContextType>::new(entry_point_function as usize);
-            new_task.inner_mut().saved_sp = new_context_destination as *const _ as usize;
+            // We write the new Context struct at the "top" (usable top) of the stack,
+            // which is at the end of the stack's MappedPages. 
+            // We must subtract "size of usize" (8) bytes from the offset to ensure
+            // that the new Context struct doesn't spill over past the top of the stack.
+            let context_mp_offset = new_task_inner.kstack.size_in_bytes()
+                - mem::size_of::<usize>()
+                - mem::size_of::<$ContextType>();
+            let context_dest: &mut $ContextType = new_task_inner.kstack
+                .as_type_mut(context_mp_offset)?;
+            let mut new_context =  <$ContextType>::new(entry_point_function as usize);
+            // Store the new task's ID in an unused register in the new Context struct. 
+            new_context.set_first_register(new_task_id);
+            *context_dest = new_context;
+            // Save the address of this newly-stored Context struct
+            // (which is within the new task's stack) so that it can be used by the
+            // context switch routine in the future when this task is first switched to.
+            new_task_inner.saved_sp = context_dest as *const _ as usize;
         );
     }
 
@@ -594,13 +630,18 @@ fn setup_context_trampoline(new_task: &mut Task, entry_point_function: fn() -> !
     Ok(())
 }
 
-/// Internal code of `task_wrapper` shared by `task_wrapper` and 
-/// `task_wrapper_restartable`. 
+/// Internal code of `task_wrapper` shared by `task_wrapper` and `task_wrapper_restartable`.
 fn task_wrapper_internal<F, A, R>() -> Result<R, task::KillReason>
-    where A: Send + 'static, 
-          R: Send + 'static,
-          F: FnOnce(A) -> R, 
+where
+    A: Send + 'static,
+    R: Send + 'static,
+    F: FnOnce(A) -> R,
 {
+    // This should be the first statement in this function in order to ensure
+    // that no other code utilizes the "first register" before we can read it.
+    // See `setup_context_trampoline()` for more info on how this works.
+    let current_task_id = context_switch::read_first_register();
+
     let task_entry_func;
     let task_arg;
     let recovered_preemption_guard;
@@ -610,7 +651,12 @@ fn task_wrapper_internal<F, A, R>() -> Result<R, task::KillReason>
     // *No* local variables should exist on the stack at the end of this function,
     // except for the task's `func` and `arg`, which are obviously required.
     {
-        let curr_task = get_my_current_task().expect("BUG: task_wrapper: couldn't get current task (before task func).");
+        // Set this task as the current task.
+        // We cannot do until this task is actually running, because it uses thread-local storage.
+        let current_task = task::init_current_task(current_task_id, None)
+            .expect("BUG: task_wrapper: couldn't init this task as the current task");
+        assert!(current_task_id == current_task.id);
+        assert!(get_current_task().unwrap() == get_my_current_task().unwrap().clone());
 
         // The first time that a task runs, its entry function `task_wrapper()` is jumped to
         // from the `task_switch()` function, right after the end of `context_switch`().
@@ -618,10 +664,10 @@ fn task_wrapper_internal<F, A, R>() -> Result<R, task::KillReason>
         // because this is the first code to run immediately after a context switch
         // switches to this task for the first time.
         // For more details, see the comments at the end of `Task::task_switch()`.
-        recovered_preemption_guard = curr_task.post_context_switch_action();
+        recovered_preemption_guard = current_task.post_context_switch_action();
 
         // This task's function and argument were placed at the bottom of the stack when this task was spawned.
-        let task_func_arg = curr_task.with_kstack(|kstack| {
+        let task_func_arg = current_task.with_kstack(|kstack| {
             kstack.as_type(0).map(|tfa_box_raw_ptr: &usize| {
                 // SAFE: we placed this Box in this task's stack in the `spawn()` function when creating the TaskFuncArg struct.
                 let tfa_boxed = unsafe { Box::from_raw((*tfa_box_raw_ptr) as *mut TaskFuncArg<F, A, R>) };
@@ -629,11 +675,11 @@ fn task_wrapper_internal<F, A, R>() -> Result<R, task::KillReason>
             })
         }).expect("BUG: task_wrapper: couldn't access task's function/argument at bottom of stack");
         task_entry_func = task_func_arg.func;
-        task_arg  = task_func_arg.arg;
+        task_arg        = task_func_arg.arg;
 
         #[cfg(not(any(rq_eval, downtime_eval)))]
         debug!("task_wrapper [1]: \"{}\" about to call task entry func {:?} {{{}}} with arg {:?}",
-            curr_task.name.clone(), debugit!(task_entry_func), core::any::type_name::<F>(), debugit!(task_arg)
+            current_task.name.clone(), debugit!(task_entry_func), core::any::type_name::<F>(), debugit!(task_arg)
         );
     };
 
@@ -652,12 +698,14 @@ fn task_wrapper_internal<F, A, R>() -> Result<R, task::KillReason>
     catch_unwind::catch_unwind_with_arg(task_entry_func, task_arg)
 }
 
-/// The entry point for all new `Task`s except restartable tasks. 
-/// This does not return, because it doesn't really have anywhere to return.
+/// The entry point for all new `Task`s.
+/// 
+/// This does not return, as it doesn't really have anywhere to return to.
 fn task_wrapper<F, A, R>() -> !
-    where A: Send + 'static, 
-          R: Send + 'static,
-          F: FnOnce(A) -> R, 
+where
+    A: Send + 'static,
+    R: Send + 'static,
+    F: FnOnce(A) -> R,
 {
     let result = task_wrapper_internal::<F, A, R>();
 
@@ -672,7 +720,9 @@ fn task_wrapper<F, A, R>() -> !
     //
     // Operations 1 happen in `task_cleanup_success` or `task_cleanup_failure`, 
     // while operations 2 and 3 then happen in `task_cleanup_final`.
-    let curr_task = get_my_current_task().expect("BUG: task_wrapper: couldn't get current task (after task func).").clone();
+    let curr_task = get_my_current_task()
+        .expect("BUG: task_wrapper: couldn't get current task (after task func).")
+        .clone();
     match result {
         Ok(exit_value)   => task_cleanup_success::<F, A, R>(curr_task, exit_value),
         Err(kill_reason) => task_cleanup_failure::<F, A, R>(curr_task, kill_reason),
@@ -683,14 +733,17 @@ fn task_wrapper<F, A, R>() -> !
 /// restartable tasks. Further restricts `argument` to implement `Clone` trait. 
 /// // We cannot use `task_wrapper` as it is not bounded by `Clone` trait.
 fn task_wrapper_restartable<F, A, R>() -> !
-    where A: Send + Clone + 'static, 
-          R: Send + 'static,
-          F: FnOnce(A) -> R + Send + Clone + 'static,
+where
+    A: Send + Clone + 'static,
+    R: Send + 'static,
+    F: FnOnce(A) -> R + Send + Clone + 'static,
 {
     let result = task_wrapper_internal::<F, A, R>();
 
     // See `task_wrapper` for an explanation of how the below functions work.
-    let curr_task = get_my_current_task().expect("BUG: task_wrapper: couldn't get current task (after task func).").clone();
+    let curr_task = get_my_current_task()
+        .expect("BUG: task_wrapper: couldn't get current task (after task func).")
+        .clone();
     match result {
         Ok(exit_value)   => task_restartable_cleanup_success::<F, A, R>(curr_task, exit_value),
         Err(kill_reason) => task_restartable_cleanup_failure::<F, A, R>(curr_task, kill_reason),


### PR DESCRIPTION
* More efficient access than the original GS-based approach.
* Frees up the GS register for fast per-CPU storage (future work).

* Ensure that TLS offsets are always calculated correctly for relocation entries.
* Force all compiled crates to use the simplest, most efficient `local-exec` TLS model.

* Enable dependencies on TLS sections defined in foreign crates.
* Also, fix how statically-known TLS variables (in the base kernel image)
  store their negative offset value (from the TLS self pointer) for the purpose
  of ensuring that foreign relocations against them are correct.

* Now that the current task feature uses TLS, we must move the part of
  the `task_switch()` routine that changes the current task until after
  all other task switch-related operations have been done already, i.e.,
  at the end of the routine right before actually invoking `context_switch()`.