### PR TITLE
Move most codegen RUSTFLAGS to target specs

### DIFF
--- a/cfg/Config.mk
+++ b/cfg/Config.mk
@@ -61,34 +61,20 @@ BUILD_STD_CARGOFLAGS += -Z build-std-features=compiler-builtins-mem
 export override RUSTFLAGS += --emit=obj
 ## enable debug info even for release builds
 export override RUSTFLAGS += -C debuginfo=2
-## using a large code model 
-export override RUSTFLAGS += -C code-model=large
-## use static relocation model to avoid GOT-based relocation types and .got/.got.plt sections
-export override RUSTFLAGS += -C relocation-model=static
 ## promote unused must-use types (like Result) to an error
 export override RUSTFLAGS += -D unused-must-use
-
-## As of Dec 31, 2018, this is needed to make loadable mode work, because otherwise, 
-## some core generic function implementations won't exist in the object files.
-## Details here: https://github.com/rust-lang/rust/pull/57268
-## Relevant rusct commit: https://github.com/jethrogb/rust/commit/71990226564e9fe327bc9ea969f9d25e8c6b58ed#diff-8ad3595966bf31a87e30e1c585628363R8
-## Either "trampolines" or "disabled" works here, not sure how they're different
-export override RUSTFLAGS += -Z merge-functions=disabled
-# export override RUSTFLAGS += -Z merge-functions=trampolines
 
 ## This prevents monomorphized instances of generic functions from being shared across crates.
 ## It vastly simplifies the procedure of finding missing symbols in the crate loader,
 ## because we know that instances of generic functions will not be found in another crate
 ## besides the current crate or the crate that defines the function.
 ## As far as I can tell, this does not have a significant impact on object code size or performance.
+## More info: <https://internals.rust-lang.org/t/explicit-monomorphization-for-compilation-time-reduction/15907/7>
+##
+## Update: this might work now, see <https://github.com/rust-lang/rust/issues/96486#issuecomment-1180395751>.
+## Thus, we should experiment with removing this to see if it offers any code size reduction benefits
+## without breaking our loader/linker assumptions.
 export override RUSTFLAGS += -Z share-generics=no
-
-## This forces all code to use the simplest (and most efficient) model
-## for Thread-Local Storage (TLS): the "Local Exec" model.
-## We don't currently support the three other forms, as some of them
-## (e.g., "Initial Exec") require support for a Global Offset Table (GOT).
-## If we support GOT in the future, we can remove this.
-export override RUSTFLAGS += -Z tls-model=local-exec
 
 ## This forces frame pointers to be generated, i.e., the stack base pointer (RBP register on x86_64)
 ## will be used to store the starting address of the current stack frame.

