### PR TITLE
Add PAT support; map framebuffer memory as write-combining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,6 +2189,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_attribute_table"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "memory",
+ "msr",
+ "raw-cpuid",
+ "x86_64",
+]
+
+[[package]]
 name = "page_table_entry"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,7 @@ dependencies = [
  "log",
  "memory",
  "multicore_bringup",
+ "page_attribute_table",
  "shapes",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,6 +2194,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "memory",
+ "modular-bitfield",
  "msr",
  "raw-cpuid",
  "x86_64",

--- a/kernel/apic/Cargo.toml
+++ b/kernel/apic/Cargo.toml
@@ -36,8 +36,8 @@ path = "../kernel_config"
 [dependencies.raw-cpuid]
 version = "10.6.0"
 
-[features]
-apic_timer_fixed = []
+# [features]
+# apic_timer_fixed = []
 
 
 [lib]

--- a/kernel/framebuffer/Cargo.toml
+++ b/kernel/framebuffer/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "framebuffer"
 version = "0.1.0"
-authors = ["Wenqiu Yu <yuwenqiuj@gmail.com>"]
+authors = ["Kevin Boos <kevinaboos@gmail.com>", "Wenqiu Yu <yuwenqiuj@gmail.com>"]
 description = "a framebuffer is a buffer of pixels which can be composited to another framebuffer or be mapped to some physical memory"
+edition = "2021"
 
 [dependencies]
 log = "0.4.8"
 zerocopy = "0.5.0"
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+page_attribute_table = { path = "../page_attribute_table" }
 
 [dependencies.memory]
 path = "../memory"

--- a/kernel/memory/src/paging/mapper.rs
+++ b/kernel/memory/src/paging/mapper.rs
@@ -176,12 +176,7 @@ impl Mapper {
     {
         let frames = frames.into_inner();
         let flags = flags.into();
-        let top_level_flags = flags.valid(true)
-            // P4, P3, and P2 entries should never set NOT_EXECUTABLE; only the lowest-level P1 entry should.
-            .executable(true)
-            // Currently we cannot use the EXCLUSIVE bit for page table frames (P4, P3, P2),
-            // because another page table frame may re-use (create another alias for) it without us knowing here.
-            .exclusive(false);
+        let higher_level_flags = flags.adjust_for_higher_level_pte();
 
         // Only the lowest-level P1 entry can be considered exclusive, and only when
         // we are mapping it exclusively (i.e., owned `AllocatedFrames` are passed in).
@@ -200,9 +195,9 @@ impl Mapper {
 
         // iterate over pages and frames in lockstep
         for (page, frame) in pages.deref().clone().into_iter().zip(frames.borrow().into_iter()) {
-            let p3 = self.p4_mut().next_table_create(page.p4_index(), top_level_flags);
-            let p2 = p3.next_table_create(page.p3_index(), top_level_flags);
-            let p1 = p2.next_table_create(page.p2_index(), top_level_flags);
+            let p3 = self.p4_mut().next_table_create(page.p4_index(), higher_level_flags);
+            let p2 = p3.next_table_create(page.p3_index(), higher_level_flags);
+            let p1 = p2.next_table_create(page.p2_index(), higher_level_flags);
 
             if !p1[page.p1_index()].is_unused() {
                 error!("map_allocated_pages_to(): page {:#X} -> frame {:#X}, page was already in use!", page.start_address(), frame.start_address());
@@ -253,16 +248,10 @@ impl Mapper {
         flags: F,
     ) -> Result<MappedPages, &'static str> {
         let flags = flags.into();
-        let top_level_flags = flags
-        // P4, P3, and P2 entries should never set NOT_EXECUTABLE; only the lowest-level P1 entry should.
-            .executable(true)
-            // Currently we cannot use the EXCLUSIVE bit for page table frames (P4, P3, P2),
-            // because another page table frame may re-use (create another alias for) it without us knowing here.
-            .exclusive(false)
-            .valid(true);
+        let higher_level_flags = flags.adjust_for_higher_level_pte();
 
-        // Only the lowest-level P1 entry can be considered exclusive, and only when
-        // we are mapping it exclusively (i.e., owned `AllocatedFrames` are passed in).
+        // Only the lowest-level P1 entry can be considered exclusive, and only because
+        // we are mapping it exclusively (to owned `AllocatedFrames`).
         let actual_flags = flags
             .exclusive(true)
             .valid(true);
@@ -270,9 +259,9 @@ impl Mapper {
         for page in pages.deref().clone() {
             let af = frame_allocator::allocate_frames(1).ok_or("map_allocated_pages(): couldn't allocate new frame, out of memory")?;
 
-            let p3 = self.p4_mut().next_table_create(page.p4_index(), top_level_flags);
-            let p2 = p3.next_table_create(page.p3_index(), top_level_flags);
-            let p1 = p2.next_table_create(page.p2_index(), top_level_flags);
+            let p3 = self.p4_mut().next_table_create(page.p4_index(), higher_level_flags);
+            let p2 = p3.next_table_create(page.p3_index(), higher_level_flags);
+            let p1 = p2.next_table_create(page.p2_index(), higher_level_flags);
 
             if !p1[page.p1_index()].is_unused() {
                 error!("map_allocated_pages(): page {:#X} -> frame {:#X}, page was already in use!",

--- a/kernel/page_attribute_table/Cargo.toml
+++ b/kernel/page_attribute_table/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+name = "page_attribute_table"
+description = "Support for x86 Page Attribute Table (PAT) for controlling memory type cacheability"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+log = "0.4.8"
+x86_64 = "0.14.8"
+
+[dependencies.msr]
+path = "../../libs/msr"
+
+[dependencies.memory]
+path = "../memory"
+
+[dependencies.raw-cpuid]
+version = "10.6.0"
+
+[lib]
+crate-type = ["rlib"]

--- a/kernel/page_attribute_table/Cargo.toml
+++ b/kernel/page_attribute_table/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 log = "0.4.8"
 x86_64 = "0.14.8"
+modular-bitfield = "0.11.2"
 
 [dependencies.msr]
 path = "../../libs/msr"

--- a/kernel/page_attribute_table/src/lib.rs
+++ b/kernel/page_attribute_table/src/lib.rs
@@ -1,0 +1,34 @@
+//! Support for the Page Attribute Table (PAT) feature on x86.
+//!
+//! PAT replaces the legacy Memory Type Range Registers (MTRRs) on x86.
+//! PAT allows the system to assign memory types to regions of "linear" (virtual) addresses
+//! instead of the MTRRs, which operate on regions of physical addresses.
+//! 
+
+#![no_std]
+
+use log::*;
+
+use raw_cpuid::CpuId;
+
+use x86_64::registers::control::{Cr0, Cr0Flags};
+
+
+
+
+pub const PAT_MSR: u32 = msr::IA32_PAT;
+
+#[doc(alias("pat", "mtrr", "page attribute table"))]
+pub enum MemoryCachingType {
+    Uncacheable = 0x00,
+    WriteCombining = 0x01,
+    // 0x02 and 0x03 are reserved
+    WriteThrough = 0x04,
+    WriteProtected = 0x05,
+    WriteBack = 0x06,
+    Uncached = 0x07,
+    // All other values are reserved.
+}
+
+pub struct PatMsr {
+}

--- a/kernel/page_attribute_table/src/lib.rs
+++ b/kernel/page_attribute_table/src/lib.rs
@@ -1,34 +1,154 @@
 //! Support for the Page Attribute Table (PAT) feature on x86.
 //!
 //! PAT replaces the legacy Memory Type Range Registers (MTRRs) on x86.
-//! PAT allows the system to assign memory types to regions of "linear" (virtual) addresses
-//! instead of the MTRRs, which operate on regions of physical addresses.
-//! 
+//! PAT allows the system to assign memory types, i.e., specify their caching behavior,
+//! to regions of "linear" (virtual) addresses.
+//! This is in contrast to MTRRs, which operate on regions of physical addresses.
 
 #![no_std]
 
 use log::*;
-
+use modular_bitfield::{specifiers::{B3, B5}, bitfield};
+use msr::IA32_PAT;
 use raw_cpuid::CpuId;
+// use x86_64::registers::control::{Cr0, Cr0Flags};
 
-use x86_64::registers::control::{Cr0, Cr0Flags};
+/// Theseus's fixed [`PageAttributeTable`] has slots that align with
+/// the default meaning of page table entry bits on x86_64.
+///
+/// | Bit Position | If Clear (0)  | If Set (1)     |
+/// |:-------------|:--------------|:---------------|
+/// | 0  (LSB)     | write back    | write through  |
+/// | 1  (middle)  | cache enabled | cache disabled |
+/// | 2  (MSB)     | N/A           | N/A            |
+///
+/// Thus, the following slots are chosen to align with those bits:
+/// * Slot 0 (`0b000`): [MemoryCachingType::WriteBack]
+/// * Slot 1 (`0b001`): [MemoryCachingType::WriteThrough]
+/// * Slot 2 (`0b010`): [MemoryCachingType::Uncacheable] (caching disabled)
+/// * Slot 3 (`0b011`): unused -- write through and cache enabled doesn't make sense,
+///   but this is set up as `Uncacheable` because the cache disabled flag takes priority.
+///
+/// The following slots are available for custom use,
+/// and Theseus currently sets them up as such:
+/// * Slot 4 (`0b100`): [MemoryCachingType::WriteProtected]
+/// * Slot 5 (`0b101`): [MemoryCachingType::WriteCombining]
+/// * Slot 6 (`0b110`): [MemoryCachingType::UncachedMinus]
+/// * Slot 7 (`0b111`): [MemoryCachingType::UncachedMinus]
+///
+/// Currently, the difference between `Uncacheable` and
+/// `UncachedMinus` is not clear, so we offer slots for both.
+///
+/// ## Usage
+/// You cannot and do not need to use this type directly, as it is
+/// pre-set up statically for you.
+/// Instead, use [`MemoryCachingType::pat_slot_index()`] to obtain
+/// the index of the PAT slot that has been set up for whatever
+/// `MemoryCachingType` you need. 
+pub static FIXED_PAT: PageAttributeTable = PageAttributeTable::from_bytes([
+    //
+    // NOTE: this order must be kept in sync with `MemoryCachingType::pat_slot_index`.
+    //
+    MemoryCachingType::WriteBack      as u8, // 0: 0b000 
+    MemoryCachingType::WriteThrough   as u8, // 1: 0b001
+    MemoryCachingType::Uncacheable    as u8, // 2: 0b010
+    MemoryCachingType::Uncacheable    as u8, // 3: 0b011
+    MemoryCachingType::WriteProtected as u8, // 4: 0b100
+    MemoryCachingType::WriteCombining as u8, // 5: 0b101
+    MemoryCachingType::UncachedMinus  as u8, // 6: 0b110
+    MemoryCachingType::UncachedMinus  as u8, // 7: 0b111
+]);
 
 
-
-
-pub const PAT_MSR: u32 = msr::IA32_PAT;
-
-#[doc(alias("pat", "mtrr", "page attribute table"))]
-pub enum MemoryCachingType {
-    Uncacheable = 0x00,
-    WriteCombining = 0x01,
-    // 0x02 and 0x03 are reserved
-    WriteThrough = 0x04,
-    WriteProtected = 0x05,
-    WriteBack = 0x06,
-    Uncached = 0x07,
-    // All other values are reserved.
+/// The Page Attribute Table (PAT) consists of 8 "slots" that can each
+/// be configured with a different [MemoryCachingType].
+#[bitfield(bits = 64)]
+#[repr(u64)]
+#[derive(Copy, Clone)]
+pub struct PageAttributeTable {
+    #[skip] pat_slot_0: B3,
+    #[skip] _reserved0: B5,
+    #[skip] pat_slot_1: B3,
+    #[skip] _reserved1: B5,
+    #[skip] pat_slot_2: B3,
+    #[skip] _reserved2: B5,
+    #[skip] pat_slot_3: B3,
+    #[skip] _reserved3: B5,
+    #[skip] pat_slot_4: B3,
+    #[skip] _reserved4: B5,
+    #[skip] pat_slot_5: B3,
+    #[skip] _reserved5: B5,
+    #[skip] pat_slot_6: B3,
+    #[skip] _reserved6: B5,
+    #[skip] pat_slot_7: B3,
+    #[skip] _reserved7: B5,
 }
 
-pub struct PatMsr {
+
+/// The various types of memory caching that x86 supports
+/// for usage in the [`PageAttributeTable`].
+///
+/// The default is [`MemoryCachingType::WriteBack`],
+/// which corresponds to the standard default caching mode
+/// when no specific page table entry flags are set.
+#[doc(alias("pat", "mtrr", "page attribute table"))]
+#[derive(Debug, Copy, Clone)]
+#[repr(u8)]
+pub enum MemoryCachingType {
+    Uncacheable    = 0x00,
+    WriteCombining = 0x01,
+    // 0x02 and 0x03 are reserved.
+    WriteThrough   = 0x04,
+    WriteProtected = 0x05,
+    WriteBack      = 0x06,
+    UncachedMinus  = 0x07,
+    // All other values are reserved.
+}
+impl MemoryCachingType {
+    /// Returns the index of the [`PageAttributeTable`] (PAT) slot
+    /// that has been pre-configured with this `MemoryCachingType`.
+    ///
+    /// See the docs of [FIXED_PAT] for more info.
+    pub const fn pat_slot_index(self) -> u8 {
+        //
+        // NOTE: this must be kept in sync with the definition of `FIXED_PAT`.
+        //
+        match self {
+            Self::WriteBack      => 0,
+            Self::WriteThrough   => 1,
+            Self::Uncacheable    => 2, // also 3
+            Self::WriteProtected => 4,
+            Self::WriteCombining => 5,
+            Self::UncachedMinus  => 6, // also 6
+        }
+    }
+}
+
+
+/// Sets up the Page Attribute Table (PAT) for this CPU.
+///
+/// This works by setting the [`IA32_PAT`] MSR to the value
+/// specified by [`FIXED_PAT`].
+///
+/// Returns `Ok(())` upon success, and `Err(())` if PAT is unsupported.
+pub fn init() -> Result<(), ()> {
+    let has_pat = CpuId::new()
+        .get_feature_info()
+        .map(|finfo| finfo.has_pat())
+        .ok_or(())?;
+    
+    if !has_pat {
+        error!("This CPU does not support the Page Attribute Table");
+        return Err(());
+    }
+
+    // TODO: do we need to disable the cache using CR0 first? or flush it?
+
+    let mut pat_msr = x86_64::registers::model_specific::Msr::new(IA32_PAT);
+    unsafe {
+        pat_msr.write(FIXED_PAT.into());
+    }
+
+    debug!("Enabled the Page Attribute Table");
+    Ok(())
 }

--- a/kernel/pte_flags/src/pte_flags_x86_64.rs
+++ b/kernel/pte_flags/src/pte_flags_x86_64.rs
@@ -49,7 +49,8 @@ bitflags! {
         /// the least-significant bit of the 3-bit index into the Page Attribute Table;
         /// that index is used to determine the PAT entry that holds the
         /// memory caching type that is applied to this page.
-        const _WRITE_THROUGH     = 1 << 3;
+        const WRITE_THROUGH      = 1 << 3;
+        const PAT_BIT0           = Self::WRITE_THROUGH.bits;
 
         /// * If set, this page's content is never cached, neither for read nor writes. 
         /// * If not set, this page's content is cached as normal, both for read nor writes. 
@@ -61,6 +62,7 @@ bitflags! {
         const CACHE_DISABLE      = 1 << 4;
         /// An alias for [`Self::CACHE_DISABLE`] in order to ease compatibility with aarch64.
         const DEVICE_MEMORY      = Self::CACHE_DISABLE.bits;
+        const PAT_BIT1           = Self::CACHE_DISABLE.bits;
 
         /// * The hardware will set this bit when the page is accessed.
         /// * The OS can then clear this bit once it has acknowledged that the page was accessed,
@@ -88,7 +90,7 @@ bitflags! {
         /// memory caching type that is applied to this page.
         /// 
         /// This *cannot* be used for PAT index bits in a mid-level (P2 or P3) entry.
-        const PAT_FOR_P1         = 1 <<  7;
+        const PAT_BIT2_FOR_P1    = 1 <<  7;
 
         /// * If set, this page is mapped identically across all address spaces
         ///   (all root page tables) and doesn't need to be flushed out of the TLB
@@ -109,7 +111,7 @@ bitflags! {
         // /// memory caching type that is applied to this page.
         // /// 
         // /// This *cannot* be used for PAT index bits in a lowest-level (P1) PTE.
-        // const PAT_FOR_P2_P3      = 1 << 12;
+        // const PAT_BIT2_FOR_P2_P3 = 1 << 12;
 
         /// See [PteFlags::EXCLUSIVE].
         ///  We use bit 55 because it is available for custom OS usage on both x86_64 and aarch64.
@@ -128,6 +130,7 @@ impl Default for PteFlagsX86_64 {
     }
 }
 
+/// Functions common to PTE flags on all architectures.
 impl PteFlagsX86_64 {
     /// Returns a new `PteFlagsX86_64` with the default value, in which
     /// only the `NOT_EXECUTABLE` bit is set.
@@ -250,13 +253,70 @@ impl PteFlagsX86_64 {
         self.contains(Self::ACCESSED)
     }
 
+    pub const fn is_exclusive(&self) -> bool {
+        self.contains(Self::EXCLUSIVE)
+    }
+}
+
+const BIT_0: u8 = 1 << 0;
+const BIT_1: u8 = 1 << 1;
+const BIT_2: u8 = 1 << 2;
+
+/// Functions specific to x86_64 PTE flags only.
+impl PteFlagsX86_64 {
+    /// Returns a copy of this `PteFlagsX86_64` with its flags adjusted
+    /// for use in a higher-level page table entry, e.g., P4, P3, P2.
+    ///
+    /// Currently, on x86_64, this does the following:
+    /// * Clears the `NOT_EXECUTABLE` bit.  
+    ///   * P4, P3, and P2 entries should never set `NOT_EXECUTABLE`,
+    ///     only the lowest-level P1 entry should.
+    /// * Clears the `EXCLUSIVE` bit.
+    ///   * Currently, we do not use the `EXCLUSIVE` bit for P4, P3, or P2 entries,
+    ///     because another page table frame may re-use it (create another alias to it)
+    ///     without our page table implementation knowing about it.
+    ///   * Only P1-level PTEs can map a frame exclusively.
+    /// * Clears the PAT index value, as we only support PAT on P1-level PTEs.
+    /// * Sets the `VALID` bit, as every P4, P3, and P2 entry must be valid.
+    #[must_use]
+    pub fn adjust_for_higher_level_pte(self) -> Self {
+        self.executable(true)
+            .exclusive(false)
+            .pat_index(0)
+            .valid(true)
+    }
+
+    /// Returns a copy of this `PteFlagsX86_64` with the PAT index bits
+    /// set to the value specifying the given `pat_slot`.
+    ///
+    /// This sets the following bits:
+    /// * [`PteFlagsX86_64::PAT_BIT0`] = Bit 0 of `pat_slot`
+    /// * [`PteFlagsX86_64::PAT_BIT1`] = Bit 1 of `pat_slot`
+    /// * [`PteFlagsX86_64::PAT_BIT2`] = Bit 2 of `pat_slot`
+    ///
+    /// The other bits `[3:7]` of `pat_slot` are ignored.
+    #[must_use]
+    #[doc(alias("PAT", "page attribute table", "slot"))]
+    pub fn pat_index(mut self, pat_slot: u8) -> Self {
+        self.set(Self::PAT_BIT0,        pat_slot & BIT_0 == BIT_0);
+        self.set(Self::PAT_BIT1,        pat_slot & BIT_1 == BIT_1);
+        self.set(Self::PAT_BIT2_FOR_P1, pat_slot & BIT_2 == BIT_2);
+        self
+    }
+
+    #[doc(alias("PAT", "page attribute table", "slot"))]
+    pub fn get_pat_index(&self) -> u8 {
+        let mut pat_index = 0;
+        if self.contains(Self::PAT_BIT0)        { pat_index |= BIT_0; }
+        if self.contains(Self::PAT_BIT1)        { pat_index |= BIT_1; }
+        if self.contains(Self::PAT_BIT2_FOR_P1) { pat_index |= BIT_2; }
+        pat_index
+    }
+
     pub const fn is_huge(&self) -> bool {
         self.contains(Self::HUGE_PAGE)
     }
 
-    pub const fn is_exclusive(&self) -> bool {
-        self.contains(Self::EXCLUSIVE)
-    }
 }
 
 impl From<PteFlags> for PteFlagsX86_64 {


### PR DESCRIPTION
* Adds support for the Page Attribute Table on x86, which allows
  specific page table entries to select a `MemoryCachingType` for
  the memory mapped by those page table entries.
  
* Use a dedicated PAT slot to map the real framebuffer memory
  as `WriteCombining`, which improves framebuffer performance.

* If PAT is not available (unsupported or not on x86), then we fall back
  to disabling all caching for the framebuffer memory.

* Currently, setting a PAT slot is only supported for P1 (the lowest level)
  page table entries. P2, P3, and P4 cannot use them, and this is enforced
  by means of `PteFlagsArch:: adjust_for_higher_level_pte()`.