### PR TITLE
Ensure basic memory types work on all architectures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,11 +1719,8 @@ version = "0.1.0"
 dependencies = [
  "bit_field 0.7.0",
  "derive_more",
- "entryflags_x86_64",
  "kernel_config",
- "multiboot2",
  "paste",
- "xmas-elf",
  "zerocopy",
 ]
 
@@ -2202,6 +2199,7 @@ dependencies = [
  "frame_allocator",
  "kernel_config",
  "memory_structs",
+ "memory_x86_64",
  "zerocopy",
 ]
 

--- a/kernel/memory_structs/Cargo.toml
+++ b/kernel/memory_structs/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "memory_structs"
-description = "Common types used in the memory management subsystem"
+description = "Basic types used for memory management"
 version = "0.1.0"
 
 [dependencies]
-multiboot2 = "0.14.0"
-xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 bit_field = "0.7.0"
 zerocopy = "0.5.0"
 derive_more = "0.99.0"
@@ -14,9 +12,6 @@ paste = "1.0.5"
 
 [dependencies.kernel_config]
 path = "../kernel_config"
-
-[dependencies.entryflags_x86_64]
-path = "../entryflags_x86_64"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/memory_structs/src/lib.rs
+++ b/kernel/memory_structs/src/lib.rs
@@ -1,15 +1,16 @@
-//! This crate contains common types used for memory mapping. 
+//! This crate contains basic types used for memory management.
+//!
+//! The types of interest are divided into three categories:
+//! 1. addresses: `VirtualAddress` and `PhysicalAddress`.
+//! 2. "chunk" types: `Page` and `Frame`.
+//! 3. ranges of chunks: `PageRange` and `FrameRange`.  
 
 #![no_std]
 #![feature(step_trait)]
 
 extern crate kernel_config;
-extern crate multiboot2;
-extern crate xmas_elf;
 #[macro_use] extern crate derive_more;
 extern crate bit_field;
-#[cfg(target_arch = "x86_64")]
-extern crate entryflags_x86_64;
 extern crate zerocopy;
 extern crate paste;
 
@@ -22,8 +23,6 @@ use core::{
     ops::{Add, AddAssign, Deref, DerefMut, RangeInclusive, Sub, SubAssign},
 };
 use kernel_config::memory::{MAX_PAGE_NUMBER, PAGE_SIZE};
-#[cfg(target_arch = "x86_64")]
-pub use entryflags_x86_64::{EntryFlags, PAGE_TABLE_ENTRY_FRAME_MASK};
 use zerocopy::FromBytes;
 use paste::paste;
 
@@ -126,6 +125,7 @@ macro_rules! implement_address {
     };
 }
 
