### PR TITLE
Fix `DEVICE_MEMORY` PTE flags on aarch64

### DIFF
--- a/kernel/pte_flags/src/lib.rs
+++ b/kernel/pte_flags/src/lib.rs
@@ -89,9 +89,9 @@ bitflags! {
         /// * If set, this page maps device memory, which is non-cacheable.
         /// * If not set, this page maps normal memory, which is cacheable by default.
         //
-        // This does not require a conversion between architectures.
-        const DEVICE_MEMORY  = PteFlagsArch::DEVICE_MEMORY.bits();
-        
+        // This DOES require a conversion for aarch64, but not for x86_64.
+        const DEVICE_MEMORY = DEVICE_MEM_BIT.bits();
+
         /// * The hardware will set this bit when the page is accessed.
         /// * The OS can then clear this bit once it has acknowledged that the page was accessed,
         ///   if it cares at all about this information.
@@ -145,11 +145,13 @@ bitflags! {
 // The bits defined below have different semantics on x86_64 vs aarch64.
 // These are the ones that require special handling during From/Into conversions.
 cfg_if!{ if #[cfg(target_arch = "x86_64")] {
-    const WRITABLE_BIT: PteFlagsX86_64 = PteFlagsX86_64::WRITABLE;
-    const GLOBAL_BIT:   PteFlagsX86_64 = PteFlagsX86_64::_GLOBAL;
+    const DEVICE_MEM_BIT: PteFlagsX86_64 = PteFlagsX86_64::DEVICE_MEMORY;
+    const WRITABLE_BIT:   PteFlagsX86_64 = PteFlagsX86_64::WRITABLE;
+    const GLOBAL_BIT:     PteFlagsX86_64 = PteFlagsX86_64::_GLOBAL;
 } else if #[cfg(target_arch = "aarch64")] {
-    const WRITABLE_BIT: PteFlagsAarch64 = PteFlagsAarch64::READ_ONLY;
-    const GLOBAL_BIT:   PteFlagsAarch64 = PteFlagsAarch64::_NOT_GLOBAL;
+    const DEVICE_MEM_BIT: PteFlagsAarch64 = PteFlagsAarch64::NORMAL_MEMORY;
+    const WRITABLE_BIT:   PteFlagsAarch64 = PteFlagsAarch64::READ_ONLY;
+    const GLOBAL_BIT:     PteFlagsAarch64 = PteFlagsAarch64::_NOT_GLOBAL;
 }}
 
 /// See [`PteFlags::new()`] for what bits are set by default.

--- a/kernel/pte_flags/src/pte_flags_aarch64.rs
+++ b/kernel/pte_flags/src/pte_flags_aarch64.rs
@@ -212,7 +212,7 @@ impl From<PteFlags> for PteFlagsAarch64 {
     /// * `OUTER_SHAREABLE` will be set.
     fn from(general: PteFlags) -> Self {
         let mut specific = Self::from_bits_truncate(general.bits());
-        specific.toggle(super::WRITABLE_BIT | super::GLOBAL_BIT);
+        specific.toggle(super::WRITABLE_BIT | super::GLOBAL_BIT | super::DEVICE_MEM_BIT);
         specific &= !Self::OVERWRITTEN_BITS_FOR_CONVERSION; // clear the masked bits
         specific |= Self::OUTER_SHAREABLE; // set the masked bits to their default
         specific
@@ -221,7 +221,7 @@ impl From<PteFlags> for PteFlagsAarch64 {
 
 impl From<PteFlagsAarch64> for PteFlags {
     fn from(mut specific: PteFlagsAarch64) -> Self {
-        specific.toggle(super::WRITABLE_BIT | super::GLOBAL_BIT);
+        specific.toggle(super::WRITABLE_BIT | super::GLOBAL_BIT | super::DEVICE_MEM_BIT);
         Self::from_bits_truncate(specific.bits())
     }
 }

--- a/kernel/pte_flags/src/pte_flags_x86_64.rs
+++ b/kernel/pte_flags/src/pte_flags_x86_64.rs
@@ -35,6 +35,8 @@ bitflags! {
         const WRITABLE           = 1 << 1;
         /// * If set, userspace (ring 3) can access this page.
         /// * If not set, only kernelspace (ring 0) can access this page.
+        ///
+        /// This is unused in Theseus because it is a single privilege level OS.
         const _USER_ACCESSIBLE    = 1 << 2;
         /// * If set, writes to this page go directly to memory.
         /// * It not set, writes are first written to the CPU cache, and then written to memory.
@@ -43,7 +45,7 @@ bitflags! {
         /// * If set, this page's content is never cached, neither for read nor writes. 
         /// * If not set, this page's content is cached as normal, both for read nor writes. 
         const NO_CACHE           = 1 << 4;
-        /// An alias for `NO_CACHE` in order to ease compatibility with aarch64.
+        /// An alias for [`Self::NO_CACHE`] in order to ease compatibility with aarch64.
         const DEVICE_MEMORY      = Self::NO_CACHE.bits;
         /// * The hardware will set this bit when the page is accessed.
         /// * The OS can then clear this bit once it has acknowledged that the page was accessed,


### PR DESCRIPTION
On AArch64:
- `PteFlags::DEVICE_MEMORY` → `PteFlagsAarch64::DEVICE_MEMORY`
- `PteFlagsAarch64::DEVICE_MEMORY` → `PteFlagsAarch64::MAIR_INDEX_0`
- `PteFlagsAarch64::MAIR_INDEX_0` = 0

This makes every page table entry appear as if it described device memory because a zero flag is always present.

This PR makes `PteFlags::DEVICE_MEMORY` work like `WRITABLE` & `GLOBAL`: it has an inverted value on aarch64 and the bit is flipped during conversion to and from arch-specific `PteFlags`.