### PR TITLE
Add time to doc index

### DIFF
--- a/kernel/_doc_root.rs
+++ b/kernel/_doc_root.rs
@@ -58,6 +58,7 @@
 //! * `serial_port`: simple driver for writing to the serial_port, used mostly for debugging.
 //! * `spawn`: Functions and wrappers for spawning new Tasks.
 //! * `task`: Task types and structure definitions, a Task is a thread of execution.
+//! * `time`: Abstractions to interact with hardware clocks. 
 //! * `tsc`: TSC (TimeStamp Counter) support for performance counters on x86. Basically a wrapper around rdtsc.
 //! * `tss`: TSS (Task State Segment support (x86 only) for Theseus.
 //! * `vfs_node`: contains the structs VFSDirectory and VFSFile, which are the most basic, generic implementers of the traits Directory and File


### PR DESCRIPTION
[this](https://www.theseus-os.com/Theseus/doc/___Theseus_Crates___/index.html) page doesn't mention `time` in the list. I solved it. 