### PR TITLE
Make `page_table_entry` fully arch-agnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,7 +2330,6 @@ dependencies = [
 name = "page_table_entry"
 version = "0.1.0"
 dependencies = [
- "bit_field 0.7.0",
  "frame_allocator",
  "kernel_config",
  "memory_structs",

--- a/kernel/page_table_entry/Cargo.toml
+++ b/kernel/page_table_entry/Cargo.toml
@@ -6,20 +6,12 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-bit_field = "0.7.0"
 zerocopy = "0.5.0"
 
-[dependencies.kernel_config]
-path = "../kernel_config"
-
-[dependencies.memory_structs]
-path = "../memory_structs"
-
-[dependencies.frame_allocator]
-path = "../frame_allocator"
-
-[dependencies.pte_flags]
-path = "../pte_flags"
+frame_allocator = { path = "../frame_allocator" }
+memory_structs = { path = "../memory_structs" }
+kernel_config = { path = "../kernel_config" }
+pte_flags = { path = "../pte_flags" }
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/page_table_entry/src/lib.rs
+++ b/kernel/page_table_entry/src/lib.rs
@@ -14,11 +14,9 @@
 
 use core::ops::Deref;
 use memory_structs::{Frame, FrameRange, PhysicalAddress};
-use pte_flags::{PteFlagsArch, PTE_FRAME_MASK};
-use bit_field::BitField;
-use kernel_config::memory::PAGE_SHIFT;
 use zerocopy::FromBytes;
 use frame_allocator::AllocatedFrame;
+use pte_flags::{PteFlagsArch, PTE_FRAME_MASK};
 
 /// A page table entry, which is a `u64` value under the hood.
 ///
@@ -67,7 +65,7 @@ impl PageTableEntry {
 
     /// Returns this `PageTableEntry`'s flags.
     pub fn flags(&self) -> PteFlagsArch {
-        PteFlagsArch::from_bits_truncate(self.0)
+        PteFlagsArch::from_bits_truncate(self.0 & !PTE_FRAME_MASK)
     }
 
     /// Returns the physical `Frame` pointed to (mapped by) this `PageTableEntry`.
@@ -83,7 +81,7 @@ impl PageTableEntry {
     /// Extracts the value of the frame referred to by this page table entry.
     fn frame_value(&self) -> Frame {
         let mut frame_paddr = self.0 as usize;
-        frame_paddr.set_bits(0 .. (PAGE_SHIFT as u8), 0);
+        frame_paddr &= PTE_FRAME_MASK as usize;
         Frame::containing_address(PhysicalAddress::new_canonical(frame_paddr))
     }
 

--- a/kernel/pte_flags/src/pte_flags_x86_64.rs
+++ b/kernel/pte_flags/src/pte_flags_x86_64.rs
@@ -5,7 +5,7 @@ use bitflags::bitflags;
 use static_assertions::const_assert_eq;
 
 /// A mask for the bits of a page table entry that contain the physical frame address.
-pub const PTE_FRAME_MASK: u64 = 0x000_FFFFFFFFFF_000;
+pub const PTE_FRAME_MASK: u64 = 0x000F_FFFF_FFFF_F000;
 
 // Ensure that we never expose reserved bits [12:51] as part of the `PteFlagsX86_64` interface.
 const_assert_eq!(PteFlagsX86_64::all().bits() & PTE_FRAME_MASK, 0);


### PR DESCRIPTION
Co-authored-by: Nathan Royer <nathan.royer.pro@gmail.com>

Based on some changes from #701