--- a/cfg/README.md
+++ b/cfg/README.md
@@ -1,0 +1,58 @@
+## Theseus OS target specifications
+
+Theseus OS uses its own target specification to configure how `rustc` compiles its code.
+The default target spec is [x86_64-theseus.json], which builds Theseus for the `x86_64` architecture.
+
+We describe the key items in the target spec below; you can read more about the various options
+in [`rustc`'s `TargetSpec` type documentation](https://docs.rs/rustc-ap-rustc_target/196.0.0/rustc_target/spec/struct.TargetOptions.html).
+
+* `features`: `-mmx,-sse,+soft-float`.
+  This builds Theseus with hardware floating point support disabled in favor of soft floating point.
+  This is the typical choice for most OS kernels, since using hardware floating point and/or SIMD
+  instructions causes more overhead during a context switch, as all of the actively-used SIMD
+  registers must also be saved to and restored from the stack.
+
+* [`code-model`]: we use the `large` code model because Theseus runs in a single address space,
+  meaning that code may exist at addresses across the entire 48-bit address space.
+  Thus, an instruction that jumps to or references another address must be able to
+  access addresses anywhere in the address space.
+
+* [`relocation-model`]: we use the `static` relocation model to keep the logic of our
+  runtime loader and linker as simple as possible.
+   * This relocation model avoids GOT- and PLT-based relocation entries in favor of
+     direct relocation models based on absolute addresses.
+   * In the future, we may support other relocation models, but for now this is required.
+
+* [`tls-model`]: we use the `local-exec` model for Thread-Local Storage (TLS) because
+  it is the simplest and most efficient model.
+  Also, Theseus's runtime loader/linker can even support the `local-exec` TLS model
+  in crate object files that are dynamically loaded during runtime, even if they weren't
+  included in the initial build-time list of TLS sections that exist in the
+  statically-linked base kernel image.
+  * Currently, Theseus doesn't support the other three TLS models, as some of them
+    (e.g., `initial-exec`) require support for a Global Offset Table (GOT).
+
+* [`merge-functions`]: we disable this option in order to ensure that `loadable` mode
+  works correctly, in which Theseus loads and links all crate object files at runtime.
+  Without this, some functions may be merged together, preventing our loader/linker from
+  finding generic function implementations in the expected emitted object files.
+  See [PR #57268](https://github.com/rust-lang/rust/pull/57268) and
+  [Issue #57356](https://github.com/rust-lang/rust/issues/57356) for more details.
+  * It appears that Theseus still works correctly without setting this option,
+    so we may not need it, but it doesn't hurt to explicitly disable it.
+
+### Other target specs
+* [x86_64-theseus-sse.json]: similar to the default `x86_64-theseus`, but enables the compiler to
+  generate instructions that use SSE2 (and higher SSE versions) SIMD features.
+  With this, all crates across Theseus can use SSE2 SIMD instructions and registers.
+* [x86_64-theseus-avx.json]: similar to above, but enables AVX (version 1) instructions/registers.
+  With this, all crates across Theseus can use AVX SIMD instructions and registers.
+  This does not yet enable support for AVX2 or AVX512.
+
+
+[x86_64-theseus.json]: ./x86_64-theseus.json
+[x86_64-theseus-sse.json]: ./x86_64-theseus-sse.json
+[x86_64-theseus-avx.json]: ./x86_64-theseus-avx.json
+[`code-model`]: https://doc.rust-lang.org/rustc/codegen-options/index.html#code-model
+[`relocation-model`]: https://doc.rust-lang.org/rustc/codegen-options/index.html#relocation-model
+[`tls-model`]: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/tls-model.html#tls_model

--- a/cfg/x86_64-theseus-avx.json
+++ b/cfg/x86_64-theseus-avx.json
@@ -8,5 +8,10 @@
   "arch": "x86_64",
   "os": "theseus",
   "features": "+avx",
+  "code-model": "large",
+  "relocation-model": "static",
+  "tls-model": "local-exec",
+  "has-thread-local": true,
+  "merge-functions": "disabled",
   "disable-redzone": true
 }

--- a/cfg/x86_64-theseus-sse.json
+++ b/cfg/x86_64-theseus-sse.json
@@ -8,5 +8,10 @@
   "arch": "x86_64",
   "os": "theseus",
   "features": "+sse2",
+  "code-model": "large",
+  "relocation-model": "static",
+  "tls-model": "local-exec",
+  "has-thread-local": true,
+  "merge-functions": "disabled",
   "disable-redzone": true
 }

--- a/cfg/x86_64-theseus.json
+++ b/cfg/x86_64-theseus.json
@@ -8,5 +8,10 @@
   "arch": "x86_64",
   "os": "theseus",
   "features": "-mmx,-sse,+soft-float",
+  "code-model": "large",
+  "relocation-model": "static",
+  "tls-model": "local-exec",
+  "has-thread-local": true,
+  "merge-functions": "disabled",
   "disable-redzone": true
 }


### PR DESCRIPTION
This makes it easier to ensure that all builds of crates that target Theseus, both in-tree and out-of-tree builds, will use the correct configurations for codegen and other options.

Also relevant to upstreaming support for Theseus as a built-in target in rustc.