### PR TITLE
Uefi aarch64 paging_entry_flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.so
 *.rlib
 *.dll
+*.fd
 
 # Executables
 *.exe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ exclude = [
 	"build",
 	"target",
 
+	## Exclude the aarch64 experiment
+	"aarch64",
+
 	## Exclude configuration, tools, scripts, etc
 	"cfg",
 	"compiler_plugins",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 	"build",
 	"target",
 
-	## Exclude the aarch64 experiment
+	## Exclude the `aarch64` directory, which is a WIP port that currently must be built separately.
 	"aarch64",
 
 	## Exclude configuration, tools, scripts, etc

--- a/aarch64/Cargo.toml
+++ b/aarch64/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+resolver = "2"
+
+members = [
+    "kernel/[!.]*/",
+]
+
+exclude = [
+    "build",
+    "resources",
+]

--- a/aarch64/Cargo.toml
+++ b/aarch64/Cargo.toml
@@ -1,6 +1,10 @@
 [workspace]
 resolver = "2"
 
+default-members = [
+    "kernel/nano_core"
+]
+
 members = [
     "kernel/[!.]*/",
 ]

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -1,6 +1,6 @@
 TARGET=aarch64-unknown-uefi
 
-CARGOFLAGS += -p nano_core
+CARGOFLAGS += --workspace
 CARGOFLAGS += --release
 
 BUILD_STD_CARGOFLAGS += -Z unstable-options
@@ -41,7 +41,7 @@ create-build-structure:
 cargo-build: create-build-structure
 	@echo -e "\n=================== BUILDING ALL CRATES ==================="
 	@echo -e "\t TARGET: \"$(TARGET)\""
-	cargo +nightly build $(CARGOFLAGS) $(BUILD_STD_CARGOFLAGS) --target $(TARGET)
+	cargo build $(CARGOFLAGS) $(BUILD_STD_CARGOFLAGS) --target $(TARGET)
 
 ## This builds the nano_core binary itself, which is the fully-linked code that first runs right after the bootloader
 $(nano_core_binary): cargo-build

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -1,0 +1,53 @@
+TARGET=aarch64-unknown-uefi
+
+CARGOFLAGS += -p nano_core
+CARGOFLAGS += --release
+
+BUILD_STD_CARGOFLAGS += -Z unstable-options
+BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
+BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
+
+AARCH64_DIR = .
+BUILD_DIR = $(AARCH64_DIR)/build
+QEMU_EFI_FD = $(AARCH64_DIR)/resources/qemu-efi.fd
+NATIVE_OUTPUT = $(AARCH64_DIR)/target/aarch64-unknown-uefi/release/nano_core.efi
+nano_core_binary = $(BUILD_DIR)/efi
+
+# Configure the machine
+QEMU_FLAGS += -machine virt
+QEMU_FLAGS += -cpu cortex-a72
+QEMU_FLAGS += -smp 4
+QEMU_FLAGS += -m 1000
+QEMU_FLAGS += -net none
+# QEMU_FLAGS += -nographic
+
+# Include that file which enables efi support in qemu
+QEMU_FLAGS += -drive if=pflash,format=raw,file=$(QEMU_EFI_FD)
+
+# Include the build dir as an emulated fat drive
+QEMU_FLAGS += -drive file=fat:rw:$(BUILD_DIR)
+
+
+
+
+
+
+all: run
+
+create-build-structure:
+	mkdir -p $(BUILD_DIR)
+
+## This target invokes the actual Rust build process via `cargo`.
+cargo-build: create-build-structure
+	@echo -e "\n=================== BUILDING ALL CRATES ==================="
+	@echo -e "\t TARGET: \"$(TARGET)\""
+	cargo +nightly build $(CARGOFLAGS) $(BUILD_STD_CARGOFLAGS) --target $(TARGET)
+
+## This builds the nano_core binary itself, which is the fully-linked code that first runs right after the bootloader
+$(nano_core_binary): cargo-build
+	cp $(NATIVE_OUTPUT) $(nano_core_binary)
+
+### builds and runs Theseus in QEMU
+run: $(nano_core_binary)
+	cat resources/qemu-instructions.txt
+	qemu-system-aarch64 $(QEMU_FLAGS)

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -7,7 +7,7 @@ BUILD_STD_CARGOFLAGS += -Z unstable-options
 BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
 BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
 
-QEMU_EFI_FD_URL ?= https://l0.pm/qemu-efi.fd
+QEMU_EFI_ZIP_URL ?= https://github.com/theseus-os/prebuilt-resources/raw/main/qemu-efi.fd.zip
 
 AARCH64_DIR ?= .
 BUILD_DIR ?= $(AARCH64_DIR)/build
@@ -53,7 +53,10 @@ build: $(nano_core_binary)
 
 ## This downloads the binary blob making Qemu compatible with UEFI
 $(QEMU_EFI_FD):
-	wget $(QEMU_EFI_FD_URL) -O $(QEMU_EFI_FD)
+	wget $(QEMU_EFI_ZIP_URL) -O qemu-efi.zip
+	@# this will extract to ./resources/qemu-efi.fd
+	unzip qemu-efi.zip
+	rm qemu-efi.zip
 
 ### builds and runs Theseus in QEMU
 run: build $(QEMU_EFI_FD)

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -7,11 +7,13 @@ BUILD_STD_CARGOFLAGS += -Z unstable-options
 BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
 BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
 
-AARCH64_DIR = .
-BUILD_DIR = $(AARCH64_DIR)/build
-QEMU_EFI_FD = $(AARCH64_DIR)/resources/qemu-efi.fd
-NATIVE_OUTPUT = $(AARCH64_DIR)/target/aarch64-unknown-uefi/release/nano_core.efi
-nano_core_binary = $(BUILD_DIR)/efi
+QEMU_EFI_FD_URL ?= https://l0.pm/qemu-efi.fd
+
+AARCH64_DIR ?= .
+BUILD_DIR ?= $(AARCH64_DIR)/build
+QEMU_EFI_FD ?= $(AARCH64_DIR)/resources/qemu-efi.fd
+NATIVE_OUTPUT ?= $(AARCH64_DIR)/target/aarch64-unknown-uefi/release/nano_core.efi
+nano_core_binary ?= $(BUILD_DIR)/efi
 
 # Configure the machine
 QEMU_FLAGS += -machine virt
@@ -47,7 +49,10 @@ cargo-build: create-build-structure
 $(nano_core_binary): cargo-build
 	cp $(NATIVE_OUTPUT) $(nano_core_binary)
 
+$(QEMU_EFI_FD):
+	wget $(QEMU_EFI_FD_URL) -O $(QEMU_EFI_FD)
+
 ### builds and runs Theseus in QEMU
-run: $(nano_core_binary)
+run: $(nano_core_binary) $(QEMU_EFI_FD)
 	cat resources/qemu-instructions.txt
 	qemu-system-aarch64 $(QEMU_FLAGS)

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -49,10 +49,13 @@ cargo-build: create-build-structure
 $(nano_core_binary): cargo-build
 	cp $(NATIVE_OUTPUT) $(nano_core_binary)
 
+build: $(nano_core_binary)
+
+## This downloads the binary blob making Qemu compatible with UEFI
 $(QEMU_EFI_FD):
 	wget $(QEMU_EFI_FD_URL) -O $(QEMU_EFI_FD)
 
 ### builds and runs Theseus in QEMU
-run: $(nano_core_binary) $(QEMU_EFI_FD)
+run: build $(QEMU_EFI_FD)
 	cat resources/qemu-instructions.txt
 	qemu-system-aarch64 $(QEMU_FLAGS)

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -7,7 +7,7 @@ BUILD_STD_CARGOFLAGS += -Z unstable-options
 BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
 BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
 
-QEMU_EFI_ZIP_URL ?= https://github.com/theseus-os/prebuilt-resources/raw/main/qemu-efi.fd.zip
+QEMU_EFI_ZIP_URL ?= https://github.com/theseus-os/prebuilt-aavmf/raw/main/qemu-efi.fd.zip
 
 AARCH64_DIR ?= .
 BUILD_DIR ?= $(AARCH64_DIR)/build

--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -7,7 +7,7 @@ BUILD_STD_CARGOFLAGS += -Z unstable-options
 BUILD_STD_CARGOFLAGS += -Z build-std=core,alloc
 BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
 
-QEMU_EFI_ZIP_URL ?= https://github.com/theseus-os/prebuilt-aavmf/raw/main/qemu-efi.fd.zip
+QEMU_EFI_ZIP_URL ?= https://github.com/theseus-os/prebuilt-aavmf/blob/2c7254d98ee98297ad0db243bb21ed5a631d2e50/qemu-efi.fd.zip
 
 AARCH64_DIR ?= .
 BUILD_DIR ?= $(AARCH64_DIR)/build

--- a/aarch64/README.md
+++ b/aarch64/README.md
@@ -1,0 +1,37 @@
+### Aarch64+UEFI port of Theseus OS
+
+This is an effort to port Theseus OS to Aarch64 (Arm).
+
+Only basic logging is currently implemented.
+
+This currently targets the "virt" Qemu virtual machine.
+It is not tested on any real-life machine at the moment.
+
+### Building and Running
+
+0. You will need
+
+- a Rust toolchain
+- `qemu-system-aarch64`
+- `wget`
+- make
+
+1. Build the UEFI app:
+
+```text
+$ make build
+```
+
+2. Run this app in Qemu:
+
+```text
+$ make run
+```
+
+3. Once Qemu has started:
+
+    a. Open the "View" menu
+    b. Click "Serial" to see the serial output
+    c. spam [enter] a few times until you see a prompt
+    d. write "fs0:\efi"
+    e. You should see the "Hello world" line among the other ones

--- a/aarch64/README.md
+++ b/aarch64/README.md
@@ -15,6 +15,7 @@ It is not tested on any real-life machine at the moment.
 - `qemu-system-aarch64`
 - `wget`
 - make
+- unzip
 
 1. Build the UEFI app:
 

--- a/aarch64/kernel/frame_allocator/Cargo.toml
+++ b/aarch64/kernel/frame_allocator/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "frame_allocator"
+description = "The allocator for physical memory frames."
+version = "0.1.0"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+spin = "0.9.0"
+static_assertions = "1.1.0"
+memory_structs = { path = "../memory_structs" }
+static_array_collections = { path = "../static_array_collections" }
+log = "0.4.8"

--- a/aarch64/kernel/frame_allocator/lib.rs
+++ b/aarch64/kernel/frame_allocator/lib.rs
@@ -128,7 +128,6 @@ pub fn init<F, R, P>(
         }
     }
 
-
     // Finally, one last sanity check -- ensure no two regions overlap. 
     let all_areas = free_list[..free_list_idx].iter().flatten()
         .chain(reserved_list[..reserved_list_idx].iter().flatten());

