### PR TITLE
Change `extra_files` delimiter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,13 +393,13 @@ limine:
 
 
 ### This target copies all extra files into the `ISOFILES` directory,
-### collapsing their directory structure into a single file name with `?` as the directory delimiter.
+### collapsing their directory structure into a single file name with `!` as the directory delimiter.
 ### The contents of the EXTRA_FILES directory will be available at runtime within Theseus's root fs, too.
 ### See the `README.md` in the `extra_files` directory for more info.
 extra_files:
 	@mkdir -p $(OBJECT_FILES_BUILD_DIR)
 	@for f in $(shell cd $(EXTRA_FILES) && find * -type f); do \
-		ln -f  $(EXTRA_FILES)/$${f}  $(OBJECT_FILES_BUILD_DIR)/`echo -n $${f} | sed 's/\//?/g'`  & \
+		ln -f  $(EXTRA_FILES)/$${f}  $(OBJECT_FILES_BUILD_DIR)/`echo -n $${f} | sed 's/\//!/g'`  & \
 	done; wait
 
 

--- a/extra_files/README.md
+++ b/extra_files/README.md
@@ -13,11 +13,12 @@ Examples include:
 
 ## How it works
 All files and directories here will be copied as-is without modification into the `/extra_files/` directory within Theseus.
-Directory hierarchies are preserved as well, but empty directories are ignored.
+Directory hierarchies are preserved as well, but empty directories are ignored. Hierarchies are encoded using an exclamation
+mark when creating the bootloader modules.
 
-Here are some examples of how a hypothetical file in this directory will appear in Theseus at runtime:
-```
-./hello.txt       -->  /extra_files/hello.txt
-./wasm/test.wasm  -->  /extra_files/wasm/test.wasm
-./foo/bar/me.o    -->  /extra_files/foo/bar/me.o
-```
+Here are some examples of how file paths would work:
+| Host machine     | Bootloader module          | Runtime path                |
+|------------------|----------------------------|-----------------------------|
+| ./hello.txt      | extra_files!hello.txt      | /extra_files/hello.txt      |
+| ./wasm/test.wasm | extra_files!wasm!test.wasm | /extra_files/wasm/test.wasm |
+| ./foo/bar/me.o   | extra_files!foo!bar!me.o   | /extra_files/foo/bar/me.o   |

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -32,7 +32,7 @@ pub const NAMESPACES_DIRECTORY_NAME: &'static str = "namespaces";
 
 /// The name of the directory that contains all other "extra_files" contents.
 pub const EXTRA_FILES_DIRECTORY_NAME: &'static str = "extra_files";
-const EXTRA_FILES_DIRECTORY_DELIMITER: char = '?';
+const EXTRA_FILES_DIRECTORY_DELIMITER: char = '!';
 
 /// The initial `CrateNamespace` that all kernel crates are added to by default.
 static INITIAL_KERNEL_NAMESPACE: Once<Arc<CrateNamespace>> = Once::new();
@@ -231,9 +231,9 @@ fn parse_bootloader_modules_into_files(
 /// (files that exist as areas of pre-loaded memory).
 /// 
 /// Their file paths are encoded by flattening directory hierarchies into a the file name,
-/// using `'?'` (question marks) to replace the directory delimiter `'/'`.
+/// using `'!'` (exclamation marks) to replace the directory delimiter `'/'`.
 /// 
-/// Thus, for example, a file named `"foo?bar?me?test.txt"` will be placed at the path
+/// Thus, for example, a file named `"foo!bar!me!test.txt"` will be placed at the path
 /// `/extra_files/foo/bar/me/test.txt`.
 fn parse_extra_file(
     extra_file_name: &str,


### PR DESCRIPTION
Changed the `extra_files` delimiter from `?` to `!` so that the bootloader names are compatible with a FAT filesystem for the upcoming UEFI port.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>