+#[cfg(target_arch = "x86_64")]
 #[inline]
 fn is_canonical_virtual_address(virt_addr: usize) -> bool {
     match virt_addr.get_bits(47..64) {
@@ -134,6 +134,7 @@ fn is_canonical_virtual_address(virt_addr: usize) -> bool {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 #[inline]
 const fn canonicalize_virtual_address(virt_addr: usize) -> usize {
     // match virt_addr.get_bit(47) {
@@ -145,6 +146,7 @@ const fn canonicalize_virtual_address(virt_addr: usize) -> usize {
     ((virt_addr << 16) as isize >> 16) as usize
 }
 
+#[cfg(target_arch = "x86_64")]
 #[inline]
 fn is_canonical_physical_address(phys_addr: usize) -> bool {
     match phys_addr.get_bits(52..64) {
@@ -153,6 +155,7 @@ fn is_canonical_physical_address(phys_addr: usize) -> bool {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 #[inline]
 const fn canonicalize_physical_address(phys_addr: usize) -> usize {
     phys_addr & 0x000F_FFFF_FFFF_FFFF
@@ -429,39 +432,3 @@ macro_rules! implement_page_frame_range {
 
 implement_page_frame_range!(PageRange, "virtual", virt, Page, VirtualAddress);
 implement_page_frame_range!(FrameRange, "physical", phys, Frame, PhysicalAddress);
-
-
-/// The address bounds and mapping flags of a section's memory region.
-#[derive(Debug)]
-pub struct SectionMemoryBounds {
-    /// The starting virtual address and physical address.
-    pub start: (VirtualAddress, PhysicalAddress),
-    /// The ending virtual address and physical address.
-    pub end: (VirtualAddress, PhysicalAddress),
-    /// The page table entry flags that should be used for mapping this section.
-    pub flags: EntryFlags,
-}
-
-/// The address bounds and flags of the initial kernel sections that need mapping. 
-/// 
-/// Individual sections in the kernel's ELF image are combined here according to their flags,
-/// as described below, but some are kept separate for the sake of correctness or ease of use.
-/// 
-/// It contains three main items, in which each item includes all sections that have identical flags:
-/// * The `text` section bounds cover all sections that are executable.
-/// * The `rodata` section bounds cover those that are read-only (.rodata, .gcc_except_table, .eh_frame).
-///   * The `rodata` section also includes thread-local storage (TLS) areas (.tdata, .tbss) if they exist,
-///     because they can be mapped using the same page table flags.
-/// * The `data` section bounds cover those that are writable (.data, .bss).
-/// 
-/// It also contains:
-/// * The `page_table` section bounds cover the initial page table's top-level (root) P4 frame. 
-/// * The `stack` section bounds cover the initial stack, which are maintained separately.
-#[derive(Debug)]
-pub struct AggregatedSectionMemoryBounds {
-   pub text:        SectionMemoryBounds,
-   pub rodata:      SectionMemoryBounds,
-   pub data:        SectionMemoryBounds,
-   pub page_table:  SectionMemoryBounds,
-   pub stack:       SectionMemoryBounds,
-}

--- a/kernel/memory_x86_64/src/lib.rs
+++ b/kernel/memory_x86_64/src/lib.rs
@@ -19,9 +19,7 @@ pub use multiboot2::BootInformation;
 pub use entryflags_x86_64::{EntryFlags, PAGE_TABLE_ENTRY_FRAME_MASK};
 
 use kernel_config::memory::KERNEL_OFFSET;
-use memory_structs::{
-    PhysicalAddress, VirtualAddress, SectionMemoryBounds, AggregatedSectionMemoryBounds,
-};
+use memory_structs::{PhysicalAddress, VirtualAddress};
 use x86_64::{registers::control::Cr3, instructions::tlb};
 
 
@@ -90,6 +88,42 @@ pub fn get_boot_info_mem_area(
         PhysicalAddress::new(boot_info.end_address() - KERNEL_OFFSET)
             .ok_or("boot info end physical address was invalid")?,
     ))
+}
+
+
+/// The address bounds and mapping flags of a section's memory region.
+#[derive(Debug)]
+pub struct SectionMemoryBounds {
+    /// The starting virtual address and physical address.
+    pub start: (VirtualAddress, PhysicalAddress),
+    /// The ending virtual address and physical address.
+    pub end: (VirtualAddress, PhysicalAddress),
+    /// The page table entry flags that should be used for mapping this section.
+    pub flags: EntryFlags,
+}
+
+/// The address bounds and flags of the initial kernel sections that need mapping. 
+/// 
+/// Individual sections in the kernel's ELF image are combined here according to their flags,
+/// as described below, but some are kept separate for the sake of correctness or ease of use.
+/// 
+/// It contains three main items, in which each item includes all sections that have identical flags:
+/// * The `text` section bounds cover all sections that are executable.
+/// * The `rodata` section bounds cover those that are read-only (.rodata, .gcc_except_table, .eh_frame).
+///   * The `rodata` section also includes thread-local storage (TLS) areas (.tdata, .tbss) if they exist,
+///     because they can be mapped using the same page table flags.
+/// * The `data` section bounds cover those that are writable (.data, .bss).
+/// 
+/// It also contains:
+/// * The `page_table` section bounds cover the initial page table's top-level (root) P4 frame. 
+/// * The `stack` section bounds cover the initial stack, which are maintained separately.
+#[derive(Debug)]
+pub struct AggregatedSectionMemoryBounds {
+   pub text:        SectionMemoryBounds,
+   pub rodata:      SectionMemoryBounds,
+   pub data:        SectionMemoryBounds,
+   pub page_table:  SectionMemoryBounds,
+   pub stack:       SectionMemoryBounds,
 }
 
 

--- a/kernel/page_table_entry/Cargo.toml
+++ b/kernel/page_table_entry/Cargo.toml
@@ -18,5 +18,8 @@ path = "../memory_structs"
 [dependencies.frame_allocator]
 path = "../frame_allocator"
 
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+memory_x86_64 = { path = "../memory_x86_64" }
+
 [lib]
 crate-type = ["rlib"]

--- a/kernel/page_table_entry/src/lib.rs
+++ b/kernel/page_table_entry/src/lib.rs
@@ -13,7 +13,9 @@
 #![no_std]
 
 use core::ops::Deref;
-use memory_structs::{Frame, FrameRange, PAGE_TABLE_ENTRY_FRAME_MASK, EntryFlags, PhysicalAddress};
+use memory_structs::{Frame, FrameRange, PhysicalAddress};
+#[cfg(target_arch = "x86_64")]
+use memory_x86_64::{ PAGE_TABLE_ENTRY_FRAME_MASK, EntryFlags};
 use bit_field::BitField;
 use kernel_config::memory::PAGE_SHIFT;
 use zerocopy::FromBytes;


### PR DESCRIPTION
* Clean up `memory_structs` to remove unnecessary content specific to multiboot2 or the x86_64 architecture.

* Note that some content in `memory_x86_64` is more multiboot2-specific than x86_64-specific, but that will be refactored in a future PR that introduces UEFI support.

* Also, the `page_table_entry` crate now contains some explicitly x86_64-specific code, but that can be removed once we start using the new arch-agnostic `pte_flags` crate instead of the current `entryflags_x86_64`.