--- a/aarch64/kernel/frame_allocator/lib.rs
+++ b/aarch64/kernel/frame_allocator/lib.rs
@@ -1,0 +1,1053 @@
+//! Provides an allocator for physical memory frames.
+//! The minimum unit of allocation is a single frame. 
+//!
+//! This is currently a modified and more complex version of the `page_allocator` crate.
+//! TODO: extract the common code and create a generic allocator that can be specialized to allocate pages or frames.
+//! 
+//! This also supports early allocation of frames before heap allocation is available, 
+//! and does so behind the scenes using the same single interface. 
+//! Early pre-heap allocations are limited to tracking a small number of available chunks (currently 32).
+//! 
+//! Once heap allocation is available, it uses a dynamically-allocated list of frame chunks to track allocations.
+//! 
+//! The core allocation function is [`allocate_frames_deferred()`](fn.allocate_frames_deferred.html), 
+//! but there are several convenience functions that offer simpler interfaces for general usage. 
+//!
+//! # Notes and Missing Features
+//! This allocator currently does **not** merge freed chunks (de-fragmentation). 
+//! We don't need to do so until we actually run out of address space or until 
+//! a requested address is in a chunk that needs to be merged.
+
+#![no_std]
+
+extern crate alloc;
+extern crate memory_structs;
+extern crate spin;
+#[macro_use] extern crate log;
+#[macro_use] extern crate static_assertions;
+extern crate static_array_collections;
+
+#[cfg(test)]
+mod test;
+
+use core::{borrow::Borrow, cmp::{Ordering, min, max}, fmt, ops::{Deref, DerefMut}, marker::PhantomData};
+use memory_structs::{PAGE_SIZE, PhysicalAddress, Frame, FrameRange};
+use spin::Mutex;
+use static_array_collections::intrusive_collections::Bound;
+use static_array_collections::static_array_rb_tree::*;
+
+const FRAME_SIZE: usize = PAGE_SIZE;
+const MIN_FRAME: Frame = Frame::containing_address(PhysicalAddress::zero());
+const MAX_FRAME: Frame = Frame::containing_address(PhysicalAddress::new_canonical(usize::MAX));
+
+// Note: we keep separate lists for "free, general-purpose" areas and "reserved" areas, as it's much faster. 
+
+/// The single, system-wide list of free physical memory frames available for general usage. 
+static FREE_GENERAL_FRAMES_LIST: Mutex<StaticArrayRBTree<Chunk>> = Mutex::new(StaticArrayRBTree::empty()); 
+/// The single, system-wide list of free physical memory frames reserved for specific usage. 
+static FREE_RESERVED_FRAMES_LIST: Mutex<StaticArrayRBTree<Chunk>> = Mutex::new(StaticArrayRBTree::empty()); 
+
+/// The fixed list of all known regions that are available for general use.
+/// This does not indicate whether these regions are currently allocated, 
+/// rather just where they exist and which regions are known to this allocator.
+static GENERAL_REGIONS: Mutex<StaticArrayRBTree<Chunk>> = Mutex::new(StaticArrayRBTree::empty());
+/// The fixed list of all known regions that are reserved for specific purposes. 
+/// This does not indicate whether these regions are currently allocated, 
+/// rather just where they exist and which regions are known to this allocator.
+static RESERVED_REGIONS: Mutex<StaticArrayRBTree<Chunk>> = Mutex::new(StaticArrayRBTree::empty());
+
+
+/// Initialize the frame allocator with the given list of available and reserved physical memory regions.
+///
+/// Any regions in either of the lists may overlap, this is checked for and handled properly.
+/// Reserved regions take priority -- if a reserved region partially or fully overlaps any part of a free region,
+/// that portion will be considered reserved, not free. 
+/// 
+/// The iterator (`R`) over reserved physical memory regions must be cloneable, 
+/// as this runs before heap allocation is available, and we may need to iterate over it multiple times. 
+/// 
+/// ## Return
+/// Upon success, this function returns a callback function that allows the caller
+/// (the memory subsystem init function) to convert a range of unmapped frames 
+/// back into an [`AllocatedFrames`] object.
+pub fn init<F, R, P>(
+    free_physical_memory_areas: F,
+    reserved_physical_memory_areas: R,
+) -> Result<fn(FrameRange) -> AllocatedFrames, &'static str> 
+    where P: Borrow<PhysicalMemoryRegion>,
+          F: IntoIterator<Item = P>,
+          R: IntoIterator<Item = P> + Clone,
+{
+    if  FREE_GENERAL_FRAMES_LIST .lock().len() != 0 ||
+        FREE_RESERVED_FRAMES_LIST.lock().len() != 0 ||
+        GENERAL_REGIONS          .lock().len() != 0 ||
+        RESERVED_REGIONS         .lock().len() != 0 
+    {
+        return Err("BUG: Frame allocator was already initialized, cannot be initialized twice.");
+    }
+
+    let mut free_list: [Option<Chunk>; 32] = Default::default();
+    let mut free_list_idx = 0;
+    let mut reserved_list: [Option<Chunk>; 32] = Default::default();
+    let mut reserved_list_idx = 0;
+
+    // Populate the list of free regions for general-purpose usage.
+    for area in free_physical_memory_areas.into_iter() {
+        let area = area.borrow();
+        // debug!("Frame Allocator: looking to add free physical memory area: {:?}", area);
+        check_and_add_free_region(
+            &area,
+            &mut free_list,
+            &mut free_list_idx,
+            reserved_physical_memory_areas.clone(),
+        );
+    }
+
+    // Insert all of the reserved memory areas into the list of free reserved regions,
+    // while de-duplicating overlapping areas by merging them.
+    for reserved in reserved_physical_memory_areas.into_iter() {
+        let reserved = reserved.borrow();
+        let mut reserved_was_merged = false;
+        for existing in reserved_list[..reserved_list_idx].iter_mut().flatten() {
+            if let Some(_overlap) = existing.overlap(reserved) {
+                // merge the `reserved` range into the `existing` range
+                existing.frames = FrameRange::new(
+                    min(*existing.start(), *reserved.start()),
+                    max(*existing.end(),   *reserved.end()),
+                );
+                reserved_was_merged = true;
+                break;
+            }
+        }
+        if !reserved_was_merged {
+            reserved_list[reserved_list_idx] = Some(Chunk {
+                typ:  MemoryRegionType::Reserved,
+                frames: reserved.frames.clone(),
+            });
+            reserved_list_idx += 1;
+        }
+    }
+
+
+    // Finally, one last sanity check -- ensure no two regions overlap. 
+    let all_areas = free_list[..free_list_idx].iter().flatten()
+        .chain(reserved_list[..reserved_list_idx].iter().flatten());
+    for (i, elem) in all_areas.clone().enumerate() {
+        let next_idx = i + 1;
+        for other in all_areas.clone().skip(next_idx) {
+            if let Some(overlap) = elem.overlap(other) {
+                panic!("BUG: frame allocator free list had overlapping ranges: \n \t {:?} and {:?} overlap at {:?}",
+                    elem, other, overlap,
+                );
+            }
+        }
+    }
+
+    *FREE_GENERAL_FRAMES_LIST.lock()  = StaticArrayRBTree::new(free_list.clone());
+    *FREE_RESERVED_FRAMES_LIST.lock() = StaticArrayRBTree::new(reserved_list.clone());
+    *GENERAL_REGIONS.lock()           = StaticArrayRBTree::new(free_list);
+    *RESERVED_REGIONS.lock()          = StaticArrayRBTree::new(reserved_list);
+
+    Ok(into_allocated_frames)
+}
+
+
+/// The main logic of the initialization routine 
+/// used to populate the list of free frame chunks.
+///
+/// This function recursively iterates over the given `area` of frames
+/// and adds any ranges of frames within that `area` that are not covered by
+/// the given list of `reserved_physical_memory_areas`.
+fn check_and_add_free_region<P, R>(
+    area: &FrameRange,
+    free_list: &mut [Option<Chunk>; 32],
+    free_list_idx: &mut usize,
+    reserved_physical_memory_areas: R,
+)
+    where P: Borrow<PhysicalMemoryRegion>,
+          R: IntoIterator<Item = P> + Clone,
+{
+    // This will be set to the frame that is the start of the current free region. 
+    let mut current_start = *area.start();
+    // This will be set to the frame that is the end of the current free region. 
+    let mut current_end = *area.end();
+    // trace!("looking at sub-area {:X?} to {:X?}", current_start, current_end);
+
+    for reserved in reserved_physical_memory_areas.clone().into_iter() {
+        let reserved = &reserved.borrow().frames;
+        // trace!("\t Comparing with reserved area {:X?}", reserved);
+        if reserved.contains(&current_start) {
+            // info!("\t\t moving current_start from {:X?} to {:X?}", current_start, *reserved.end() + 1);
+            current_start = *reserved.end() + 1;
+        }
+        if &current_start <= reserved.start() && reserved.start() <= &current_end {
+            // Advance up to the frame right before this reserved region started.
+            // info!("\t\t moving current_end from {:X?} to {:X?}", current_end, min(current_end, *reserved.start() - 1));
+            current_end = min(current_end, *reserved.start() - 1);
+            if area.end() <= reserved.end() {
+                // Optimization here: the rest of the current area is reserved,
+                // so there's no need to keep iterating over the reserved areas.
+                // info!("\t !!! skipping the rest of the area");
+                break;
+            } else {
+                let after = FrameRange::new(*reserved.end() + 1, *area.end());
+                // warn!("moving on to after {:X?}", after);
+                // Here: the current area extends past this current reserved area,
+                // so there might be another free area that starts after this reserved area.
+                check_and_add_free_region(
+                    &after,
+                    free_list,
+                    free_list_idx,
+                    reserved_physical_memory_areas.clone(),
+                );
+            }
+        }
+    }
+
+    let new_area = FrameRange::new(current_start, current_end);
+    if new_area.size_in_frames() > 0 {
+        free_list[*free_list_idx] = Some(Chunk {
+            typ:  MemoryRegionType::Free,
+            frames: new_area,
+        });
+        *free_list_idx += 1;
+    }
+}
+
+
+/// A region of physical memory.
+#[derive(Clone, Debug)]
+pub struct PhysicalMemoryRegion {
+    pub frames: FrameRange,
+    pub typ: MemoryRegionType,
+}
+impl PhysicalMemoryRegion {
+    pub fn new(frames: FrameRange, typ: MemoryRegionType) -> PhysicalMemoryRegion {
+        PhysicalMemoryRegion { frames, typ }
+    }
+}
+impl Deref for PhysicalMemoryRegion {
+    type Target = FrameRange;
+    fn deref(&self) -> &FrameRange {
+        &self.frames
+    }
+}
+
+/// Types of physical memory. See each variant's documentation.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum MemoryRegionType {
+    /// Memory that is available for any general purpose.
+    Free,
+    /// Memory that is reserved for special use and is only ever allocated from if specifically requested. 
+    /// This includes custom memory regions added by third parties, e.g., 
+    /// device memory discovered and added by device drivers later during runtime.
+    Reserved,
+    /// Memory of an unknown type.
+    /// This is a default value that acts as a sanity check, because it is invalid
+    /// to do any real work (e.g., allocation, access) with an unknown memory region.
+    Unknown,
+}
+
+/// A range of contiguous frames.
+///
+/// # Ordering and Equality
+///
+/// `Chunk` implements the `Ord` trait, and its total ordering is ONLY based on
+/// its **starting** `Frame`. This is useful so we can store `Chunk`s in a sorted collection.
+///
+/// Similarly, `Chunk` implements equality traits, `Eq` and `PartialEq`,
+/// both of which are also based ONLY on the **starting** `Frame` of the `Chunk`.
+/// Thus, comparing two `Chunk`s with the `==` or `!=` operators may not work as expected.
+/// since it ignores their actual range of frames.
+#[derive(Debug, Clone, Eq)]
+struct Chunk {
+    /// The type of this memory chunk, e.g., whether it's in a free or reserved region.
+    typ: MemoryRegionType,
+    /// The Frames covered by this chunk, an inclusive range. 
+    frames: FrameRange,
+}
+impl Chunk {
+    fn as_allocated_frames(&self) -> AllocatedFrames {
+        AllocatedFrames {
+            frames: self.frames.clone(),
+        }
+    }
+
+    /// Returns a new `Chunk` with an empty range of frames. 
+    const fn empty() -> Chunk {
+        Chunk {
+            typ: MemoryRegionType::Unknown,
+            frames: FrameRange::empty(),
+        }
+    }
+}
+impl Deref for Chunk {
+    type Target = FrameRange;
+    fn deref(&self) -> &FrameRange {
+        &self.frames
+    }
+}
+impl Ord for Chunk {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.frames.start().cmp(other.frames.start())
+    }
+}
+impl PartialOrd for Chunk {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl PartialEq for Chunk {
+    fn eq(&self, other: &Self) -> bool {
+        self.frames.start() == other.frames.start()
+    }
+}
+impl Borrow<Frame> for &'_ Chunk {
+    fn borrow(&self) -> &Frame {
+        self.frames.start()
+    }
+}
+
+
+/// Represents a range of allocated physical memory [`Frame`]s; derefs to [`FrameRange`].
+/// 
+/// These frames are not immediately accessible because they're not yet mapped
+/// by any virtual memory pages.
+/// You must do that separately in order to create a `MappedPages` type,
+/// which can then be used to access the contents of these frames.
+/// 
+/// This object represents ownership of the range of allocated physical frames;
+/// if this object falls out of scope, its allocated frames will be auto-deallocated upon drop. 
+pub struct AllocatedFrames {
+    frames: FrameRange,
+}
+
+// AllocatedFrames must not be Cloneable, and it must not expose its inner frames as mutable.
+assert_not_impl_any!(AllocatedFrames: DerefMut, Clone);
+
+impl Deref for AllocatedFrames {
+    type Target = FrameRange;
+    fn deref(&self) -> &FrameRange {
+        &self.frames
+    }
+}
+impl fmt::Debug for AllocatedFrames {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "AllocatedFrames({:?})", self.frames)
+    }
+}
+
+impl AllocatedFrames {
+    /// Returns an empty AllocatedFrames object that performs no frame allocation. 
+    /// Can be used as a placeholder, but will not permit any real usage. 
+    pub const fn empty() -> AllocatedFrames {
+        AllocatedFrames {
+            frames: FrameRange::empty()
+        }
+    }
+
+    /// Merges the given `AllocatedFrames` object `other` into this `AllocatedFrames` object (`self`).
+    /// This is just for convenience and usability purposes, it performs no allocation or remapping.
+    ///
+    /// The given `other` must be physically contiguous with `self`, i.e., come immediately before or after `self`.
+    /// That is, either `self.start == other.end + 1` or `self.end + 1 == other.start` must be true. 
+    ///
+    /// If either of those conditions are met, `self` is modified and `Ok(())` is returned,
+    /// otherwise `Err(other)` is returned.
+    pub fn merge(&mut self, other: AllocatedFrames) -> Result<(), AllocatedFrames> {
+        if *self.start() == *other.end() + 1 {
+            // `other` comes contiguously before `self`
+            self.frames = FrameRange::new(*other.start(), *self.end());
+        } 
+        else if *self.end() + 1 == *other.start() {
+            // `self` comes contiguously before `other`
+            self.frames = FrameRange::new(*self.start(), *other.end());
+        }
+        else {
+            // non-contiguous
+            return Err(other);
+        }
+
+        // ensure the now-merged AllocatedFrames doesn't run its drop handler and free its frames.
+        core::mem::forget(other); 
+        Ok(())
+    }
+
+    /// Splits this `AllocatedFrames` into two separate `AllocatedFrames` objects:
+    /// * `[beginning : at_frame - 1]`
+    /// * `[at_frame : end]`
+    /// 
+    /// This function follows the behavior of [`core::slice::split_at()`],
+    /// thus, either one of the returned `AllocatedFrames` objects may be empty. 
+    /// * If `at_frame == self.start`, the first returned `AllocatedFrames` object will be empty.
+    /// * If `at_frame == self.end + 1`, the second returned `AllocatedFrames` object will be empty.
+    /// 
+    /// Returns an `Err` containing this `AllocatedFrames` if `at_frame` is otherwise out of bounds.
+    /// 
+    /// [`core::slice::split_at()`]: https://doc.rust-lang.org/core/primitive.slice.html#method.split_at
+    pub fn split(self, at_frame: Frame) -> Result<(AllocatedFrames, AllocatedFrames), AllocatedFrames> {
+        let end_of_first = at_frame - 1;
+
+        let (first, second) = if at_frame == *self.start() && at_frame <= *self.end() {
+            let first  = FrameRange::empty();
+            let second = FrameRange::new(at_frame, *self.end());
+            (first, second)
+        } 
+        else if at_frame == (*self.end() + 1) && end_of_first >= *self.start() {
+            let first  = FrameRange::new(*self.start(), *self.end()); 
+            let second = FrameRange::empty();
+            (first, second)
+        }
+        else if at_frame > *self.start() && end_of_first <= *self.end() {
+            let first  = FrameRange::new(*self.start(), end_of_first);
+            let second = FrameRange::new(at_frame, *self.end());
+            (first, second)
+        }
+        else {
+            return Err(self);
+        };
+
+        // ensure the original AllocatedFrames doesn't run its drop handler and free its frames.
+        core::mem::forget(self);   
+        Ok((
+            AllocatedFrames { frames: first }, 
+            AllocatedFrames { frames: second },
+        ))
+    }
+
+    /// Returns an `AllocatedFrame` if this `AllocatedFrames` object contains only one frame.
+    /// 
+    /// ## Panic
+    /// Panics if this `AllocatedFrame` contains multiple frames or zero frames.
+    pub fn as_allocated_frame(&self) -> AllocatedFrame {
+        assert!(self.size_in_frames() == 1);
+        AllocatedFrame {
+            frame: *self.start(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// This function is a callback used to convert `UnmappedFrames` into `AllocatedFrames`.
+/// `UnmappedFrames` represents frames that have been unmapped from a page that had
+/// exclusively mapped them, indicating that no others pages have been mapped 
+/// to those same frames, and thus, they can be safely deallocated.
+/// 
+/// This exists to break the cyclic dependency cycle between this crate and
+/// the `page_table_entry` crate, since `page_table_entry` must depend on types
+/// from this crate in order to enforce safety when modifying page table entries.
+fn into_allocated_frames(frames: FrameRange) -> AllocatedFrames {
+    AllocatedFrames { frames }
+}
+
+impl Drop for AllocatedFrames {
+    fn drop(&mut self) {
+        if self.size_in_frames() == 0 { return; }
+
+        let (list, typ) = if frame_is_in_list(&RESERVED_REGIONS.lock(), self.start()) {
+            (&FREE_RESERVED_FRAMES_LIST, MemoryRegionType::Reserved)
+        } else {
+            (&FREE_GENERAL_FRAMES_LIST, MemoryRegionType::Free)
+        };
+        // trace!("frame_allocator: deallocating {:?}, typ {:?}", self, typ);
+
+        // Simply add the newly-deallocated chunk to the free frames list.
+        let mut locked_list = list.lock();
+        let res = locked_list.insert(Chunk {
+            typ,
+            frames: self.frames.clone(),
+        });
+        match res {
+            Ok(_inserted_free_chunk) => return,
+            Err(c) => error!("BUG: couldn't insert deallocated chunk {:?} into free frame list", c),
+        }
+        
+        // Here, we could optionally use above `_inserted_free_chunk` to merge the adjacent (contiguous) chunks
+        // before or after the newly-inserted free chunk. 
+        // However, there's no *need* to do so until we actually run out of address space or until 
+        // a requested address is in a chunk that needs to be merged.
+        // Thus, for performance, we save that for those future situations.
+    }
+}
+
+impl<'f> IntoIterator for &'f AllocatedFrames {
+    type IntoIter = AllocatedFramesIter<'f>;
+    type Item = AllocatedFrame<'f>;
+    fn into_iter(self) -> Self::IntoIter {
+        AllocatedFramesIter {
+            _owner: self,
+            range: self.frames.clone(),
+        }
+    }
+}
+
+/// An iterator over each [`AllocatedFrame`] in a range of [`AllocatedFrames`].
+/// 
+/// We must implement our own iterator type here in order to tie the lifetime `'f`
+/// of a returned `AllocatedFrame<'f>` type to the lifetime of its containing `AllocatedFrames`.
+/// This is because the underlying type of `AllocatedFrames` is a [`FrameRange`],
+/// which itself is a [`core::ops::RangeInclusive`] of [`Frame`]s, and unfortunately the
+/// `RangeInclusive` type doesn't implement an immutable iterator.
+/// 
+/// Iterating through a `RangeInclusive` actually modifies its own internal range,
+/// so we must avoid doing that because it would break the semantics of a `FrameRange`.
+/// In fact, this is why [`FrameRange`] only implements `IntoIterator` but
+/// does not implement [`Iterator`] itself.
+pub struct AllocatedFramesIter<'f> {
+    _owner: &'f AllocatedFrames,
+    range: FrameRange,
+}
+impl<'f> Iterator for AllocatedFramesIter<'f> {
+    type Item = AllocatedFrame<'f>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.range.next().map(|frame|
+            AllocatedFrame {
+                frame, _phantom: PhantomData,
+            }
+        )
+    }
+}
+
+/// A reference to a single frame within a range of `AllocatedFrames`.
+/// 
+/// The lifetime of this type is tied to the lifetime of its owning `AllocatedFrames`.
+#[derive(Debug)]
+pub struct AllocatedFrame<'f> {
+    frame: Frame,
+    _phantom: PhantomData<&'f Frame>,
+}
+impl<'f> Deref for AllocatedFrame<'f> {
+    type Target = Frame;
+    fn deref(&self) -> &Self::Target {
+        &self.frame
+    }
+}
+assert_not_impl_any!(AllocatedFrame: DerefMut, Clone);
+
+
+/// A series of pending actions related to frame allocator bookkeeping,
+/// which may result in heap allocation. 
+/// 
+/// The actions are triggered upon dropping this struct. 
+/// This struct can be returned from the `allocate_frames()` family of functions 
+/// in order to allow the caller to precisely control when those actions 
+/// that may result in heap allocation should occur. 
+/// Such actions include adding chunks to lists of free frames or frames in use. 
+/// 
+/// The vast majority of use cases don't care about such precise control, 
+/// so you can simply drop this struct at any time or ignore it
+/// with a `let _ = ...` binding to instantly drop it. 
+pub struct DeferredAllocAction<'list> {
+    /// A reference to the list into which we will insert the free general-purpose `Chunk`s.
+    free_list: &'list Mutex<StaticArrayRBTree<Chunk>>,
+    /// A reference to the list into which we will insert the free "reserved" `Chunk`s.
+    reserved_list: &'list Mutex<StaticArrayRBTree<Chunk>>,
+    /// A free chunk that needs to be added back to the free list.
+    free1: Chunk,
+    /// Another free chunk that needs to be added back to the free list.
+    free2: Chunk,
+}
+impl<'list> DeferredAllocAction<'list> {
+    fn new<F1, F2>(free1: F1, free2: F2) -> DeferredAllocAction<'list> 
+        where F1: Into<Option<Chunk>>,
+              F2: Into<Option<Chunk>>,
+    {
+        let free1 = free1.into().unwrap_or_else(Chunk::empty);
+        let free2 = free2.into().unwrap_or_else(Chunk::empty);
+        DeferredAllocAction {
+            free_list: &FREE_GENERAL_FRAMES_LIST,
+            reserved_list: &FREE_RESERVED_FRAMES_LIST,
+            free1,
+            free2
+        }
+    }
+}
+impl<'list> Drop for DeferredAllocAction<'list> {
+    fn drop(&mut self) {
+        // Insert all of the chunks, both allocated and free ones, into the list. 
+        if self.free1.size_in_frames() > 0 {
+            match self.free1.typ {
+                MemoryRegionType::Free     => { self.free_list.lock().insert(self.free1.clone()).unwrap(); }
+                MemoryRegionType::Reserved => { self.reserved_list.lock().insert(self.free1.clone()).unwrap(); }
+                _ => error!("BUG likely: DeferredAllocAction encountered free1 chunk {:?} of a type Unknown", self.free1),
+            }
+        }
+        if self.free2.size_in_frames() > 0 {
+            match self.free2.typ {
+                MemoryRegionType::Free     => { self.free_list.lock().insert(self.free2.clone()).unwrap(); }
+                MemoryRegionType::Reserved => { self.reserved_list.lock().insert(self.free2.clone()).unwrap(); }
+                _ => error!("BUG likely: DeferredAllocAction encountered free2 chunk {:?} of a type Unknown", self.free2),
+            };
+        }
+    }
+}
+
+
+/// Possible allocation errors.
+#[derive(Debug)]
+enum AllocationError {
+    /// The requested address was not free: it was already allocated, or is outside the range of this allocator.
+    AddressNotFree(Frame, usize),
+    /// The address space was full, or there was not a large-enough chunk 
+    /// or enough remaining chunks that could satisfy the requested allocation size.
+    OutOfAddressSpace(usize),
+}
+impl From<AllocationError> for &'static str {
+    fn from(alloc_err: AllocationError) -> &'static str {
+        match alloc_err {
+            AllocationError::AddressNotFree(..) => "address was in use or outside of this frame allocator's range",
+            AllocationError::OutOfAddressSpace(..) => "out of physical address space",
+        }
+    }
+}
+
+
+/// Searches the given `list` for the chunk that contains the range of frames from
+/// `requested_frame` to `requested_frame + num_frames`.
+fn find_specific_chunk(
+    list: &mut StaticArrayRBTree<Chunk>,
+    requested_frame: Frame,
+    num_frames: usize
+) -> Result<(AllocatedFrames, DeferredAllocAction<'static>), AllocationError> {
+
+    // The end frame is an inclusive bound, hence the -1. Parentheses are needed to avoid overflow.
+    let requested_end_frame = requested_frame + (num_frames - 1);
+
+    match &mut list.0 {
+        Inner::Array(ref mut arr) => {
+            for elem in arr.iter_mut() {
+                if let Some(chunk) = elem {
+                    if requested_frame >= *chunk.start() && requested_end_frame <= *chunk.end() {
+                        // Here: `chunk` was big enough and did contain the requested address.
+                        return allocate_from_chosen_chunk(requested_frame, num_frames, &chunk.clone(), ValueRefMut::Array(elem));
+                    }
+                }
+            }
+        }
+        Inner::RBTree(ref mut tree) => {
+            let mut cursor_mut = tree.upper_bound_mut(Bound::Included(&requested_frame));
+            if let Some(chunk) = cursor_mut.get().map(|w| w.deref().clone()) {
+                if chunk.contains(&requested_frame) {
+                    if requested_end_frame <= *chunk.end() {
+                        return allocate_from_chosen_chunk(requested_frame, num_frames, &chunk, ValueRefMut::RBTree(cursor_mut));
+                    } else {
+                        // We found the chunk containing the requested address, but it was too small to cover all of the requested frames.
+                        // Let's try to merge the next-highest contiguous chunk to see if those two chunks together 
+                        // cover enough frames to fulfill the allocation request.
+                        //
+                        // trace!("Frame allocator: found chunk containing requested address, but it was too small. \
+                        //     Attempting to merge multiple chunks during an allocation. \
+                        //     Requested address: {:?}, num_frames: {}, chunk: {:?}",
+                        //     requested_frame, num_frames, chunk,
+                        // );
+                        let next_contiguous_chunk: Option<Chunk> = {
+                            let next_cursor = cursor_mut.peek_next();
+                            if let Some(next_chunk) = next_cursor.get().map(|w| w.deref()) {
+                                if *chunk.end() + 1 == *next_chunk.start() {
+                                    // Here: next chunk was contiguous with the original chunk. 
+                                    if requested_end_frame <= *next_chunk.end() {
+                                        // trace!("Frame allocator: found suitably-large contiguous next {:?} after initial too-small {:?}", next_chunk, chunk);
+                                        Some(next_chunk.clone())
+                                    } else {
+                                        todo!("Frame allocator: found chunk containing requested address, but it was too small. \
+                                            Theseus does not yet support merging more than two chunks during an allocation request. \
+                                            Requested address: {:?}, num_frames: {}, chunk: {:?}, next_chunk {:?}",
+                                            requested_frame, num_frames, chunk, next_chunk
+                                        );
+                                        // None
+                                    }
+                                } else {
+                                    trace!("Frame allocator: next {:?} was not contiguously above initial too-small {:?}", next_chunk, chunk);
+                                    None
+                                }
+                            } else {
+                                trace!("Frame allocator: couldn't get next chunk above initial too-small {:?}", chunk);
+                                None
+                            }
+                        };
+                        if let Some(mut next_chunk) = next_contiguous_chunk {
+                            // We found a suitable chunk that came contiguously after the initial too-small chunk. 
+                            // Remove the initial chunk (since we have a cursor pointing to it already) 
+                            // and "merge" it into this `next_chunk`.
+                            let _removed_initial_chunk = cursor_mut.remove();
+                            // trace!("Frame allocator: removed suitably-large contiguous next {:?} after initial too-small {:?}", _removed_initial_chunk, chunk);
+                            // Here, `cursor_mut` has been moved forward to point to the `next_chunk` now. 
+                            next_chunk.frames = FrameRange::new(*chunk.start(), *next_chunk.end());
+                            return allocate_from_chosen_chunk(requested_frame, num_frames, &next_chunk, ValueRefMut::RBTree(cursor_mut));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Err(AllocationError::AddressNotFree(requested_frame, num_frames))
+}
+
+
+/// Searches the given `list` for any chunk large enough to hold at least `num_frames`.
+fn find_any_chunk<'list>(
+    list: &'list mut StaticArrayRBTree<Chunk>,
+    num_frames: usize
+) -> Result<(AllocatedFrames, DeferredAllocAction<'static>), AllocationError> {
+    // During the first pass, we ignore designated regions.
+    match list.0 {
+        Inner::Array(ref mut arr) => {
+            for elem in arr.iter_mut() {
+                if let Some(chunk) = elem {
+                    // Skip chunks that are too-small or in the designated regions.
+                    if  chunk.size_in_frames() < num_frames || chunk.typ != MemoryRegionType::Free {
+                        continue;
+                    } 
+                    else {
+                        return allocate_from_chosen_chunk(*chunk.start(), num_frames, &chunk.clone(), ValueRefMut::Array(elem));
+                    }
+                }
+            }
+        }
+        Inner::RBTree(ref mut tree) => {
+            // Because we allocate new frames by peeling them off from the beginning part of a chunk, 
+            // it's MUCH faster to start the search for free frames from higher addresses moving down. 
+            // This results in an O(1) allocation time in the general case, until all address ranges are already in use.
+            let mut cursor = tree.upper_bound_mut(Bound::<&Chunk>::Unbounded);
+            while let Some(chunk) = cursor.get().map(|w| w.deref()) {
+                if num_frames <= chunk.size_in_frames() && chunk.typ == MemoryRegionType::Free {
+                    return allocate_from_chosen_chunk(*chunk.start(), num_frames, &chunk.clone(), ValueRefMut::RBTree(cursor));
+                }
+                warn!("Frame allocator: inefficient scenario: had to search multiple chunks \
+                    (skipping {:?}) while trying to allocate {} frames at any address.",
+                    chunk, num_frames
+                );
+                cursor.move_prev();
+            }
+        }
+    }
+
+    error!("frame_allocator: non-reserved chunks are all allocated (requested {} frames). \
+        TODO: we could attempt to merge free chunks here.", num_frames
+    );
+
+    Err(AllocationError::OutOfAddressSpace(num_frames))
+}
+
+
+
+/// The final part of the main allocation routine that splits the given chosen chunk
+/// into multiple smaller chunks, thereby "allocating" frames from it.
+///
+/// This function breaks up that chunk into multiple ones and returns an `AllocatedFrames` 
+/// from (part of) that chunk, ranging from `start_frame` to `start_frame + num_frames`.
+fn allocate_from_chosen_chunk(
+    start_frame: Frame,
+    num_frames: usize,
+    chosen_chunk: &Chunk,
+    mut chosen_chunk_ref: ValueRefMut<Chunk>,
+) -> Result<(AllocatedFrames, DeferredAllocAction<'static>), AllocationError> {
+    let (new_allocation, before, after) = split_chosen_chunk(start_frame, num_frames, chosen_chunk);
+
+    // Remove the chosen chunk from the free frame list.
+    let _removed_chunk = chosen_chunk_ref.remove();
+
+    // TODO: Re-use the allocated wrapper if possible, rather than allocate a new one entirely.
+    // if let RemovedValue::RBTree(Some(wrapper_adapter)) = _removed_chunk { ... }
+
+    Ok((
+        new_allocation.as_allocated_frames(),
+        DeferredAllocAction::new(before, after),
+    ))
+
+}
+
+/// An inner function that breaks up the given chunk into multiple smaller chunks.
+/// 
+/// Returns a tuple of three chunks:
+/// 1. The `Chunk` containing the requested range of frames starting at `start_frame`.
+/// 2. The range of frames in the `chosen_chunk` that came before the beginning of the requested frame range.
+/// 3. The range of frames in the `chosen_chunk` that came after the end of the requested frame range.
+fn split_chosen_chunk(
+    start_frame: Frame,
+    num_frames: usize,
+    chosen_chunk: &Chunk,
+) -> (Chunk, Option<Chunk>, Option<Chunk>) {
+    // The new allocated chunk might start in the middle of an existing chunk,
+    // so we need to break up that existing chunk into 3 possible chunks: before, newly-allocated, and after.
+    //
+    // Because Frames and PhysicalAddresses use saturating add/subtract, we need to double-check that 
+    // we don't create overlapping duplicate Chunks at either the very minimum or the very maximum of the address space.
+    let new_allocation = Chunk {
+        typ: chosen_chunk.typ,
+        // The end frame is an inclusive bound, hence the -1. Parentheses are needed to avoid overflow.
+        frames: FrameRange::new(start_frame, start_frame + (num_frames - 1)),
+    };
+    let before = if start_frame == MIN_FRAME {
+        None
+    } else {
+        Some(Chunk {
+            typ: chosen_chunk.typ,
+            frames: FrameRange::new(*chosen_chunk.start(), *new_allocation.start() - 1),
+        })
+    };
+    let after = if new_allocation.end() == &MAX_FRAME { 
+        None
+    } else {
+        Some(Chunk {
+            typ: chosen_chunk.typ,
+            frames: FrameRange::new(*new_allocation.end() + 1, *chosen_chunk.end()),
+        })
+    };
+
+    // some sanity checks -- these can be removed or disabled for better performance
+    if let Some(ref b) = before {
+        assert!(!new_allocation.contains(b.end()));
+        assert!(!b.contains(new_allocation.start()));
+    }
+    if let Some(ref a) = after {
+        assert!(!new_allocation.contains(a.start()));
+        assert!(!a.contains(new_allocation.end()));
+    }
+
+    (new_allocation, before, after)
+}
+
+
+/// Returns whether the given `Frame` is contained within the given `list`.
+fn frame_is_in_list(
+    list: &StaticArrayRBTree<Chunk>,
+    frame: &Frame,
+) -> bool {
+    match &list.0 {
+        Inner::Array(ref arr) => {
+            for elem in arr.iter() {
+                if let Some(chunk) = elem {
+                    if chunk.contains(frame) { 
+                        return true;
+                    }
+                }
+            }
+        }
+        Inner::RBTree(ref tree) => {     
+            let cursor = tree.upper_bound(Bound::Included(frame));
+            if let Some(chunk) = cursor.get().map(|w| w.deref()) {
+                if chunk.contains(frame) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+
+/// Adds the given `frames` to the given `list` as a Chunk of reserved frames. 
+/// 
+/// Returns the range of **new** frames that were added to the list, 
+/// which will be a subset of the given input `frames`.
+///
+/// Currently, this function adds no new frames at all if any frames within the given `frames` list
+/// overlap any existing regions at all. 
+/// TODO: handle partially-overlapping regions by extending existing regions on either end.
+fn add_reserved_region(
+    list: &mut StaticArrayRBTree<Chunk>,
+    frames: FrameRange,
+) -> Result<FrameRange, &'static str> {
+
+    // Check whether the reserved region overlaps any existing regions.
+    match &mut list.0 {
+        Inner::Array(ref mut arr) => {
+            for elem in arr.iter() {
+                if let Some(chunk) = elem {
+                    if let Some(_overlap) = chunk.overlap(&frames) {
+                        // trace!("Failed to add reserved region {:?} due to overlap {:?} with existing chunk {:?}",
+                        //     frames, _overlap, chunk
+                        // );
+                        return Err("Failed to add reserved region that overlapped with existing reserved regions (array).");
+                    }
+                }
+            }
+        }
+        Inner::RBTree(ref mut tree) => {
+            let mut cursor_mut = tree.upper_bound_mut(Bound::Included(frames.start()));
+            while let Some(chunk) = cursor_mut.get().map(|w| w.deref()) {
+                if chunk.start() > frames.end() {
+                    // We're iterating in ascending order over a sorted tree,
+                    // so we can stop looking for overlapping regions once we pass the end of the new frames to add.
+                    break;
+                }
+                if let Some(_overlap) = chunk.overlap(&frames) {
+                    // trace!("Failed to add reserved region {:?} due to overlap {:?} with existing chunk {:?}",
+                    //     frames, _overlap, chunk
+                    // );
+                    return Err("Failed to add reserved region that overlapped with existing reserved regions (RBTree).");
+                }
+                cursor_mut.move_next();
+            }
+        }
+    }
+
+    list.insert(Chunk {
+        typ: MemoryRegionType::Reserved,
+        frames: frames.clone(),
+    }).map_err(|_c| "BUG: Failed to insert non-overlapping frames into list.")?;
+
+    Ok(frames)
+}
+
+
+/// The core frame allocation routine that allocates the given number of physical frames,
+/// optionally at the requested starting `PhysicalAddress`.
+/// 
+/// This simply reserves a range of frames; it does not perform any memory mapping. 
+/// Thus, the memory represented by the returned `AllocatedFrames` isn't directly accessible
+/// until you map virtual pages to them.
+/// 
+/// Allocation is based on a red-black tree and is thus `O(log(n))`.
+/// Fragmentation isn't cleaned up until we're out of address space, but that's not really a big deal.
+/// 
+/// # Arguments
+/// * `requested_paddr`: if `Some`, the returned `AllocatedFrames` will start at the `Frame`
+///   containing this `PhysicalAddress`. 
+///   If `None`, the first available `Frame` range will be used, starting at any random physical address.
+/// * `num_frames`: the number of `Frame`s to be allocated. 
+/// 
+/// # Return
+/// If successful, returns a tuple of two items:
+/// * the frames that were allocated, and
+/// * an opaque struct representing details of bookkeeping-related actions that may cause heap allocation. 
+///   Those actions are deferred until this returned `DeferredAllocAction` struct object is dropped, 
+///   allowing the caller (such as the heap implementation itself) to control when heap allocation may occur.
+pub fn allocate_frames_deferred(
+    requested_paddr: Option<PhysicalAddress>,
+    num_frames: usize,
+) -> Result<(AllocatedFrames, DeferredAllocAction<'static>), &'static str> {
+    if num_frames == 0 {
+        warn!("frame_allocator: requested an allocation of 0 frames... stupid!");
+        return Err("cannot allocate zero frames");
+    }
+    
+    if let Some(paddr) = requested_paddr {
+        let start_frame = Frame::containing_address(paddr);
+        let end_frame = start_frame + (num_frames - 1);
+        // Try to allocate the frames at the specific address.
+        let mut free_reserved_frames_list = FREE_RESERVED_FRAMES_LIST.lock();
+        if let Ok(success) = find_specific_chunk(&mut free_reserved_frames_list, start_frame, num_frames) {
+            Ok(success)
+        } else {
+            // If allocation failed, then the requested `start_frame` may be found in the general-purpose list
+            // or may represent a new, previously-unknown reserved region that we must add.
+            // We first attempt to allocate it from the general-purpose free regions.
+            if let Ok(result) = find_specific_chunk(&mut FREE_GENERAL_FRAMES_LIST.lock(), start_frame, num_frames) {
+                Ok(result)
+            } 
+            // If we failed to allocate the requested frames from the general list,
+            // we can add a new reserved region containing them,
+            // but ONLY if those frames are *NOT* in the general-purpose region.
+            else if {
+                let g = GENERAL_REGIONS.lock();  
+                !frame_is_in_list(&g, &start_frame) && !frame_is_in_list(&g, &end_frame)
+            } {
+                let frames = FrameRange::new(start_frame, end_frame);
+                let new_reserved_frames = add_reserved_region(&mut RESERVED_REGIONS.lock(), frames)?;
+                // If we successfully added a new reserved region,
+                // then add those frames to the actual list of *available* reserved regions.
+                let _new_free_reserved_frames = add_reserved_region(&mut free_reserved_frames_list, new_reserved_frames.clone())?;
+                assert_eq!(new_reserved_frames, _new_free_reserved_frames);
+                find_specific_chunk(&mut free_reserved_frames_list, start_frame, num_frames)
+            } 
+            else {
+                Err(AllocationError::AddressNotFree(start_frame, num_frames))
+            }
+        }
+    } else {
+        find_any_chunk(&mut FREE_GENERAL_FRAMES_LIST.lock(), num_frames)
+    }.map_err(From::from) // convert from AllocationError to &str
+}
+
+
+/// Similar to [`allocated_frames_deferred()`](fn.allocate_frames_deferred.html),
+/// but accepts a size value for the allocated frames in number of bytes instead of number of frames. 
+/// 
+/// This function still allocates whole frames by rounding up the number of bytes. 
+pub fn allocate_frames_by_bytes_deferred(
+    requested_paddr: Option<PhysicalAddress>,
+    num_bytes: usize,
+) -> Result<(AllocatedFrames, DeferredAllocAction<'static>), &'static str> {
+    let actual_num_bytes = if let Some(paddr) = requested_paddr {
+        num_bytes + (paddr.value() % FRAME_SIZE)
+    } else {
+        num_bytes
+    };
+    let num_frames = (actual_num_bytes + FRAME_SIZE - 1) / FRAME_SIZE; // round up
+    allocate_frames_deferred(requested_paddr, num_frames)
+}
+
+
+/// Allocates the given number of frames with no constraints on the starting physical address.
+/// 
+/// See [`allocate_frames_deferred()`](fn.allocate_frames_deferred.html) for more details. 
+pub fn allocate_frames(num_frames: usize) -> Option<AllocatedFrames> {
+    allocate_frames_deferred(None, num_frames)
+        .map(|(af, _action)| af)
+        .ok()
+}
+
+
+/// Allocates frames with no constraints on the starting physical address, 
+/// with a size given by the number of bytes. 
+/// 
+/// This function still allocates whole frames by rounding up the number of bytes. 
+/// See [`allocate_frames_deferred()`](fn.allocate_frames_deferred.html) for more details. 
+pub fn allocate_frames_by_bytes(num_bytes: usize) -> Option<AllocatedFrames> {
+    allocate_frames_by_bytes_deferred(None, num_bytes)
+        .map(|(af, _action)| af)
+        .ok()
+}
+
+
+/// Allocates frames starting at the given `PhysicalAddress` with a size given in number of bytes. 
+/// 
+/// This function still allocates whole frames by rounding up the number of bytes. 
+/// See [`allocate_frames_deferred()`](fn.allocate_frames_deferred.html) for more details. 
+pub fn allocate_frames_by_bytes_at(paddr: PhysicalAddress, num_bytes: usize) -> Result<AllocatedFrames, &'static str> {
+    allocate_frames_by_bytes_deferred(Some(paddr), num_bytes)
+        .map(|(af, _action)| af)
+}
+
+
+/// Allocates the given number of frames starting at (inclusive of) the frame containing the given `PhysicalAddress`.
+/// 
+/// See [`allocate_frames_deferred()`](fn.allocate_frames_deferred.html) for more details. 
+pub fn allocate_frames_at(paddr: PhysicalAddress, num_frames: usize) -> Result<AllocatedFrames, &'static str> {
+    allocate_frames_deferred(Some(paddr), num_frames)
+        .map(|(af, _action)| af)
+}
+
+
+/// Converts the frame allocator from using static memory (a primitive array) to dynamically-allocated memory.
+/// 
+/// Call this function once heap allocation is available. 
+/// Calling this multiple times is unnecessary but harmless, as it will do nothing after the first invocation.
+#[doc(hidden)] 
+pub fn convert_to_heap_allocated() {
+    FREE_GENERAL_FRAMES_LIST.lock().convert_to_heap_allocated();
+    FREE_RESERVED_FRAMES_LIST.lock().convert_to_heap_allocated();
+    GENERAL_REGIONS.lock().convert_to_heap_allocated();
+    RESERVED_REGIONS.lock().convert_to_heap_allocated();
+}
+
+/// A debugging function used to dump the full internal state of the frame allocator. 
+#[doc(hidden)] 
+pub fn dump_frame_allocator_state() {
+    debug!("----------------- FREE GENERAL FRAMES ---------------");
+    FREE_GENERAL_FRAMES_LIST.lock().iter().for_each(|e| debug!("\t {:?}", e) );
+    debug!("-----------------------------------------------------");
+    debug!("----------------- FREE RESERVED FRAMES --------------");
+    FREE_RESERVED_FRAMES_LIST.lock().iter().for_each(|e| debug!("\t {:?}", e) );
+    debug!("-----------------------------------------------------");
+    debug!("------------------ GENERAL REGIONS -----------------");
+    GENERAL_REGIONS.lock().iter().for_each(|e| debug!("\t {:?}", e) );
+    debug!("-----------------------------------------------------");
+    debug!("------------------ RESERVED REGIONS -----------------");
+    RESERVED_REGIONS.lock().iter().for_each(|e| debug!("\t {:?}", e) );
+    debug!("-----------------------------------------------------");
+}

--- a/aarch64/kernel/frame_allocator/test.rs
+++ b/aarch64/kernel/frame_allocator/test.rs
@@ -1,0 +1,212 @@
+//! Tests for the AllocatedFrames type, mainly the `split` method.
+
+extern crate std;
+
+use self::std::dbg;
+
+use super::*;
+
+impl PartialEq for AllocatedFrames {
+    fn eq(&self, other: &Self) -> bool {
+        self.frames == other.frames
+    }
+}
+
+fn from_addr(start_addr: usize, end_addr: usize) -> AllocatedFrames {
+    AllocatedFrames {
+        frames: FrameRange::new(
+            Frame::containing_address(PhysicalAddress::new_canonical(start_addr)),
+            Frame::containing_address(PhysicalAddress::new_canonical(end_addr)),
+        )
+    }
+}
+
+fn frame_addr(addr: usize) -> Frame {
+    Frame::containing_address(PhysicalAddress::new_canonical(addr))
+}
+
+#[test]
+fn split_before_beginning() {
+    let original = from_addr( 0x4275000, 0x4285000);
+    let split_at = frame_addr(0x4274000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    assert!(result.is_err());
+}
+
+#[test]
+fn split_at_beginning() {
+    let original = from_addr( 0x4275000, 0x4285000);
+    let split_at = frame_addr(0x4275000);
+    let first    = AllocatedFrames::empty();
+    let second   = from_addr( 0x4275000, 0x4285000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    let (result1, result2) = result.unwrap();
+    assert_eq!(result1, first);
+    assert_eq!(result2, second);
+}
+
+
+#[test]
+fn split_at_middle() {
+    let original = from_addr( 0x4275000, 0x4285000);
+    let split_at = frame_addr(     0x427D000);
+    let first    = from_addr( 0x4275000, 0x427C000);
+    let second   = from_addr( 0x427D000, 0x4285000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    let (result1, result2) = result.unwrap();
+    assert_eq!(result1, first);
+    assert_eq!(result2, second);
+}
+
+#[test]
+fn split_at_end() {
+    let original = from_addr( 0x4275000, 0x4285000);
+    let split_at = frame_addr(           0x4285000);
+    let first    = from_addr( 0x4275000, 0x4284000);
+    let second   = from_addr( 0x4285000, 0x4285000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    let (result1, result2) = result.unwrap();
+    assert_eq!(result1, first);
+    assert_eq!(result2, second);
+}
+
+
+#[test]
+fn split_after_end() {
+    let original = from_addr( 0x4275000, 0x4285000);
+    let split_at = frame_addr(           0x4286000);
+    let first    = from_addr( 0x4275000, 0x4285000);
+    let second   = AllocatedFrames::empty();
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    let (result1, result2) = result.unwrap();
+    assert_eq!(result1, first);
+    assert_eq!(result2, second);
+}
+
+
+#[test]
+fn split_empty_at_zero() {
+    let original = AllocatedFrames::empty();
+    let split_at = frame_addr(0x0000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    assert!(result.is_err());
+}
+
+#[test]
+fn split_empty_at_one() {
+    let original = AllocatedFrames::empty();
+    let split_at = frame_addr(0x1000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    assert!(result.is_err());
+}
+
+#[test]
+fn split_empty_at_two() {
+    let original = AllocatedFrames::empty();
+    let split_at = frame_addr(0x2000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    assert!(result.is_err());
+}
+
+
+
+#[test]
+fn split_at_beginning_zero() {
+    let original = from_addr( 0x0, 0x5000);
+    let split_at = frame_addr(0x0);
+    let first  = AllocatedFrames::empty();
+    let second = from_addr(0x0, 0x5000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    let (result1, result2) = result.unwrap();
+    assert_eq!(result1, first);
+    assert_eq!(result2, second);
+}
+
+#[test]
+fn split_at_beginning_one() {
+    let original = from_addr( 0x0000, 0x5000);
+    let split_at = frame_addr(0x1000);
+    let first    = from_addr( 0x0000, 0x0000);
+    let second   = from_addr( 0x1000, 0x5000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    let (result1, result2) = result.unwrap();
+    assert_eq!(result1, first);
+    assert_eq!(result2, second);
+}
+
+#[test]
+fn split_at_beginning_max_length_one() {
+    let original = from_addr( 0xFFFF_FFFF_FFFF_F000, 0xFFFF_FFFF_FFFF_F000);
+    let split_at = frame_addr(0xFFFF_FFFF_FFFF_F000);
+    let first    = AllocatedFrames::empty();
+    let second   = from_addr(0xFFFF_FFFF_FFFF_F000, 0xFFFF_FFFF_FFFF_F000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    let (result1, result2) = result.unwrap();
+    assert_eq!(result1, first);
+    assert_eq!(result2, second);
+}
+
+#[test]
+fn split_at_end_max_length_two() {
+    let original = from_addr( 0xFFFF_FFFF_FFFF_E000, 0xFFFF_FFFF_FFFF_F000);
+    let split_at = frame_addr(                       0xFFFF_FFFF_FFFF_F000);
+    let first    = from_addr( 0xFFFF_FFFF_FFFF_E000, 0xFFFF_FFFF_FFFF_E000);
+    let second   = from_addr( 0xFFFF_FFFF_FFFF_F000, 0xFFFF_FFFF_FFFF_F000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    let (result1, result2) = result.unwrap();
+    assert_eq!(result1, first);
+    assert_eq!(result2, second);
+}
+
+
+#[test]
+fn split_after_end_max() {
+    let original = from_addr( 0xFFFF_FFFF_FFFF_E000, 0xFFFF_FFFF_FFFF_E000);
+    let split_at = frame_addr(0xFFFF_FFFF_FFFF_F000);
+    let first  =   from_addr( 0xFFFF_FFFF_FFFF_E000, 0xFFFF_FFFF_FFFF_E000);
+    let second =   AllocatedFrames::empty();
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    let (result1, result2) = result.unwrap();
+    assert_eq!(result1, first);
+    assert_eq!(result2, second);
+}
+
+#[test]
+fn split_at_beginning_max() {
+    let original = from_addr( 0xFFFF_FFFF_FFFF_E000, 0xFFFF_FFFF_FFFF_E000);
+    let split_at = frame_addr(0xFFFF_FFFF_FFFF_E000);
+    let first    = AllocatedFrames::empty();
+    let second   = from_addr(0xFFFF_FFFF_FFFF_E000, 0xFFFF_FFFF_FFFF_E000);
+
+    let result = original.split(split_at);
+    dbg!(&result);
+    let (result1, result2) = result.unwrap();
+    assert_eq!(result1, first);
+    assert_eq!(result2, second);
+}

--- a/aarch64/kernel/kernel_config/Cargo.toml
+++ b/aarch64/kernel/kernel_config/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "kernel_config"
+description = "configuration values and settings used in the Theseus kernel, e.g., timeslices, memory layouts, etc"
+version = "0.1.0"

--- a/aarch64/kernel/kernel_config/src/display.rs
+++ b/aarch64/kernel/kernel_config/src/display.rs
@@ -1,0 +1,4 @@
+/// The maximum resolution `(width, height)` of the graphical framebuffer, in pixels.
+/// This is a **requested limit** and does not control what the actual
+/// resolution of the graphical framebuffer will be.
+pub const FRAMEBUFFER_MAX_RESOLUTION: (u16, u16) = (1024, 768);

--- a/aarch64/kernel/kernel_config/src/lib.rs
+++ b/aarch64/kernel/kernel_config/src/lib.rs
@@ -1,0 +1,5 @@
+#![no_std]
+
+pub mod memory;
+pub mod time;
+pub mod display;

--- a/aarch64/kernel/kernel_config/src/memory.rs
+++ b/aarch64/kernel/kernel_config/src/memory.rs
@@ -1,0 +1,104 @@
+//! WARNING: DO NOT USE ANY ADDRESS THAT MAPS TO THE SAME P4 ENTRY AS THE ONE
+//! USED FOR THE RECURSIVE PAGE TABLE ENTRY (CURRENTLY 510). 
+//! Currently, that would be any address that starts with 0xFFFF_FF0*_****_****,
+//! so do not use that virtual address range for anything!!
+
+//! Current P4 (top-level page table) mappings:
+//! * 511: kernel text sections
+//! * 510: recursive mapping to top of P4
+//! * 509: kernel heap
+//! * 508: kernel stacks
+//! * 507: userspace stacks
+//! * 506 down to 0:  available for user processes
+
+
+/// 64-bit architecture results in 8 bytes per address.
+pub const BYTES_PER_ADDR: usize = core::mem::size_of::<usize>();
+
+/// The lower 12 bits of a virtual address correspond to the P1 page frame offset. 
+pub const PAGE_SHIFT: usize = 12;
+/// Page size is 4096 bytes, 4KiB pages.
+pub const PAGE_SIZE: usize = 1 << PAGE_SHIFT;
+
+/// Value: 0. Shift the Page number (not the address!) by this to get the P1 index.
+pub const P1_INDEX_SHIFT: usize = 0;
+/// Value: 9. Shift the Page number (not the address!) by this to get the P2 index.
+pub const P2_INDEX_SHIFT: usize = P1_INDEX_SHIFT + 9;
+/// Value: 18. Shift the Page number (not the address!) by this to get the P3 index.
+pub const P3_INDEX_SHIFT: usize = P2_INDEX_SHIFT + 9;
+/// Value: 27. Shift the Page number (not the address!) by this to get the P4 index.
+pub const P4_INDEX_SHIFT: usize = P3_INDEX_SHIFT + 9;
+
+/// Value: 512 GiB.
+pub const ADDRESSABILITY_PER_P4_ENTRY: usize = 1 << (PAGE_SHIFT + P4_INDEX_SHIFT);
+
+pub const MAX_VIRTUAL_ADDRESS: usize = usize::MAX;
+
+pub const TEMPORARY_PAGE_VIRT_ADDR: usize = MAX_VIRTUAL_ADDRESS;
+
+/// Value: 512. 
+pub const ENTRIES_PER_PAGE_TABLE: usize = PAGE_SIZE / BYTES_PER_ADDR;
+/// Value: 511. The 511th entry is used for kernel text sections
+pub const KERNEL_TEXT_P4_INDEX: usize = ENTRIES_PER_PAGE_TABLE - 1;
+/// Value: 510. The 510th entry is used for the recursive P4 mapping.
+pub const RECURSIVE_P4_INDEX: usize = ENTRIES_PER_PAGE_TABLE - 2;
+/// Value: 509. The 509th entry is used for the kernel heap
+pub const KERNEL_HEAP_P4_INDEX: usize = ENTRIES_PER_PAGE_TABLE - 3;
+/// Value: 508. The 508th entry is used for all kernel stacks
+pub const KERNEL_STACK_P4_INDEX: usize = ENTRIES_PER_PAGE_TABLE - 4;
+/// Value: 507. The 507th entry is used for all userspace stacks
+pub const USER_STACK_P4_INDEX: usize = ENTRIES_PER_PAGE_TABLE - 5;
+
+
+pub const MAX_PAGE_NUMBER: usize = MAX_VIRTUAL_ADDRESS / PAGE_SIZE;
+
+/// The size in pages of each kernel stack. 
+/// If it's too small, complex kernel functions will overflow, causing a page fault / double fault.
+#[cfg(not(debug_assertions))]
+pub const KERNEL_STACK_SIZE_IN_PAGES: usize = 16;
+#[cfg(debug_assertions)]
+pub const KERNEL_STACK_SIZE_IN_PAGES: usize = 32; // debug builds require more stack space.
+
+/// The virtual address where the initial kernel (the nano_core) is mapped to.
+/// Actual value: 0xFFFFFFFF80000000.
+/// i.e., the linear offset between physical memory and kernel memory.
+/// So, for example, the VGA buffer will be mapped from 0xb8000 to 0xFFFFFFFF800b8000.
+/// This is -2GiB from the end of the 64-bit address space.
+pub const KERNEL_OFFSET: usize = 0xFFFF_FFFF_8000_0000;
+
+
+
+/// The kernel text region is where we load kernel modules. 
+/// It starts at the 511th P4 entry and goes up until the KERNEL_OFFSET,
+/// which is where the nano_core itself starts. 
+/// Actual value: 0o177777_777_000_000_000_0000, or 0xFFFF_FF80_0000_0000
+pub const KERNEL_TEXT_START: usize = 0xFFFF_0000_0000_0000 | (KERNEL_TEXT_P4_INDEX << (P4_INDEX_SHIFT + PAGE_SHIFT));
+/// The size in bytes, not in pages.
+pub const KERNEL_TEXT_MAX_SIZE: usize = ADDRESSABILITY_PER_P4_ENTRY - (2 * 1024 * 1024 * 1024); // because the KERNEL_OFFSET starts at -2GiB
+
+
+/// The higher-half heap gets the 512GB address range starting at the 509th P4 entry,
+/// which is the slot right below the recursive P4 entry (510).
+/// Actual value: 0o177777_775_000_000_000_0000, or 0xFFFF_FE80_0000_0000
+pub const KERNEL_HEAP_START: usize = 0xFFFF_0000_0000_0000 | (KERNEL_HEAP_P4_INDEX << (P4_INDEX_SHIFT + PAGE_SHIFT));
+#[cfg(not(debug_assertions))]
+pub const KERNEL_HEAP_INITIAL_SIZE: usize = 64 * 1024 * 1024; // 64 MiB
+#[cfg(debug_assertions)]
+pub const KERNEL_HEAP_INITIAL_SIZE: usize = 256 * 1024 * 1024; // 256 MiB, debug builds require more heap space.
+/// the kernel heap gets the whole 509th P4 entry.
+pub const KERNEL_HEAP_MAX_SIZE: usize = ADDRESSABILITY_PER_P4_ENTRY;
+
+
+/// the kernel stack allocator gets the 508th P4 entry of addressability.
+/// actual value: 0o177777_774_000_000_000_0000, or 0xFFFF_FE00_0000_0000 
+pub const KERNEL_STACK_ALLOCATOR_BOTTOM: usize = 0xFFFF_0000_0000_0000 | (KERNEL_STACK_P4_INDEX << (P4_INDEX_SHIFT + PAGE_SHIFT));
+/// the highest actually usuable address in the kernel stack allocator
+pub const KERNEL_STACK_ALLOCATOR_TOP_ADDR: usize = KERNEL_STACK_ALLOCATOR_BOTTOM + ADDRESSABILITY_PER_P4_ENTRY - BYTES_PER_ADDR;
+
+
+/// the userspace stack allocators (one per userspace task) each get the 507th P4 entry of addressability.
+/// actual value: 0o177777_773_000_000_000_0000, or 0xFFFF_FD80_0000_0000  
+pub const USER_STACK_ALLOCATOR_BOTTOM: usize = 0xFFFF_0000_0000_0000 | (USER_STACK_P4_INDEX << (P4_INDEX_SHIFT + PAGE_SHIFT));
+/// the highest actually usuable address in each userspace stack allocator
+pub const USER_STACK_ALLOCATOR_TOP_ADDR: usize = USER_STACK_ALLOCATOR_BOTTOM + ADDRESSABILITY_PER_P4_ENTRY - BYTES_PER_ADDR;
+

--- a/aarch64/kernel/kernel_config/src/time.rs
+++ b/aarch64/kernel/kernel_config/src/time.rs
@@ -1,0 +1,15 @@
+
+
+/// the chosen interrupt frequency (in Hertz) of the PIT clock 
+pub const CONFIG_PIT_FREQUENCY_HZ: u32 = 1000; 
+
+/// the chosen interrupt frequency (in Hertz) of the RTC.
+/// valid values are powers of 2, from 2 Hz up to 8192 Hz
+/// see [change_rtc_frequency()](rtc/)
+pub const CONFIG_RTC_FREQUENCY_HZ: usize = 128;
+
+/// The timeslice period, specified in microseconds.
+pub const CONFIG_TIMESLICE_PERIOD_MICROSECONDS: u32 = 8000; // 8ms
+
+/// the heartbeat period in milliseconds
+pub const CONFIG_HEARTBEAT_PERIOD_MS: usize = 10000;

--- a/aarch64/kernel/logger/Cargo.toml
+++ b/aarch64/kernel/logger/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "logger"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+log = "0.4.17"
+pl011_qemu = { git = "https://github.com/theseus-os/pl011/", branch = "aarch64-qemu-virt-test" }

--- a/aarch64/kernel/logger/lib.rs
+++ b/aarch64/kernel/logger/lib.rs
@@ -1,0 +1,37 @@
+#![no_std]
+
+use pl011_qemu::{PL011, UART1};
+use log::{Record, Metadata, Log, set_logger, set_max_level, STATIC_MAX_LEVEL};
+use core::{fmt::Write, mem::MaybeUninit};
+
+type QemuVirtUart = PL011<UART1>;
+
+pub struct Logger {
+    pub pl011: PL011<UART1>,
+}
+
+impl Log for Logger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        let mutable = unsafe { (self as *const Self).cast_mut().as_mut().unwrap() };
+
+        if self.enabled(record.metadata()) {
+            let _ = write!(&mut mutable.pl011, "{} - {}\r\n", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub static mut LOGGER: Logger = unsafe { MaybeUninit::uninit().assume_init() };
+
+pub fn init() {
+    unsafe {
+        LOGGER = Logger { pl011: QemuVirtUart::new(UART1::take().unwrap()) };
+        set_logger(&LOGGER).unwrap();
+        set_max_level(STATIC_MAX_LEVEL);
+    }
+}

--- a/aarch64/kernel/logger/lib.rs
+++ b/aarch64/kernel/logger/lib.rs
@@ -28,10 +28,10 @@ impl Log for Logger {
 
 pub static mut LOGGER: Logger = unsafe { MaybeUninit::uninit().assume_init() };
 
-pub fn init() {
+pub fn init() -> Result<(), &'static str> {
+    set_max_level(STATIC_MAX_LEVEL);
     unsafe {
         LOGGER = Logger { pl011: QemuVirtUart::new(UART1::take().unwrap()) };
-        set_logger(&LOGGER).unwrap();
-        set_max_level(STATIC_MAX_LEVEL);
+        set_logger(&LOGGER).map_err(|_| "logger::init - couldn't set logger")
     }
 }

--- a/aarch64/kernel/memory_structs/Cargo.toml
+++ b/aarch64/kernel/memory_structs/Cargo.toml
@@ -10,5 +10,7 @@ zerocopy = "0.5.0"
 derive_more = "0.99.0"
 paste = "1.0.5"
 
+kernel_config = { path = "../kernel_config" }
+
 [lib]
 path = "lib.rs"

--- a/aarch64/kernel/memory_structs/Cargo.toml
+++ b/aarch64/kernel/memory_structs/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "memory_structs"
+description = "Common types used in the memory management subsystem"
+version = "0.1.0"
+
+[dependencies]
+bit_field = "0.7.0"
+zerocopy = "0.5.0"
+derive_more = "0.99.0"
+paste = "1.0.5"
+
+[lib]
+path = "lib.rs"

--- a/aarch64/kernel/memory_structs/lib.rs
+++ b/aarch64/kernel/memory_structs/lib.rs
@@ -5,9 +5,9 @@
 
 #[macro_use] extern crate derive_more;
 extern crate bit_field;
+extern crate kernel_config;
 extern crate zerocopy;
 extern crate paste;
-
 
 use bit_field::BitField;
 use core::{
@@ -19,9 +19,7 @@ use core::{
 use zerocopy::FromBytes;
 use paste::paste;
 
-// temporary redefinitions
-pub const PAGE_SIZE: usize = 4096;
-pub const MAX_PAGE_NUMBER: usize = usize::MAX / PAGE_SIZE;
+pub use kernel_config::memory::{PAGE_SIZE, MAX_PAGE_NUMBER};
 
 /// A macro for defining `VirtualAddress` and `PhysicalAddress` structs
 /// and implementing their common traits, which are generally identical.

--- a/aarch64/kernel/memory_structs/lib.rs
+++ b/aarch64/kernel/memory_structs/lib.rs
@@ -1,0 +1,426 @@
+//! This crate contains common types used for memory mapping. 
+
+#![no_std]
+#![feature(step_trait)]
+
+#[macro_use] extern crate derive_more;
+extern crate bit_field;
+extern crate zerocopy;
+extern crate paste;
+
+
+use bit_field::BitField;
+use core::{
+    cmp::{min, max},
+    fmt,
+    iter::Step,
+    ops::{Add, AddAssign, Deref, DerefMut, RangeInclusive, Sub, SubAssign},
+};
+use zerocopy::FromBytes;
+use paste::paste;
+
+// temporary redefinitions
+pub const PAGE_SIZE: usize = 4096;
+pub const MAX_PAGE_NUMBER: usize = usize::MAX / PAGE_SIZE;
+
+/// A macro for defining `VirtualAddress` and `PhysicalAddress` structs
+/// and implementing their common traits, which are generally identical.
+macro_rules! implement_address {
+    ($TypeName:ident, $desc:literal, $prefix:literal, $is_canonical:ident, $canonicalize:ident, $chunk:ident) => {
+        paste! { // using the paste crate's macro for easy concatenation
+
+            #[doc = "A " $desc " memory address, which is a `usize` under the hood."]
+            #[derive(
+                Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, 
+                Binary, Octal, LowerHex, UpperHex, 
+                BitAnd, BitOr, BitXor, BitAndAssign, BitOrAssign, BitXorAssign, 
+                Add, Sub, AddAssign, SubAssign,
+                FromBytes,
+            )]
+            #[repr(transparent)]
+            pub struct $TypeName(usize);
+
+            impl $TypeName {
+                #[doc = "Creates a new `" $TypeName "`, returning an error if the address is not canonical.\n\n \
+                    This is useful for checking whether an address is valid before using it. 
+                    For example, on x86_64, virtual addresses are canonical
+                    if their upper bits `(64:48]` are sign-extended from bit 47,
+                    and physical addresses are canonical if their upper bits `(64:52]` are 0."]
+                pub fn new(addr: usize) -> Option<$TypeName> {
+                    if $is_canonical(addr) { Some($TypeName(addr)) } else { None }
+                }
+
+                #[doc = "Creates a new `" $TypeName "` that is guaranteed to be canonical."]
+                pub const fn new_canonical(addr: usize) -> $TypeName {
+                    $TypeName($canonicalize(addr))
+                }
+
+                #[doc = "Creates a new `" $TypeName "` with a value 0."]
+                pub const fn zero() -> $TypeName {
+                    $TypeName(0)
+                }
+
+                #[doc = "Returns the underlying `usize` value for this `" $TypeName "`."]
+                #[inline]
+                pub const fn value(&self) -> usize {
+                    self.0
+                }
+
+                #[doc = "Returns the offset from the " $chunk " boundary specified by this `"
+                    $TypeName ".\n\n \
+                    For example, if the [`PAGE_SIZE`] is 4096 (4KiB), then this will return
+                    the least significant 12 bits `(12:0]` of this `" $TypeName "`."]
+                pub const fn [<$chunk _offset>](&self) -> usize {
+                    self.0 & (PAGE_SIZE - 1)
+                }
+            }
+            impl fmt::Debug for $TypeName {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    write!(f, concat!($prefix, "{:#X}"), self.0)
+                }
+            }
+            impl fmt::Display for $TypeName {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    write!(f, "{:?}", self)
+                }
+            }
+            impl fmt::Pointer for $TypeName {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    write!(f, "{:?}", self)
+                }
+            }
+            impl Add<usize> for $TypeName {
+                type Output = $TypeName;
+                fn add(self, rhs: usize) -> $TypeName {
+                    $TypeName::new_canonical(self.0.saturating_add(rhs))
+                }
+            }
+            impl AddAssign<usize> for $TypeName {
+                fn add_assign(&mut self, rhs: usize) {
+                    *self = $TypeName::new_canonical(self.0.saturating_add(rhs));
+                }
+            }
+            impl Sub<usize> for $TypeName {
+                type Output = $TypeName;
+                fn sub(self, rhs: usize) -> $TypeName {
+                    $TypeName::new_canonical(self.0.saturating_sub(rhs))
+                }
+            }
+            impl SubAssign<usize> for $TypeName {
+                fn sub_assign(&mut self, rhs: usize) {
+                    *self = $TypeName::new_canonical(self.0.saturating_sub(rhs));
+                }
+            }
+            impl Into<usize> for $TypeName {
+                #[inline]
+                fn into(self) -> usize {
+                    self.0
+                }
+            }
+        }
+    };
+}
+
+#[inline]
+fn is_canonical_virtual_address(virt_addr: usize) -> bool {
+    match virt_addr.get_bits(47..64) {
+        0 | 0b1_1111_1111_1111_1111 => true,
+        _ => false,
+    }
+}
+
+#[inline]
+const fn canonicalize_virtual_address(virt_addr: usize) -> usize {
+    // match virt_addr.get_bit(47) {
+    //     false => virt_addr.set_bits(48..64, 0),
+    //     true =>  virt_addr.set_bits(48..64, 0xffff),
+    // };
+
+    // The below code is semantically equivalent to the above, but it works in const functions.
+    ((virt_addr << 16) as isize >> 16) as usize
+}
+
+#[inline]
+fn is_canonical_physical_address(phys_addr: usize) -> bool {
+    match phys_addr.get_bits(52..64) {
+        0 => true,
+        _ => false,
+    }
+}
+
+#[inline]
+const fn canonicalize_physical_address(phys_addr: usize) -> usize {
+    phys_addr & 0x000F_FFFF_FFFF_FFFF
+}
+
+implement_address!(
+    VirtualAddress,
+    "virtual",
+    "v",
+    is_canonical_virtual_address,
+    canonicalize_virtual_address,
+    page
+);
+
+implement_address!(
+    PhysicalAddress,
+    "physical",
+    "p",
+    is_canonical_physical_address,
+    canonicalize_physical_address,
+    frame
+);
+
+
+
+/// A macro for defining `Page` and `Frame` structs
+/// and implementing their common traits, which are generally identical.
+macro_rules! implement_page_frame {
+    ($TypeName:ident, $desc:literal, $prefix:literal, $address:ident) => {
+        paste! { // using the paste crate's macro for easy concatenation
+
+            #[doc = "A `" $TypeName "` is a chunk of **" $desc "** memory aligned to a [`PAGE_SIZE`] boundary."]
+            #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+            pub struct $TypeName {
+                number: usize,
+            }
+
+            impl $TypeName {
+                #[doc = "Returns the `" $address "` at the start of this `" $TypeName "`."]
+                pub const fn start_address(&self) -> $address {
+                    $address::new_canonical(self.number * PAGE_SIZE)
+                }
+
+                #[doc = "Returns the number of this `" $TypeName "`."]
+                #[inline(always)]
+                pub const fn number(&self) -> usize {
+                    self.number
+                }
+                
+                #[doc = "Returns the `" $TypeName "` containing the given `" $address "`."]
+                pub const fn containing_address(addr: $address) -> $TypeName {
+                    $TypeName {
+                        number: addr.value() / PAGE_SIZE,
+                    }
+                }
+            }
+            impl fmt::Debug for $TypeName {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    write!(f, concat!(stringify!($TypeName), "(", $prefix, "{:#X})"), self.start_address())
+                }
+            }
+            impl Add<usize> for $TypeName {
+                type Output = $TypeName;
+                fn add(self, rhs: usize) -> $TypeName {
+                    // cannot exceed max page number (which is also max frame number)
+                    $TypeName {
+                        number: core::cmp::min(MAX_PAGE_NUMBER, self.number.saturating_add(rhs)),
+                    }
+                }
+            }
+            impl AddAssign<usize> for $TypeName {
+                fn add_assign(&mut self, rhs: usize) {
+                    *self = $TypeName {
+                        number: core::cmp::min(MAX_PAGE_NUMBER, self.number.saturating_add(rhs)),
+                    };
+                }
+            }
+            impl Sub<usize> for $TypeName {
+                type Output = $TypeName;
+                fn sub(self, rhs: usize) -> $TypeName {
+                    $TypeName {
+                        number: self.number.saturating_sub(rhs),
+                    }
+                }
+            }
+            impl SubAssign<usize> for $TypeName {
+                fn sub_assign(&mut self, rhs: usize) {
+                    *self = $TypeName {
+                        number: self.number.saturating_sub(rhs),
+                    };
+                }
+            }
+            #[doc = "Implementing `Step` allows `" $TypeName "` to be used in an [`Iterator`]."]
+            impl Step for $TypeName {
+                #[inline]
+                fn steps_between(start: &$TypeName, end: &$TypeName) -> Option<usize> {
+                    Step::steps_between(&start.number, &end.number)
+                }
+                #[inline]
+                fn forward_checked(start: $TypeName, count: usize) -> Option<$TypeName> {
+                    Step::forward_checked(start.number, count).map(|n| $TypeName { number: n })
+                }
+                #[inline]
+                fn backward_checked(start: $TypeName, count: usize) -> Option<$TypeName> {
+                    Step::backward_checked(start.number, count).map(|n| $TypeName { number: n })
+                }
+            }
+        }
+    };
+}
+
+implement_page_frame!(Page, "virtual", "v", VirtualAddress);
+implement_page_frame!(Frame, "physical", "p", PhysicalAddress);
+
+// Implement other functions for the `Page` type that aren't relevant for `Frame.
+impl Page {
+    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P4 page table entries list.
+    pub const fn p4_index(&self) -> usize {
+        (self.number >> 27) & 0x1FF
+    }
+
+    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P3 page table entries list.
+    pub const fn p3_index(&self) -> usize {
+        (self.number >> 18) & 0x1FF
+    }
+
+    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P2 page table entries list.
+    pub const fn p2_index(&self) -> usize {
+        (self.number >> 9) & 0x1FF
+    }
+
+    /// Returns the 9-bit part of this `Page`'s [`VirtualAddress`] that is the index into the P1 page table entries list.
+    ///
+    /// Using this returned `usize` value as an index into the P1 entries list will give you the final PTE,
+    /// from which you can extract the mapped [`Frame`]  using `PageTableEntry::pointed_frame()`.
+    pub const fn p1_index(&self) -> usize {
+        (self.number >> 0) & 0x1FF
+    }
+}
+
+
+
+/// A macro for defining `PageRange` and `FrameRange` structs
+/// and implementing their common traits, which are generally identical.
+macro_rules! implement_page_frame_range {
+    ($TypeName:ident, $desc:literal, $short:ident, $chunk:ident, $address:ident) => {
+        paste! { // using the paste crate's macro for easy concatenation
+                        
+            #[doc = "A range of [`" $chunk "`]s that are contiguous in " $desc " memory."]
+            #[derive(Clone, PartialEq, Eq)]
+            pub struct $TypeName(RangeInclusive<$chunk>);
+
+            impl $TypeName {
+                #[doc = "Creates a new range of [`" $chunk "`]s that spans from `start` to `end`, both inclusive bounds."]
+                pub const fn new(start: $chunk, end: $chunk) -> $TypeName {
+                    $TypeName(RangeInclusive::new(start, end))
+                }
+
+                #[doc = "Creates a `" $TypeName "` that will always yield `None` when iterated."]
+                pub const fn empty() -> $TypeName {
+                    $TypeName::new($chunk { number: 1 }, $chunk { number: 0 })
+                }
+
+                #[doc = "A convenience method for creating a new `" $TypeName "` that spans \
+                    all [`" $chunk "`]s from the given [`" $address "`] to an end bound based on the given size."]
+                pub fn [<from_ $short _addr>](starting_addr: $address, size_in_bytes: usize) -> $TypeName {
+                    assert!(size_in_bytes > 0);
+                    let start = $chunk::containing_address(starting_addr);
+                    // The end bound is inclusive, hence the -1. Parentheses are needed to avoid overflow.
+                    let end = $chunk::containing_address(starting_addr + (size_in_bytes - 1));
+                    $TypeName::new(start, end)
+                }
+
+                #[doc = "Returns the [`" $address "`] of the starting [`" $chunk "`] in this `" $TypeName "`."]
+                pub const fn start_address(&self) -> $address {
+                    self.0.start().start_address()
+                }
+
+                #[doc = "Returns the number of [`" $chunk "`]s covered by this iterator.\n\n \
+                    Use this instead of [`Iterator::count()`] method. \
+                    This is instant, because it doesn't need to iterate over each entry, unlike normal iterators."]
+                pub const fn [<size_in_ $chunk:lower s>](&self) -> usize {
+                    // add 1 because it's an inclusive range
+                    (self.0.end().number + 1).saturating_sub(self.0.start().number)
+                }
+
+                /// Returns the size of this range in number of bytes.
+                pub const fn size_in_bytes(&self) -> usize {
+                    self.[<size_in_ $chunk:lower s>]() * PAGE_SIZE
+                }
+
+                #[doc = "Returns `true` if this `" $TypeName "` contains the given [`" $address "`]."]
+                pub fn contains_address(&self, addr: $address) -> bool {
+                    self.0.contains(&$chunk::containing_address(addr))
+                }
+
+                #[doc = "Returns the offset of the given [`" $address "`] within this `" $TypeName "`, \
+                    i.e., `addr - self.start_address()`.\n\n \
+                    If the given `addr` is not covered by this range of [`" $chunk "`]s, this returns `None`.\n\n \
+                    # Examples\n \
+                    If the range covers addresses `0x2000` to `0x4000`, then `offset_of_address(0x3500)` would return `Some(0x1500)`."]
+                pub fn offset_of_address(&self, addr: $address) -> Option<usize> {
+                    if self.contains_address(addr) {
+                        Some(addr.value() - self.start_address().value())
+                    } else {
+                        None
+                    }
+                }
+
+                #[doc = "Returns the [`" $address "`] at the given `offset` into this `" $TypeName "`within this `" $TypeName "`, \
+                    i.e., `addr - self.start_address()`.\n\n \
+                    If the given `offset` is not within this range of [`" $chunk "`]s, this returns `None`.\n\n \
+                    # Examples\n \
+                    If the range covers addresses `0x2000` to `0x4000`, then `address_at_offset(0x1500)` would return `Some(0x3500)`."]
+                pub fn address_at_offset(&self, offset: usize) -> Option<$address> {
+                    if offset <= self.size_in_bytes() {
+                        Some(self.start_address() + offset)
+                    }
+                    else {
+                        None
+                    }
+                }
+
+                #[doc = "Returns a new separate `" $TypeName "` that is extended to include the given [`" $chunk "`]."]
+                pub fn to_extended(&self, to_include: $chunk) -> $TypeName {
+                    // if the current range was empty, return a new range containing only the given page/frame
+                    if self.is_empty() {
+                        return $TypeName::new(to_include.clone(), to_include);
+                    }
+                    let start = core::cmp::min(self.0.start(), &to_include);
+                    let end = core::cmp::max(self.0.end(), &to_include);
+                    $TypeName::new(start.clone(), end.clone())
+                }
+
+                #[doc = "Returns an inclusive `" $TypeName "` representing the [`" $chunk "`]s that overlap \
+                    across this `" $TypeName "` and the given other `" $TypeName "`.\n\n \
+                    If there is no overlap between the two ranges, `None` is returned."]
+                pub fn overlap(&self, other: &$TypeName) -> Option<$TypeName> {
+                    let starts = max(*self.start(), *other.start());
+                    let ends   = min(*self.end(),   *other.end());
+                    if starts <= ends {
+                        Some($TypeName::new(starts, ends))
+                    } else {
+                        None
+                    }
+                }
+            }
+            impl fmt::Debug for $TypeName {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    write!(f, "{:?}", self.0)
+                }
+            }
+            impl Deref for $TypeName {
+                type Target = RangeInclusive<$chunk>;
+                fn deref(&self) -> &RangeInclusive<$chunk> {
+                    &self.0
+                }
+            }
+            impl DerefMut for $TypeName {
+                fn deref_mut(&mut self) -> &mut RangeInclusive<$chunk> {
+                    &mut self.0
+                }
+            }
+            impl IntoIterator for $TypeName {
+                type Item = $chunk;
+                type IntoIter = RangeInclusive<$chunk>;
+                fn into_iter(self) -> Self::IntoIter {
+                    self.0
+                }
+            }
+        }
+    };
+}
+
+implement_page_frame_range!(PageRange, "virtual", virt, Page, VirtualAddress);
+implement_page_frame_range!(FrameRange, "physical", phys, Frame, PhysicalAddress);

--- a/aarch64/kernel/nano_core/Cargo.toml
+++ b/aarch64/kernel/nano_core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "nano_core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+uefi = { version = "0.16.1", features = [ "alloc", "exts", "logger" ] }
+uefi-services = "0.13.1"
+pl011_qemu = { git = "https://github.com/theseus-os/pl011/", branch = "aarch64-qemu-virt-test" }

--- a/aarch64/kernel/nano_core/Cargo.toml
+++ b/aarch64/kernel/nano_core/Cargo.toml
@@ -3,7 +3,22 @@ name = "nano_core"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "nano_core"
+path = "main.rs"
+
 [dependencies]
-uefi = { version = "0.16.1", features = [ "alloc", "exts", "logger" ] }
-uefi-services = "0.13.1"
-pl011_qemu = { git = "https://github.com/theseus-os/pl011/", branch = "aarch64-qemu-virt-test" }
+log = "0.4.17"
+logger = { path = "../logger" }
+
+[dependencies.uefi]
+git = "https://github.com/theseus-os/uefi-rs/"
+branch = "until-upstream-pr-merged"
+default-features = false
+features = [ "alloc", "exts" ]
+
+[dependencies.uefi-services]
+git = "https://github.com/theseus-os/uefi-rs/"
+branch = "until-upstream-pr-merged"
+default-features = false
+features = [ "panic_handler" ]

--- a/aarch64/kernel/nano_core/Cargo.toml
+++ b/aarch64/kernel/nano_core/Cargo.toml
@@ -11,6 +11,9 @@ path = "main.rs"
 log = "0.4.17"
 
 logger = { path = "../logger" }
+frame_allocator = { path = "../frame_allocator" }
+page_allocator = { path = "../page_allocator" }
+memory_structs = { path = "../memory_structs" }
 
 uefi = { version = "0.18", default-features = false, features = [ "alloc", "exts" ] }
 uefi-services = { version = "0.15", default-features = false, features = [ "panic_handler" ] }

--- a/aarch64/kernel/nano_core/Cargo.toml
+++ b/aarch64/kernel/nano_core/Cargo.toml
@@ -9,16 +9,8 @@ path = "main.rs"
 
 [dependencies]
 log = "0.4.17"
+
 logger = { path = "../logger" }
 
-[dependencies.uefi]
-git = "https://github.com/theseus-os/uefi-rs/"
-branch = "until-upstream-pr-merged"
-default-features = false
-features = [ "alloc", "exts" ]
-
-[dependencies.uefi-services]
-git = "https://github.com/theseus-os/uefi-rs/"
-branch = "until-upstream-pr-merged"
-default-features = false
-features = [ "panic_handler" ]
+uefi = { version = "0.18", default-features = false, features = [ "alloc", "exts" ] }
+uefi-services = { version = "0.15", default-features = false, features = [ "panic_handler" ] }

--- a/aarch64/kernel/nano_core/main.rs
+++ b/aarch64/kernel/nano_core/main.rs
@@ -4,22 +4,18 @@
 #![no_main]
 
 extern crate alloc;
+extern crate logger;
 
 use alloc::vec;
-use core::fmt::Write;
 use core::arch::asm;
 
-use uefi_services::init;
 use uefi::prelude::entry;
 use uefi::Status;
 use uefi::Handle;
 use uefi::table::SystemTable;
 use uefi::table::Boot;
 
-use pl011_qemu::PL011;
-use pl011_qemu::UART1;
-
-pub type Pl011 = PL011<UART1>;
+use log::info;
 
 #[inline(never)]
 extern "C" fn inf_loop_0xbeef() -> ! {
@@ -32,7 +28,10 @@ fn main(
     handle: Handle,
     mut system_table: SystemTable<Boot>,
 ) -> Status {
-    init(&mut system_table).unwrap();
+    logger::init();
+    info!("Hello, World!");
+
+    uefi_services::init(&mut system_table).unwrap();
     let bootsvc = system_table.boot_services();
 
     let safety = 16;
@@ -42,10 +41,6 @@ fn main(
 
     let _ = system_table.exit_boot_services(handle, &mut mmap).unwrap();
 
-    let mut logger = PL011::new(UART1::take().unwrap());
-
-    let _ = logger.write_str("Hello, World!\r\n");
-
-    let _ = logger.write_str("Going to infinite loop now.\r\n");
+    info!("Going to infinite loop now.");
     inf_loop_0xbeef();
 }

--- a/aarch64/kernel/nano_core/main.rs
+++ b/aarch64/kernel/nano_core/main.rs
@@ -9,13 +9,9 @@ extern crate logger;
 use alloc::vec;
 use core::arch::asm;
 
-use uefi::prelude::entry;
-use uefi::Status;
-use uefi::Handle;
-use uefi::table::SystemTable;
-use uefi::table::Boot;
+use uefi::{prelude::entry, Status, Handle, table::{SystemTable, Boot}};
 
-use log::info;
+use log::{info, error};
 
 #[inline(never)]
 extern "C" fn inf_loop_0xbeef() -> ! {
@@ -23,15 +19,17 @@ extern "C" fn inf_loop_0xbeef() -> ! {
     loop {}
 }
 
-#[entry]
 fn main(
     handle: Handle,
     mut system_table: SystemTable<Boot>,
-) -> Status {
-    logger::init();
+) -> Result<(), &'static str> {
+
+    logger::init()?;
     info!("Hello, World!");
 
-    uefi_services::init(&mut system_table).unwrap();
+    uefi_services::init(&mut system_table)
+        .map_err(|_| "nano_core::main - couldn't init uefi services")?;
+
     let bootsvc = system_table.boot_services();
 
     let safety = 16;
@@ -39,8 +37,24 @@ fn main(
     let mmap_size = bootsvc.memory_map_size();
     let mut mmap = vec![0; mmap_size.map_size + safety * mmap_size.entry_size];
 
-    let _ = system_table.exit_boot_services(handle, &mut mmap).unwrap();
+    let _ = system_table.exit_boot_services(handle, &mut mmap)
+        .map_err(|_| "nano_core::main - couldn't exit uefi boot services")?;
 
     info!("Going to infinite loop now.");
     inf_loop_0xbeef();
+
+}
+
+#[entry]
+fn uefi_main(
+    handle: Handle,
+    system_table: SystemTable<Boot>,
+) -> Status {
+    match main(handle, system_table) {
+        Ok(()) => Status::SUCCESS,
+        Err(msg) => {
+            error!("{}", msg);
+            Status::ABORTED
+        },
+    }
 }

--- a/aarch64/kernel/nano_core/main.rs
+++ b/aarch64/kernel/nano_core/main.rs
@@ -9,13 +9,13 @@ extern crate frame_allocator;
 extern crate page_allocator;
 extern crate memory_structs;
 
-use alloc::{vec, vec::Vec};
-use core::{arch::asm, mem::MaybeUninit};
+use alloc::vec;
+use core::arch::asm;
 
 use uefi::{prelude::entry, Status, Handle, table::{SystemTable, Boot, boot::MemoryType}};
 
 use frame_allocator::{PhysicalMemoryRegion, MemoryRegionType};
-use memory_structs::{PAGE_SIZE, PhysicalAddress, Frame, FrameRange};
+use memory_structs::{PAGE_SIZE, PhysicalAddress, Frame, FrameRange, VirtualAddress};
 
 use log::{info, error};
 
@@ -75,10 +75,13 @@ fn main(
         }
     }
 
-    let callback = frame_allocator::init(
+    let _callback = frame_allocator::init(
         free_regions.iter().flatten(),
         reserved_regions.iter().flatten(),
     )?;
+
+    // for now, virtual addresses will be above 4GB
+    page_allocator::init(VirtualAddress::new_canonical(0x100_000_000))?;
 
     info!("Going to infinite loop now.");
     inf_loop_0xbeef();

--- a/aarch64/kernel/nano_core/src/main.rs
+++ b/aarch64/kernel/nano_core/src/main.rs
@@ -1,0 +1,51 @@
+#![feature(naked_functions)]
+#![feature(abi_efiapi)]
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::vec;
+use core::fmt::Write;
+use core::arch::asm;
+
+use uefi_services::init;
+use uefi::prelude::entry;
+use uefi::Status;
+use uefi::Handle;
+use uefi::table::SystemTable;
+use uefi::table::Boot;
+
+use pl011_qemu::PL011;
+use pl011_qemu::UART1;
+
+pub type Pl011 = PL011<UART1>;
+
+#[inline(never)]
+extern "C" fn inf_loop_0xbeef() -> ! {
+    unsafe { asm!("mov x1, #0xbeef") };
+    loop {}
+}
+
+#[entry]
+fn main(
+    handle: Handle,
+    mut system_table: SystemTable<Boot>,
+) -> Status {
+    init(&mut system_table).unwrap();
+    let bootsvc = system_table.boot_services();
+
+    let safety = 16;
+
+    let mmap_size = bootsvc.memory_map_size();
+    let mut mmap = vec![0; mmap_size.map_size + safety * mmap_size.entry_size];
+
+    let _ = system_table.exit_boot_services(handle, &mut mmap).unwrap();
+
+    let mut logger = PL011::new(UART1::take().unwrap());
+
+    let _ = logger.write_str("Hello, World!\r\n");
+
+    let _ = logger.write_str("Going to infinite loop now.\r\n");
+    inf_loop_0xbeef();
+}

--- a/aarch64/kernel/page_allocator/Cargo.toml
+++ b/aarch64/kernel/page_allocator/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "page_allocator"
+description = "The allocator for virtual memory frames."
+version = "0.1.0"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+spin = "0.9.0"
+static_assertions = "1.1.0"
+memory_structs = { path = "../memory_structs" }
+static_array_collections = { path = "../static_array_collections" }
+kernel_config = { path = "../kernel_config" }
+log = "0.4.8"

--- a/aarch64/kernel/page_allocator/lib.rs
+++ b/aarch64/kernel/page_allocator/lib.rs
@@ -1,0 +1,716 @@
+//! Provides an allocator for virtual memory pages.
+//! The minimum unit of allocation is a single page. 
+//! 
+//! This also supports early allocation of pages (up to 32 separate chunks)
+//! before heap allocation is available, and does so behind the scenes using the same single interface. 
+//! 
+//! Once heap allocation is available, it uses a dynamically-allocated list of page chunks to track allocations.
+//! 
+//! The core allocation function is [`allocate_pages_deferred()`](fn.allocate_pages_deferred.html), 
+//! but there are several convenience functions that offer simpler interfaces for general usage. 
+//!
+//! # Notes and Missing Features
+//! This allocator currently does **not** merge freed chunks (de-fragmentation) upon deallocation. 
+//! It only merges free chunks lazily upon request, i.e., when we run out of address space
+//! or when a requested address is in a chunk that needs to be merged with a nearby chunk.
+
+#![no_std]
+
+extern crate alloc;
+extern crate memory_structs;
+extern crate kernel_config;
+extern crate spin;
+#[macro_use] extern crate log;
+#[macro_use] extern crate static_assertions;
+extern crate static_array_collections;
+
+use core::{borrow::Borrow, cmp::Ordering, fmt, ops::{Deref, DerefMut}};
+use kernel_config::memory::{KERNEL_HEAP_START, KERNEL_TEXT_START, MAX_VIRTUAL_ADDRESS, ADDRESSABILITY_PER_P4_ENTRY};
+use memory_structs::{VirtualAddress, Page, PageRange, PAGE_SIZE};
+use spin::{Mutex, Once};
+use static_array_collections::intrusive_collections::Bound;
+use static_array_collections::static_array_rb_tree::*;
+
+
+/// Certain regions are pre-designated for special usage, specifically the kernel's initial identity mapping.
+/// They will be allocated from if an address within them is specifically requested;
+/// otherwise, they will only be allocated from as a "last resort" if all other non-designated address ranges are exhausted.
+///
+/// Any virtual addresses **less than or equal** to this address are considered "designated".
+/// This lower part of the address range that's designated covers from 0x0 to this address.
+static DESIGNATED_PAGES_LOW_END: Once<Page> = Once::new();
+
+/// Defines the upper part of the address space that's designated, similar to `DESIGNATED_PAGES_LOW_END`. 
+/// Any virtual addresses **greater than or equal to** this address is considered "designated".
+/// This higher part of the address range covers from the beginning of the heap area to the end of the address space.
+///
+/// TODO: once the heap is fully dynamic and not dependent on constant addresses, we can move this up to KERNEL_TEXT_START (511th entry of P4).
+static DESIGNATED_PAGES_HIGH_START: Page = Page::containing_address(VirtualAddress::new_canonical(KERNEL_HEAP_START));
+
+const MIN_PAGE: Page = Page::containing_address(VirtualAddress::zero());
+const MAX_PAGE: Page = Page::containing_address(VirtualAddress::new_canonical(MAX_VIRTUAL_ADDRESS));
+
+/// The single, system-wide list of free chunks of virtual memory pages.
+static FREE_PAGE_LIST: Mutex<StaticArrayRBTree<Chunk>> = Mutex::new(StaticArrayRBTree::empty());
+
+
+/// Initialize the page allocator.
+///
+/// # Arguments
+/// * `end_vaddr_of_low_designated_region`: the `VirtualAddress` that marks the end of the 
+///   lower designated region, which should be the ending address of the initial kernel image
+///   (a lower-half identity address).
+/// 
+/// The page allocator will only allocate addresses lower than `end_vaddr_of_low_designated_region`
+/// if specifically requested.
+/// General allocation requests for any virtual address will not use any address lower than that,
+/// unless the rest of the entire virtual address space is already in use.
+///
+pub fn init(end_vaddr_of_low_designated_region: VirtualAddress) -> Result<(), &'static str> {
+    assert!(end_vaddr_of_low_designated_region < DESIGNATED_PAGES_HIGH_START.start_address());
+    let designated_low_end = DESIGNATED_PAGES_LOW_END.call_once(|| Page::containing_address(end_vaddr_of_low_designated_region));
+    let designated_low_end = *designated_low_end;
+
+    let initial_free_chunks = [
+        // The first region contains all pages *below* the beginning of the 510th entry of P4. 
+        // We split it up into three chunks just for ease, since it overlaps the designated regions.
+        Some(Chunk { 
+            pages: PageRange::new(
+                Page::containing_address(VirtualAddress::zero()),
+                designated_low_end,
+            )
+        }),
+        Some(Chunk { 
+            pages: PageRange::new(
+                designated_low_end + 1,
+                DESIGNATED_PAGES_HIGH_START - 1,
+            )
+        }),
+        Some(Chunk { 
+            pages: PageRange::new(
+                DESIGNATED_PAGES_HIGH_START,
+                // This is the page right below the beginning of the 510th entry of the top-level P4 page table.
+                Page::containing_address(VirtualAddress::new_canonical(KERNEL_TEXT_START - ADDRESSABILITY_PER_P4_ENTRY - 1)),
+            )
+        }),
+
+        // The second region contains all pages *above* the end of the 510th entry of P4, i.e., starting at the 511th (last) entry of P4.
+        // This is fully covered by the second (higher) designated region.
+        Some(Chunk { 
+            pages: PageRange::new(
+                Page::containing_address(VirtualAddress::new_canonical(KERNEL_TEXT_START)),
+                Page::containing_address(VirtualAddress::new_canonical(MAX_VIRTUAL_ADDRESS)),
+            )
+        }),
+        None, None, None, None,
+        None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None,
+    ];
+
+    *FREE_PAGE_LIST.lock() = StaticArrayRBTree::new(initial_free_chunks);
+    Ok(())
+}
+
+
+/// A range of contiguous pages.
+///
+/// # Ordering and Equality
+///
+/// `Chunk` implements the `Ord` trait, and its total ordering is ONLY based on
+/// its **starting** `Page`. This is useful so we can store `Chunk`s in a sorted collection.
+///
+/// Similarly, `Chunk` implements equality traits, `Eq` and `PartialEq`,
+/// both of which are also based ONLY on the **starting** `Page` of the `Chunk`.
+/// Thus, comparing two `Chunk`s with the `==` or `!=` operators may not work as expected.
+/// since it ignores their actual range of pages.
+#[derive(Debug, Clone, Eq)]
+struct Chunk {
+    /// The Pages covered by this chunk, an inclusive range. 
+    pages: PageRange,
+}
+impl Chunk {
+    fn as_allocated_pages(&self) -> AllocatedPages {
+        AllocatedPages {
+            pages: self.pages.clone(),
+        }
+    }
+
+    /// Returns a new `Chunk` with an empty range of pages. 
+    fn empty() -> Chunk {
+        Chunk {
+            pages: PageRange::empty(),
+        }
+    }
+}
+impl Deref for Chunk {
+    type Target = PageRange;
+    fn deref(&self) -> &PageRange {
+        &self.pages
+    }
+}
+impl Ord for Chunk {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.pages.start().cmp(other.pages.start())
+    }
+}
+impl PartialOrd for Chunk {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl PartialEq for Chunk {
+    fn eq(&self, other: &Self) -> bool {
+        self.pages.start() == other.pages.start()
+    }
+}
+impl Borrow<Page> for &'_ Chunk {
+    fn borrow(&self) -> &Page {
+        self.pages.start()
+    }
+}
+
+
+/// Represents a range of allocated `VirtualAddress`es, specified in `Page`s. 
+/// 
+/// These pages are not initially mapped to any physical memory frames, you must do that separately
+/// in order to actually use their memory; see the `MappedPages` type for more. 
+/// 
+/// This object represents ownership of the allocated virtual pages;
+/// if this object falls out of scope, its allocated pages will be auto-deallocated upon drop. 
+pub struct AllocatedPages {
+    pages: PageRange,
+}
+
+// AllocatedPages must not be Cloneable, and it must not expose its inner pages as mutable.
+assert_not_impl_any!(AllocatedPages: DerefMut, Clone);
+
+impl Deref for AllocatedPages {
+    type Target = PageRange;
+    fn deref(&self) -> &PageRange {
+        &self.pages
+    }
+}
+impl fmt::Debug for AllocatedPages {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "AllocatedPages({:?})", self.pages)
+    }
+}
+
+impl AllocatedPages {
+    /// Returns an empty AllocatedPages object that performs no page allocation. 
+    /// Can be used as a placeholder, but will not permit any real usage. 
+    pub const fn empty() -> AllocatedPages {
+        AllocatedPages {
+            pages: PageRange::empty()
+        }
+    }
+
+    /// Merges the given `AllocatedPages` object `ap` into this `AllocatedPages` object (`self`).
+    /// This is just for convenience and usability purposes, it performs no allocation or remapping.
+    ///
+    /// The `ap` must be virtually contiguous and come immediately after `self`,
+    /// that is, `self.end` must equal `ap.start`. 
+    /// If this condition is met, `self` is modified and `Ok(())` is returned,
+    /// otherwise `Err(ap)` is returned.
+    pub fn merge(&mut self, ap: AllocatedPages) -> Result<(), AllocatedPages> {
+        // make sure the pages are contiguous
+        if *ap.start() != (*self.end() + 1) {
+            return Err(ap);
+        }
+        self.pages = PageRange::new(*self.start(), *ap.end());
+        // ensure the now-merged AllocatedPages doesn't run its drop handler and free its pages.
+        core::mem::forget(ap); 
+        Ok(())
+    }
+
+    /// Splits this `AllocatedPages` into two separate `AllocatedPages` objects:
+    /// * `[beginning : at_page - 1]`
+    /// * `[at_page : end]`
+    /// 
+    /// This function follows the behavior of [`core::slice::split_at()`],
+    /// thus, either one of the returned `AllocatedPages` objects may be empty. 
+    /// * If `at_page == self.start`, the first returned `AllocatedPages` object will be empty.
+    /// * If `at_page == self.end + 1`, the second returned `AllocatedPages` object will be empty.
+    /// 
+    /// Returns an `Err` containing this `AllocatedPages` if `at_page` is otherwise out of bounds.
+    /// 
+    /// [`core::slice::split_at()`]: https://doc.rust-lang.org/core/primitive.slice.html#method.split_at
+    pub fn split(self, at_page: Page) -> Result<(AllocatedPages, AllocatedPages), AllocatedPages> {
+        let end_of_first = at_page - 1;
+
+        let (first, second) = if at_page == *self.start() && at_page <= *self.end() {
+            let first  = PageRange::empty();
+            let second = PageRange::new(at_page, *self.end());
+            (first, second)
+        } 
+        else if at_page == (*self.end() + 1) && end_of_first >= *self.start() {
+            let first  = PageRange::new(*self.start(), *self.end()); 
+            let second = PageRange::empty();
+            (first, second)
+        }
+        else if at_page > *self.start() && end_of_first <= *self.end() {
+            let first  = PageRange::new(*self.start(), end_of_first);
+            let second = PageRange::new(at_page, *self.end());
+            (first, second)
+        }
+        else {
+            return Err(self);
+        };
+
+        // ensure the original AllocatedPages doesn't run its drop handler and free its pages.
+        core::mem::forget(self);   
+        Ok((
+            AllocatedPages { pages: first }, 
+            AllocatedPages { pages: second },
+        ))
+    }
+}
+
+impl Drop for AllocatedPages {
+    fn drop(&mut self) {
+        if self.size_in_pages() == 0 { return; }
+        // trace!("page_allocator: deallocating {:?}", self);
+
+        // Simply add the newly-deallocated chunk to the free pages list.
+        let mut locked_list = FREE_PAGE_LIST.lock();
+        let res = locked_list.insert(Chunk {
+            pages: self.pages.clone(),
+        });
+        match res {
+            Ok(_inserted_free_chunk) => return,
+            Err(c) => error!("BUG: couldn't insert deallocated chunk {:?} into free page list", c),
+        }
+        
+        // Here, we could optionally use above `_inserted_free_chunk` to merge the adjacent (contiguous) chunks
+        // before or after the newly-inserted free chunk. 
+        // However, there's no *need* to do so until we actually run out of address space or until 
+        // a requested address is in a chunk that needs to be merged.
+        // Thus, for performance, we save that for those future situations.
+    }
+}
+
+
+
+/// A series of pending actions related to page allocator bookkeeping,
+/// which may result in heap allocation. 
+/// 
+/// The actions are triggered upon dropping this struct. 
+/// This struct can be returned from the `allocate_pages()` family of functions 
+/// in order to allow the caller to precisely control when those actions 
+/// that may result in heap allocation should occur. 
+/// Such actions include adding chunks to lists of free pages or pages in use. 
+/// 
+/// The vast majority of use cases don't  care about such precise control, 
+/// so you can simply drop this struct at any time or ignore it
+/// with a `let _ = ...` binding to instantly drop it. 
+pub struct DeferredAllocAction<'list> {
+    /// A reference to the list into which we will insert the free `Chunk`s.
+    free_list: &'list Mutex<StaticArrayRBTree<Chunk>>,
+    /// A free chunk that needs to be added back to the free list.
+    free1: Chunk,
+    /// Another free chunk that needs to be added back to the free list.
+    free2: Chunk,
+}
+impl<'list> DeferredAllocAction<'list> {
+    fn new<F1, F2>(free1: F1, free2: F2) -> DeferredAllocAction<'list> 
+        where F1: Into<Option<Chunk>>,
+              F2: Into<Option<Chunk>>,
+    {
+        let free_list = &FREE_PAGE_LIST;
+        let free1 = free1.into().unwrap_or_else(Chunk::empty);
+        let free2 = free2.into().unwrap_or_else(Chunk::empty);
+        DeferredAllocAction { free_list, free1, free2 }
+    }
+}
+impl<'list> Drop for DeferredAllocAction<'list> {
+    fn drop(&mut self) {
+        // Insert all of the chunks, both allocated and free ones, into the list. 
+        if self.free1.size_in_pages() > 0 {
+            self.free_list.lock().insert(self.free1.clone()).unwrap();
+        }
+        if self.free2.size_in_pages() > 0 {
+            self.free_list.lock().insert(self.free2.clone()).unwrap();
+        }
+    }
+}
+
+
+/// Possible allocation errors.
+#[derive(Debug)]
+enum AllocationError {
+    /// The requested address was not free: it was already allocated, or is outside the range of this allocator.
+    AddressNotFree(Page, usize),
+    /// The address space was full, or there was not a large-enough chunk 
+    /// or enough remaining chunks that could satisfy the requested allocation size.
+    OutOfAddressSpace(usize),
+    /// The allocator has not yet been initialized.
+    NotInitialized,
+}
+impl From<AllocationError> for &'static str {
+    fn from(alloc_err: AllocationError) -> &'static str {
+        match alloc_err {
+            AllocationError::AddressNotFree(..) => "address was in use or outside of this page allocator's range",
+            AllocationError::OutOfAddressSpace(..) => "out of virtual address space",
+            AllocationError::NotInitialized => "the page allocator has not yet been initialized",
+        }
+    }
+}
+
+
+/// Searches the given `list` for the chunk that contains the range of pages from
+/// `requested_page` to `requested_page + num_pages`.
+fn find_specific_chunk(
+    list: &mut StaticArrayRBTree<Chunk>,
+    requested_page: Page,
+    num_pages: usize
+) -> Result<(AllocatedPages, DeferredAllocAction<'static>), AllocationError> {
+
+    // The end page is an inclusive bound, hence the -1. Parentheses are needed to avoid overflow.
+    let requested_end_page = requested_page + (num_pages - 1); 
+
+    match &mut list.0 {
+        Inner::Array(ref mut arr) => {
+            for elem in arr.iter_mut() {
+                if let Some(chunk) = elem {
+                    if requested_page >= *chunk.start() && requested_end_page <= *chunk.end() {
+                        // Here: `chunk` was big enough and did contain the requested address.
+                        return adjust_chosen_chunk(requested_page, num_pages, &chunk.clone(), ValueRefMut::Array(elem));
+                    }
+                }
+            }
+        }
+        Inner::RBTree(ref mut tree) => {
+            let mut cursor_mut = tree.upper_bound_mut(Bound::Included(&requested_page));
+            if let Some(chunk) = cursor_mut.get().map(|w| w.deref()) {
+                if requested_page >= *chunk.start() {
+                    if requested_end_page <= *chunk.end() {
+                        return adjust_chosen_chunk(requested_page, num_pages, &chunk.clone(), ValueRefMut::RBTree(cursor_mut));
+                    } else {
+                        // Here, we've found a chunk that includes the requested start page, but it's too small
+                        // to cover the number of requested pages. 
+                        // Thus, we attempt to merge this chunk with the next contiguous chunk(s) to create one single larger chunk.
+                        let chunk = chunk.clone(); // ends the above borrow on `cursor_mut`
+                        let mut new_end_page = *chunk.end();
+                        cursor_mut.move_next();
+                        while let Some(next_chunk) = cursor_mut.get().map(|w| w.deref()) {
+                            if *next_chunk.start() - 1 == new_end_page {
+                                new_end_page = *next_chunk.end();
+                                cursor_mut.remove().expect("BUG: page_allocator failed to merge contiguous chunks.");
+                                // The above call to `cursor_mut.remove()` advances the cursor to the next chunk.
+                            } else {
+                                break; // the next chunk wasn't contiguous, so stop iterating.
+                            }
+                        }
+
+                        if new_end_page > *chunk.end() {
+                            cursor_mut.move_prev(); // move the cursor back to the original chunk
+                            let _removed_chunk = cursor_mut.replace_with(Wrapper::new_link(Chunk { pages: PageRange::new(*chunk.start(), new_end_page) }))
+                                .expect("BUG: page_allocator failed to replace the current chunk while merging contiguous chunks.");
+                            return adjust_chosen_chunk(requested_page, num_pages, &chunk, ValueRefMut::RBTree(cursor_mut));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Err(AllocationError::AddressNotFree(requested_page, num_pages))
+}
+
+
+/// Searches the given `list` for any chunk large enough to hold at least `num_pages`.
+///
+/// It first attempts to find a suitable chunk **not** in the designated regions,
+/// and only allocates from the designated regions as a backup option.
+fn find_any_chunk<'list>(
+    list: &'list mut StaticArrayRBTree<Chunk>,
+    num_pages: usize
+) -> Result<(AllocatedPages, DeferredAllocAction<'static>), AllocationError> {
+    let designated_low_end = DESIGNATED_PAGES_LOW_END.get().ok_or(AllocationError::NotInitialized)?;
+
+    // During the first pass, we ignore designated regions.
+    match list.0 {
+        Inner::Array(ref mut arr) => {
+            for elem in arr.iter_mut() {
+                if let Some(chunk) = elem {
+                    // Skip chunks that are too-small or in the designated regions.
+                    if  chunk.size_in_pages() < num_pages || 
+                        chunk.start() <= &designated_low_end || 
+                        chunk.end() >= &DESIGNATED_PAGES_HIGH_START
+                    {
+                        continue;
+                    } 
+                    else {
+                        return adjust_chosen_chunk(*chunk.start(), num_pages, &chunk.clone(), ValueRefMut::Array(elem));
+                    }
+                }
+            }
+        }
+        Inner::RBTree(ref mut tree) => {
+            // NOTE: if RBTree had a `range_mut()` method, we could simply do the following:
+            // ```
+            // let eligible_chunks = tree.range(
+            //  Bound::Excluded(&DESIGNATED_PAGES_LOW_END),
+            //  Bound::Excluded(&DESIGNATED_PAGES_HIGH_START)
+            // );
+            // for c in eligible_chunks { ... }
+            // ```
+            //
+            // However, RBTree doesn't have a `range_mut()` method, so we use cursors for manual iteration.
+            //
+            // Because we allocate new pages by peeling them off from the beginning part of a chunk, 
+            // it's MUCH faster to start the search for free pages from higher addresses moving down. 
+            // This results in an O(1) allocation time in the general case, until all address ranges are already in use.
+            let mut cursor = tree.upper_bound_mut(Bound::Excluded(&DESIGNATED_PAGES_HIGH_START));
+            while let Some(chunk) = cursor.get().map(|w| w.deref()) {
+                if chunk.start() <= &designated_low_end {
+                    break; // move on to searching through the designated regions
+                }
+                if num_pages < chunk.size_in_pages() {
+                    return adjust_chosen_chunk(*chunk.start(), num_pages, &chunk.clone(), ValueRefMut::RBTree(cursor));
+                }
+                warn!("Page allocator: unlikely scenario: had to search multiple chunks while trying to allocate {} pages at any address.", num_pages);
+                cursor.move_prev();
+            }
+        }
+    }
+
+    // If we can't find any suitable chunks in the non-designated regions, then look in both designated regions.
+    warn!("PageAllocator: unlikely scenario: non-designated chunks are all allocated, \
+          falling back to allocating {} pages from designated regions!", num_pages);
+    match list.0 {
+        Inner::Array(ref mut arr) => {
+            for elem in arr.iter_mut() {
+                if let Some(chunk) = elem {
+                    if num_pages <= chunk.size_in_pages() {
+                        return adjust_chosen_chunk(*chunk.start(), num_pages, &chunk.clone(), ValueRefMut::Array(elem));
+                    }
+                }
+            }
+        }
+        Inner::RBTree(ref mut tree) => {
+            // NOTE: if RBTree had a `range_mut()` method, we could simply do the following:
+            // ```
+            // let eligible_chunks = tree.range(
+            //  Bound::<&Page>::Unbounded,
+            //  Bound::Included(&DESIGNATED_PAGES_LOW_END)
+            // ).chain(tree.range(
+            //  Bound::Included(&DESIGNATED_PAGES_HIGH_START),
+            //  Bound::<&Page>::Unbounded
+            // ));
+            // for c in eligible_chunks { ... }
+            // ```
+            //
+            // However, RBTree doesn't have a `range_mut()` method, so we use two sets of cursors for manual iteration.
+            // The first cursor iterates over the lower designated region, from higher addresses to lower, down to zero.
+            let mut cursor = tree.upper_bound_mut(Bound::Included(designated_low_end));
+            while let Some(chunk) = cursor.get().map(|w| w.deref()) {
+                if num_pages < chunk.size_in_pages() {
+                    return adjust_chosen_chunk(*chunk.start(), num_pages, &chunk.clone(), ValueRefMut::RBTree(cursor));
+                }
+                cursor.move_prev();
+            }
+
+            // The second cursor iterates over the higher designated region, from the highest (max) address down to the designated region boundary.
+            let mut cursor = tree.upper_bound_mut::<Chunk>(Bound::Unbounded);
+            while let Some(chunk) = cursor.get().map(|w| w.deref()) {
+                if chunk.start() < &DESIGNATED_PAGES_HIGH_START {
+                    // we already iterated over non-designated pages in the first match statement above, so we're out of memory. 
+                    break; 
+                }
+                if num_pages < chunk.size_in_pages() {
+                    return adjust_chosen_chunk(*chunk.start(), num_pages, &chunk.clone(), ValueRefMut::RBTree(cursor));
+                }
+                cursor.move_prev();
+            }
+        }
+    }
+
+    Err(AllocationError::OutOfAddressSpace(num_pages))
+}
+
+
+/// The final part of the main allocation routine. 
+///
+/// The given chunk is the one we've chosen to allocate from. 
+/// This function breaks up that chunk into multiple ones and returns an `AllocatedPages` 
+/// from (part of) that chunk, ranging from `start_page` to `start_page + num_pages`.
+fn adjust_chosen_chunk(
+    start_page: Page,
+    num_pages: usize,
+    chosen_chunk: &Chunk,
+    mut chosen_chunk_ref: ValueRefMut<Chunk>,
+) -> Result<(AllocatedPages, DeferredAllocAction<'static>), AllocationError> {
+
+    // The new allocated chunk might start in the middle of an existing chunk,
+    // so we need to break up that existing chunk into 3 possible chunks: before, newly-allocated, and after.
+    //
+    // Because Pages and VirtualAddresses use saturating add and subtract, we need to double-check that we're not creating
+    // an overlapping duplicate Chunk at either the very minimum or the very maximum of the address space.
+    let new_allocation = Chunk {
+        // The end page is an inclusive bound, hence the -1. Parentheses are needed to avoid overflow.
+        pages: PageRange::new(start_page, start_page + (num_pages - 1)),
+    };
+    let before = if start_page == MIN_PAGE {
+        None
+    } else {
+        Some(Chunk {
+            pages: PageRange::new(*chosen_chunk.start(), *new_allocation.start() - 1),
+        })
+    };
+    let after = if new_allocation.end() == &MAX_PAGE { 
+        None
+    } else {
+        Some(Chunk {
+            pages: PageRange::new(*new_allocation.end() + 1, *chosen_chunk.end()),
+        })
+    };
+
+    // some sanity checks -- these can be removed or disabled for better performance
+    if let Some(ref b) = before {
+        assert!(!new_allocation.contains(b.end()));
+        assert!(!b.contains(new_allocation.start()));
+    }
+    if let Some(ref a) = after {
+        assert!(!new_allocation.contains(a.start()));
+        assert!(!a.contains(new_allocation.end()));
+    }
+
+    // Remove the chosen chunk from the free page list.
+    let _removed_chunk = chosen_chunk_ref.remove();
+    assert_eq!(Some(chosen_chunk), _removed_chunk.as_ref()); // sanity check
+
+    // TODO: Re-use the allocated wrapper if possible, rather than allocate a new one entirely.
+    // if let RemovedValue::RBTree(Some(wrapper_adapter)) = _removed_chunk { ... }
+
+    Ok((
+        new_allocation.as_allocated_pages(),
+        DeferredAllocAction::new(before, after),
+    ))
+}
+
+
+/// The core page allocation routine that allocates the given number of virtual pages,
+/// optionally at the requested starting `VirtualAddress`.
+/// 
+/// This simply reserves a range of virtual addresses, it does not allocate 
+/// actual physical memory frames nor do any memory mapping. 
+/// Thus, the returned `AllocatedPages` aren't directly usable until they are mapped to physical frames. 
+/// 
+/// Allocation is based on a red-black tree and is thus `O(log(n))`.
+/// Fragmentation isn't cleaned up until we're out of address space, but that's not really a big deal.
+/// 
+/// # Arguments
+/// * `requested_vaddr`: if `Some`, the returned `AllocatedPages` will start at the `Page`
+///   containing this `VirtualAddress`. 
+///   If `None`, the first available `Page` range will be used, starting at any random virtual address.
+/// * `num_pages`: the number of `Page`s to be allocated. 
+/// 
+/// # Return
+/// If successful, returns a tuple of two items:
+/// * the pages that were allocated, and
+/// * an opaque struct representing details of bookkeeping-related actions that may cause heap allocation. 
+///   Those actions are deferred until this returned `DeferredAllocAction` struct object is dropped, 
+///   allowing the caller (such as the heap implementation itself) to control when heap allocation may occur.
+pub fn allocate_pages_deferred(
+    requested_vaddr: Option<VirtualAddress>,
+    num_pages: usize,
+) -> Result<(AllocatedPages, DeferredAllocAction<'static>), &'static str> {
+    if num_pages == 0 {
+        warn!("PageAllocator: requested an allocation of 0 pages... stupid!");
+        return Err("cannot allocate zero pages");
+    }
+
+    let mut locked_list = FREE_PAGE_LIST.lock();
+
+    // The main logic of the allocator is to find an appropriate chunk that can satisfy the allocation request.
+    // An appropriate chunk satisfies the following conditions:
+    // - Can fit the requested size (starting at the requested address) within the chunk.
+    // - The chunk can only be within in a designated region if a specific address was requested, 
+    //   or all other non-designated chunks are already in use.
+    if let Some(vaddr) = requested_vaddr {
+        find_specific_chunk(&mut locked_list, Page::containing_address(vaddr), num_pages)
+    } else {
+        find_any_chunk(&mut locked_list, num_pages)
+    }.map_err(From::from) // convert from AllocationError to &str
+}
+
+
+/// Similar to [`allocated_pages_deferred()`](fn.allocate_pages_deferred.html),
+/// but accepts a size value for the allocated pages in number of bytes instead of number of pages. 
+/// 
+/// This function still allocates whole pages by rounding up the number of bytes. 
+pub fn allocate_pages_by_bytes_deferred(
+    requested_vaddr: Option<VirtualAddress>,
+    num_bytes: usize,
+) -> Result<(AllocatedPages, DeferredAllocAction<'static>), &'static str> {
+    let actual_num_bytes = if let Some(vaddr) = requested_vaddr {
+        num_bytes + (vaddr.value() % PAGE_SIZE)
+    } else {
+        num_bytes
+    };
+    let num_pages = (actual_num_bytes + PAGE_SIZE - 1) / PAGE_SIZE; // round up
+    allocate_pages_deferred(requested_vaddr, num_pages)
+}
+
+
+/// Allocates the given number of pages with no constraints on the starting virtual address.
+/// 
+/// See [`allocate_pages_deferred()`](fn.allocate_pages_deferred.html) for more details. 
+pub fn allocate_pages(num_pages: usize) -> Option<AllocatedPages> {
+    allocate_pages_deferred(None, num_pages)
+        .map(|(ap, _action)| ap)
+        .ok()
+}
+
+
+/// Allocates pages with no constraints on the starting virtual address, 
+/// with a size given by the number of bytes. 
+/// 
+/// This function still allocates whole pages by rounding up the number of bytes. 
+/// See [`allocate_pages_deferred()`](fn.allocate_pages_deferred.html) for more details. 
+pub fn allocate_pages_by_bytes(num_bytes: usize) -> Option<AllocatedPages> {
+    allocate_pages_by_bytes_deferred(None, num_bytes)
+        .map(|(ap, _action)| ap)
+        .ok()
+}
+
+
+/// Allocates pages starting at the given `VirtualAddress` with a size given in number of bytes. 
+/// 
+/// This function still allocates whole pages by rounding up the number of bytes. 
+/// See [`allocate_pages_deferred()`](fn.allocate_pages_deferred.html) for more details. 
+pub fn allocate_pages_by_bytes_at(vaddr: VirtualAddress, num_bytes: usize) -> Result<AllocatedPages, &'static str> {
+    allocate_pages_by_bytes_deferred(Some(vaddr), num_bytes)
+        .map(|(ap, _action)| ap)
+}
+
+
+/// Allocates the given number of pages starting at (inclusive of) the page containing the given `VirtualAddress`.
+/// 
+/// See [`allocate_pages_deferred()`](fn.allocate_pages_deferred.html) for more details. 
+pub fn allocate_pages_at(vaddr: VirtualAddress, num_pages: usize) -> Result<AllocatedPages, &'static str> {
+    allocate_pages_deferred(Some(vaddr), num_pages)
+        .map(|(ap, _action)| ap)
+}
+
+
+/// Converts the page allocator from using static memory (a primitive array) to dynamically-allocated memory.
+/// 
+/// Call this function once heap allocation is available. 
+/// Calling this multiple times is unnecessary but harmless, as it will do nothing after the first invocation.
+#[doc(hidden)] 
+pub fn convert_to_heap_allocated() {
+    FREE_PAGE_LIST.lock().convert_to_heap_allocated();
+}
+
+/// A debugging function used to dump the full internal state of the page allocator. 
+#[doc(hidden)] 
+pub fn dump_page_allocator_state() {
+    debug!("--------------- FREE PAGES LIST ---------------");
+    for c in FREE_PAGE_LIST.lock().iter() {
+        debug!("{:X?}", c);
+    }
+    debug!("---------------------------------------------------");
+}

--- a/aarch64/kernel/paging_entry_flags/Cargo.toml
+++ b/aarch64/kernel/paging_entry_flags/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "paging_entry_flags"
+authors = ["Nathan Royer <nathan.royer.pro@gmail.com>"]
+description = "The flags for page table slots."
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "lib.rs"

--- a/aarch64/kernel/paging_entry_flags/Cargo.toml
+++ b/aarch64/kernel/paging_entry_flags/Cargo.toml
@@ -5,5 +5,8 @@ description = "The flags for page table slots."
 version = "0.1.0"
 edition = "2021"
 
+[dependencies]
+bitflags = "1.3.2"
+
 [lib]
 path = "lib.rs"

--- a/aarch64/kernel/paging_entry_flags/lib.rs
+++ b/aarch64/kernel/paging_entry_flags/lib.rs
@@ -1,0 +1,172 @@
+#![no_std]
+
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PagingEntryFlags(u64);
+
+impl PagingEntryFlags {
+    pub fn new(
+        valid_entry: bool,
+        writeable: bool,
+        executable: bool,
+        cacheable: bool,
+        global: bool,
+        userland: bool,
+        exclusive: bool,
+    ) -> Self {
+        let mut flags = 0;
+
+        flags |= match valid_entry {
+            true  => arch::USED_ENTRY,
+            false => arch::UNUSED_ENTRY,
+        };
+
+        flags |= match writeable {
+            true  => arch::WRITEABLE,
+            false => arch::NON_WRITEABLE,
+        };
+
+        flags |= match executable {
+            true  => arch::EXECUTABLE,
+            false => arch::NON_EXECUTABLE,
+        };
+
+        flags |= match cacheable {
+            true  => arch::CACHEABLE,
+            false => arch::NON_CACHEABLE,
+        };
+
+        flags |= match global {
+            true  => arch::GLOBAL,
+            false => arch::NON_GLOBAL,
+        };
+
+        flags |= match userland {
+            true  => arch::USERLAND_ACCESSIBLE,
+            false => arch::USERLAND_INACCESSIBLE,
+        };
+
+        flags |= match exclusive {
+            true  => EXCLUSIVE,
+            false => NON_EXCLUSIVE,
+        };
+
+        Self(flags)
+    }
+
+    fn clear_and_set(self, pair: (u64, u64)) -> Self {
+        let (to_clear, to_set) = pair;
+        Self((self.0 & !to_clear) | to_set)
+    }
+
+    pub fn valid(self, valid: bool) -> Self {
+        self.clear_and_set(match valid {
+            true  => (arch::UNUSED_ENTRY, arch::USED_ENTRY),
+            false => (arch::USED_ENTRY, arch::UNUSED_ENTRY),
+        })
+    }
+
+    pub fn writeable(self, writeable: bool) -> Self {
+        self.clear_and_set(match writeable {
+            true  => (arch::NON_WRITEABLE, arch::WRITEABLE),
+            false => (arch::WRITEABLE, arch::NON_WRITEABLE),
+        })
+    }
+
+    pub fn executable(self, executable: bool) -> Self {
+        self.clear_and_set(match executable {
+            true  => (arch::NON_EXECUTABLE, arch::EXECUTABLE),
+            false => (arch::EXECUTABLE, arch::NON_EXECUTABLE),
+        })
+    }
+
+    pub fn cacheable(self, cacheable: bool) -> Self {
+        self.clear_and_set(match cacheable {
+            true  => (arch::NON_CACHEABLE, arch::CACHEABLE),
+            false => (arch::CACHEABLE, arch::NON_CACHEABLE),
+        })
+    }
+
+    pub fn global(self, global: bool) -> Self {
+        self.clear_and_set(match global {
+            true  => (arch::NON_GLOBAL, arch::GLOBAL),
+            false => (arch::GLOBAL, arch::NON_GLOBAL),
+        })
+    }
+
+    pub fn userland(self, userland: bool) -> Self {
+        self.clear_and_set(match userland {
+            true  => (arch::USERLAND_INACCESSIBLE, arch::USERLAND_ACCESSIBLE),
+            false => (arch::USERLAND_ACCESSIBLE, arch::USERLAND_INACCESSIBLE),
+        })
+    }
+
+    pub fn exclusive(self, exclusive: bool) -> Self {
+        self.clear_and_set(match exclusive {
+            true  => (NON_EXCLUSIVE, EXCLUSIVE),
+            false => (EXCLUSIVE, NON_EXCLUSIVE),
+        })
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+mod arch {
+    // with the mandatory NOT_A_BLOCK flag
+    pub const            USED_ENTRY: u64 = 0b11 <<  0;
+    pub const          UNUSED_ENTRY: u64 = 0b10 <<  0;
+
+    pub const             WRITEABLE: u64 =  0b0 <<  7;
+    pub const         NON_WRITEABLE: u64 =  0b1 <<  7;
+
+    // only one bit is used when the cpu supports
+    // one privilege level; when two are supported,
+    // we disable execution for both
+    pub const            EXECUTABLE: u64 = 0b00 << 53;
+    pub const        NON_EXECUTABLE: u64 = 0b11 << 53;
+
+    // this assumes the MAIR register has a first
+    // entry for non cacheable/device memory and
+    // a second entry for cacheable memory;
+    // additionally, it sets the entry as describing
+    // a page that has inner shareability.
+    //
+    //                                 shareable   MAIR index
+    pub const             CACHEABLE: u64 = 0b11 << 8 | 0b1 << 2;
+    pub const         NON_CACHEABLE: u64 = 0b00 << 8 | 0b0 << 2;
+
+    pub const                GLOBAL: u64 =  0b0 << 11;
+    pub const            NON_GLOBAL: u64 =  0b1 << 11;
+
+    pub const   USERLAND_ACCESSIBLE: u64 =  0b1 << 6;
+    pub const USERLAND_INACCESSIBLE: u64 =  0b0 << 6;
+
+    pub const        SOFTWARE_1_SET: u64 =  0b1 << 55;
+    pub const      SOFTWARE_1_CLEAR: u64 =  0b0 << 55;
+}
+
+#[cfg(target_arch = "x86_64")]
+mod arch {
+    pub const            USED_ENTRY: u64 =  0b1 <<  0;
+    pub const          UNUSED_ENTRY: u64 =  0b0 <<  0;
+
+    pub const             WRITEABLE: u64 =  0b1 <<  1;
+    pub const         NON_WRITEABLE: u64 =  0b0 <<  1;
+
+    pub const            EXECUTABLE: u64 =  0b0 << 63;
+    pub const        NON_EXECUTABLE: u64 =  0b1 << 63;
+
+    pub const             CACHEABLE: u64 =  0b0 << 4;
+    pub const         NON_CACHEABLE: u64 =  0b1 << 4;
+
+    pub const                GLOBAL: u64 =  0b1 << 8;
+    pub const            NON_GLOBAL: u64 =  0b0 << 8;
+
+    pub const   USERLAND_ACCESSIBLE: u64 =  0b1 << 2;
+    pub const USERLAND_INACCESSIBLE: u64 =  0b0 << 2;
+
+    pub const        SOFTWARE_1_SET: u64 =  0b1 << 9;
+    pub const      SOFTWARE_1_CLEAR: u64 =  0b0 << 9;
+}
+
+pub const     EXCLUSIVE: u64 = arch::SOFTWARE_1_SET;
+pub const NON_EXCLUSIVE: u64 = arch::SOFTWARE_1_CLEAR;

--- a/aarch64/kernel/static_array_collections/Cargo.toml
+++ b/aarch64/kernel/static_array_collections/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "static_array_collections"
+description = "Static-Array Linked List & RB Tree"
+version = "0.1.0"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+intrusive-collections = "0.9.0"
+log = "0.4.8"

--- a/aarch64/kernel/static_array_collections/lib.rs
+++ b/aarch64/kernel/static_array_collections/lib.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+#[macro_use] extern crate log;
+extern crate alloc;
+pub extern crate intrusive_collections;
+
+pub mod static_array_rb_tree;
+pub mod static_array_linked_list;

--- a/aarch64/kernel/static_array_collections/static_array_linked_list.rs
+++ b/aarch64/kernel/static_array_collections/static_array_linked_list.rs
@@ -1,0 +1,99 @@
+use alloc::collections::LinkedList;
+
+/// A convenience wrapper that abstracts either a `LinkedList<T>` or a primitive array `[T; N]`.
+/// 
+/// This allows the caller to create an array statically in a const context, 
+/// and then abstract over both that and the inner `LinkedList` when using it. 
+/// 
+/// TODO: use const generics to allow this to be of any arbitrary size beyond 32 elements.
+pub enum StaticArrayLinkedList<T> {
+	Array([Option<T>; 32]),
+	LinkedList(LinkedList<T>),
+}
+impl<T> StaticArrayLinkedList<T> {
+	/// Push the given `value` onto the end of this collection.
+	pub fn push_back(&mut self, value: T) -> Result<(), T> {
+		match self {
+			StaticArrayLinkedList::Array(arr) => {
+				for elem in arr {
+					if elem.is_none() {
+						*elem = Some(value);
+						return Ok(());
+					}
+				}
+				error!("Out of space in array, failed to insert value.");
+				Err(value)
+			}
+			StaticArrayLinkedList::LinkedList(ll) => {
+				ll.push_back(value);
+				Ok(())
+			}
+		}
+	}
+
+	/// Push the given `value` onto the front end of this collection.
+	/// If the inner collection is an array, then this is an expensive operation
+	/// with linear time complexity (on the size of the array) 
+	/// because it requires all successive elements to be right-shifted. 
+	pub fn push_front(&mut self, value: T) -> Result<(), T> {
+		match self {
+			StaticArrayLinkedList::Array(arr) => {
+				// The array must have space for at least one element at the end.
+				if let Some(None) = arr.last() {
+					arr.rotate_right(1);
+					arr[0].replace(value);
+					Ok(())
+				} else {
+					error!("Out of space in array, failed to insert value.");
+					Err(value)
+				}
+			}
+			StaticArrayLinkedList::LinkedList(ll) => {
+				ll.push_front(value);
+				Ok(())
+			}
+		}
+	}
+
+	/// Converts the contained collection from a primitive array into a LinkedList.
+	/// If the contained collection is already using heap allocation, this is a no-op.
+	/// 
+	/// Call this function once heap allocation is available. 
+	pub fn convert_to_heap_allocated(&mut self) {
+		let new_ll = match self {
+			StaticArrayLinkedList::Array(arr) => {
+				let mut ll = LinkedList::<T>::new();
+				for elem in arr {
+					if let Some(e) = elem.take() {
+						ll.push_back(e);
+					}
+				}
+				ll
+			}
+			StaticArrayLinkedList::LinkedList(_ll) => return,
+		};
+		*self = StaticArrayLinkedList::LinkedList(new_ll);
+	}
+
+	/// Returns a forward iterator over references to items in this collection.
+	pub fn iter(&self) -> impl Iterator<Item = &T> {
+		let mut iter_a = None;
+		let mut iter_b = None;
+		match self {
+			StaticArrayLinkedList::Array(arr)     => iter_a = Some(arr.iter().flatten()),
+			StaticArrayLinkedList::LinkedList(ll) => iter_b = Some(ll.iter()),
+		}
+		iter_a.into_iter().flatten().chain(iter_b.into_iter().flatten())
+	}
+
+	/// Returns a forward iterator over mutable references to items in this collection.
+	pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+		let mut iter_a = None;
+		let mut iter_b = None;
+		match self {
+			StaticArrayLinkedList::Array(arr)     => iter_a = Some(arr.iter_mut().flatten()),
+			StaticArrayLinkedList::LinkedList(ll) => iter_b = Some(ll.iter_mut()),
+		}
+		iter_a.into_iter().flatten().chain(iter_b.into_iter().flatten())
+	}
+}

--- a/aarch64/kernel/static_array_collections/static_array_rb_tree.rs
+++ b/aarch64/kernel/static_array_collections/static_array_rb_tree.rs
@@ -1,0 +1,232 @@
+use alloc::boxed::Box;
+use core::ops::{Deref, DerefMut};
+use intrusive_collections::{
+    intrusive_adapter,
+    rbtree::{RBTree, CursorMut},
+    RBTreeLink,
+	KeyAdapter,
+};
+
+/// A wrapper for the type stored in the `StaticArrayRBTree::Inner::RBTree` variant.
+#[derive(Debug)]
+pub struct Wrapper<T: Ord> {
+    link: RBTreeLink,
+    inner: T,
+}
+intrusive_adapter!(pub WrapperAdapter<T> = Box<Wrapper<T>>: Wrapper<T> { link: RBTreeLink } where T: Ord);
+
+// Use the inner type `T` (which must implement `Ord`) to define the key
+// for properly ordering the elements in the RBTree.
+impl<'a, T: Ord + 'a> KeyAdapter<'a> for WrapperAdapter<T> {
+    type Key = &'a T;
+    fn get_key(&self, value: &'a Wrapper<T>) -> Self::Key {
+        &value.inner
+    }
+}
+impl <T: Ord> Deref for Wrapper<T> {
+	type Target = T;
+	fn deref(&self) -> &T {
+		&self.inner
+	}
+}
+impl <T: Ord> DerefMut for Wrapper<T> {
+	fn deref_mut(&mut self) -> &mut T {
+		&mut self.inner
+	}
+}
+impl <T: Ord> Wrapper<T> {
+    /// Convenience method for creating a new link
+    pub(crate) fn new_link(value: T) -> Box<Self> {
+        Box::new(Wrapper {
+            link: RBTreeLink::new(),
+            inner: value,
+        })
+    }
+}
+
+
+/// A convenience wrapper that abstracts either an intrustive `RBTree<T>` or a primitive array `[T; N]`.
+/// 
+/// This allows the caller to create an array statically in a const context, 
+/// and then abstract over both that and the inner `RBTree` when using it. 
+/// 
+/// TODO: use const generics to allow this to be of any arbitrary size beyond 32 elements.
+pub struct StaticArrayRBTree<T: Ord>(pub Inner<T>);
+
+/// The inner enum
+pub enum Inner<T: Ord> {
+	Array([Option<T>; 32]),
+	RBTree(RBTree<WrapperAdapter<T>>),
+}
+
+impl<T: Ord> Default for StaticArrayRBTree<T> {
+	fn default() -> Self {
+		Self::empty()
+	}
+}
+impl<T: Ord> StaticArrayRBTree<T> {
+	/// Create a new empty collection (the default).
+	pub const fn empty() -> Self {
+		// Yes, this is stupid... Rust seems to have removed the [None; 32] array init syntax.
+		StaticArrayRBTree(Inner::Array([
+			None, None, None, None, None, None, None, None,
+			None, None, None, None, None, None, None, None,
+			None, None, None, None, None, None, None, None,
+			None, None, None, None, None, None, None, None,
+		]))
+	}
+
+	/// Create a new collection based on the given array of values.
+	#[allow(dead_code)]
+	pub const fn new(arr: [Option<T>; 32]) -> Self {
+		StaticArrayRBTree(Inner::Array(arr))
+	}
+}
+
+
+impl<T: Ord + 'static> StaticArrayRBTree<T> {
+    /// Push the given `value` into this collection.
+    ///
+    /// If the inner collection is an array, it is pushed onto the back of the array.
+	/// If there is no space left in the array, an `Err` containing the given `value` is returned.
+	///
+	/// If success
+	pub fn insert(&mut self, value: T) -> Result<ValueRefMut<T>, T> {
+		match &mut self.0 {
+			Inner::Array(arr) => {
+				for elem in arr {
+					if elem.is_none() {
+						*elem = Some(value);
+						return Ok(ValueRefMut::Array(elem));
+					}
+				}
+				error!("Out of space in StaticArrayRBTree's inner array, failed to insert value.");
+				Err(value)
+			}
+			Inner::RBTree(tree) => {
+                Ok(ValueRefMut::RBTree(
+					tree.insert(Wrapper::new_link(value))
+				))
+			}
+		}
+	}
+
+	/// Converts the contained collection from a primitive array into a RBTree.
+	/// If the contained collection is already using heap allocation, this is a no-op.
+	/// 
+	/// Call this function once heap allocation is available. 
+	pub fn convert_to_heap_allocated(&mut self) {
+		let new_tree = match &mut self.0 {
+			Inner::Array(arr) => {
+				let mut tree = RBTree::new(WrapperAdapter::new());
+				for elem in arr {
+					if let Some(e) = elem.take() {
+						tree.insert(Wrapper::new_link(e));
+					}
+				}
+				tree
+			}
+			Inner::RBTree(_tree) => return,
+		};
+		*self = StaticArrayRBTree(Inner::RBTree(new_tree));
+	}
+
+	/// Returns the number of elements in this collection. 
+	///
+	/// Note that this an O(N) linear-time operation, not an O(1) constant-time operation. 
+	/// This is because the internal collection types do not separately maintain their current length.
+	pub fn len(&self) -> usize {
+		match &self.0 {
+			Inner::Array(arr) => arr.iter().filter(|e| e.is_some()).count(),
+			Inner::RBTree(tree) => tree.iter().count(),
+		}
+	}
+
+	/// Returns a forward iterator over immutable references to items in this collection.
+	pub fn iter(&self) -> impl Iterator<Item = &T> {
+		let mut iter_a = None;
+		let mut iter_b = None;
+		match &self.0 {
+			Inner::Array(arr)     => iter_a = Some(arr.iter().flatten()),
+			Inner::RBTree(tree) => iter_b = Some(tree.iter()),
+		}
+        iter_a.into_iter()
+            .flatten()
+            .chain(
+                iter_b.into_iter()
+                    .flatten()
+                    .map(|wrapper| &wrapper.inner)
+			)
+	}
+
+	// /// Returns a forward iterator over mutable references to items in this collection.
+	// pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+	// 	let mut iter_a = None;
+	// 	let mut iter_b = None;
+	// 	match self {
+	// 		StaticArrayRBTree::Array(arr)     => iter_a = Some(arr.iter_mut().flatten()),
+	// 		StaticArrayRBTree::RBTree(ll) => iter_b = Some(ll.iter_mut()),
+	// 	}
+	// 	iter_a.into_iter().flatten().chain(iter_b.into_iter().flatten())
+	// }
+}
+
+
+pub enum RemovedValue<T: Ord> {
+	Array(Option<T>),
+	RBTree(Option<Box<Wrapper<T>>>),
+}
+impl<T: Ord> RemovedValue<T> {
+	#[allow(dead_code)]
+	pub fn as_ref(&self) -> Option<&T> {
+		match self {
+			Self::Array(opt) => opt.as_ref(),
+			Self::RBTree(opt) => opt.as_ref().map(|bw| &bw.inner),
+		}
+	}
+}
+
+/// A mutable reference to a value in the `StaticArrayRBTree`. 
+pub enum ValueRefMut<'list, T: Ord> {
+	Array(&'list mut Option<T>),
+	RBTree(CursorMut<'list, WrapperAdapter<T>>),
+}
+impl <'list, T: Ord> ValueRefMut<'list, T> {
+	/// Removes this value from the collection and returns the removed value, if one existed. 
+	pub fn remove(&mut self) -> RemovedValue<T> {
+		match self {
+			Self::Array(ref mut arr_ref) => {
+				RemovedValue::Array(arr_ref.take())
+			}
+			Self::RBTree(ref mut cursor_mut) => {
+				RemovedValue::RBTree(cursor_mut.remove())
+			}
+		}
+	}
+
+
+	/// Removes this value from the collection and replaces it with the given `new_value`. 
+	///
+	/// Returns the removed value, if one existed. If not, the 
+	#[allow(dead_code)]
+	pub fn replace_with(&mut self, new_value: T) -> Result<Option<T>, T> {
+		match self {
+			Self::Array(ref mut arr_ref) => {
+				Ok(arr_ref.replace(new_value))
+			}
+			Self::RBTree(ref mut cursor_mut) => {
+				cursor_mut.replace_with(Wrapper::new_link(new_value))
+					.map(|removed| Some(removed.inner))
+					.map_err(|e| e.inner)
+			}
+		}
+	}
+
+	#[allow(dead_code)]
+	pub fn get(&self) -> Option<&T> {
+		match self {
+			Self::Array(ref arr_ref) => arr_ref.as_ref(),
+			Self::RBTree(ref cursor_mut) => cursor_mut.get().map(|w| w.deref()),
+		}
+	}
+}

--- a/aarch64/kernel/static_array_collections/static_array_rb_tree.rs
+++ b/aarch64/kernel/static_array_collections/static_array_rb_tree.rs
@@ -36,7 +36,7 @@ impl <T: Ord> DerefMut for Wrapper<T> {
 }
 impl <T: Ord> Wrapper<T> {
     /// Convenience method for creating a new link
-    pub(crate) fn new_link(value: T) -> Box<Self> {
+    pub fn new_link(value: T) -> Box<Self> {
         Box::new(Wrapper {
             link: RBTreeLink::new(),
             inner: value,

--- a/aarch64/resources/qemu-instructions.txt
+++ b/aarch64/resources/qemu-instructions.txt
@@ -1,0 +1,17 @@
+
+
+
+
+########################################
+#    RUNNING THE EFI IMAGE IN QEMU     #
+########################################
+
+1. Open the "View" menu
+2. Click "Serial" to see the serial output
+3. spam [enter] a few times until you see a prompt
+4. write "fs0:\efi"
+5. You should see the "Hello world" message
+
+
+
+

--- a/aarch64/resources/qemu-instructions.txt
+++ b/aarch64/resources/qemu-instructions.txt
@@ -10,7 +10,7 @@
 2. Click "Serial" to see the serial output
 3. spam [enter] a few times until you see a prompt
 4. write "fs0:\efi"
-5. You should see the "Hello world" message
+5. You should see the "Hello world" line among the other ones
 
 
 


### PR DESCRIPTION
This PR builds on #693 and adds the `paging_entry_flags` kernel crate in aarch64.

This crate supports both `aarch64` and `x86_64`; The following flags are implemented:

- valid entry
- writeable
- executable
- cacheable
- global
- userland
- exclusive

I was also wondering if "paging_slot_flags" wouldn't be a better name, as a slot can be empty; I'm not a native english speaker so I don't really know what's best.

I could also document each flag in the crate's documentation, what do you think?