### PR TITLE
Don't re-run clippy CI checks when PRs are edited

### DIFF
--- a/.github/workflows/check-clippy.yaml
+++ b/.github/workflows/check-clippy.yaml
@@ -1,7 +1,7 @@
 name: Clippy Checks
 on:
   pull_request:
-    types: [edited, synchronize, opened, reopened]
+    types: [synchronize, opened, reopened]
 jobs:
   run-clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Editing the PR doesn't change source code contents, so this is completely unnecessary.