### PR TITLE
Enable the Page Attribute Table (PAT) on all CPUs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "log",
  "memory",
  "no_drop",
+ "page_attribute_table",
  "scheduler",
  "spawn",
  "stack",
@@ -363,6 +364,7 @@ dependencies = [
  "network_manager",
  "no_drop",
  "ota_update_client",
+ "page_attribute_table",
  "print",
  "scheduler",
  "simd_personality",
@@ -2323,6 +2325,7 @@ dependencies = [
  "modular-bitfield",
  "msr",
  "raw-cpuid",
+ "spin 0.9.4",
  "x86_64",
 ]
 

--- a/kernel/ap_start/Cargo.toml
+++ b/kernel/ap_start/Cargo.toml
@@ -34,6 +34,8 @@ path = "../apic"
 [dependencies.no_drop]
 path = "../no_drop"
 
+[dependencies.page_attribute_table]
+path = "../page_attribute_table"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -92,6 +92,12 @@ pub fn kstart_ap(
     let bootstrap_task = spawn::init(kernel_mmi_ref.clone(), apic_id, this_ap_stack).unwrap();
     spawn::create_idle_task().unwrap();
 
+    // The PAT must be initialized explicitly on every CPU,
+    // but it is not a fatal error if it doesn't exist.
+    if page_attribute_table::init().is_err() {
+        error!("This CPU does not support the Page Attribute Table");
+    }
+
     info!("Initialization complete on AP core {}. Enabling interrupts...", apic_id);
     // The following final initialization steps are important, and order matters:
     // 1. Drop any other local stack variables that still exist.

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -64,6 +64,9 @@ path = "../acpi"
 [dependencies.multicore_bringup]
 path = "../multicore_bringup"
 
+[dependencies.page_attribute_table]
+path = "../page_attribute_table"
+
 [dependencies.device_manager]
 path = "../device_manager"
 

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -137,11 +137,17 @@ pub fn init(
     // which rely on Local APICs to broadcast an IPI to all running CPUs.
     tlb_shootdown::init();
     
-    // //initialize the per core heaps
+    // Initialize the per-core heaps.
     multiple_heaps::switch_to_multiple_heaps()?;
     info!("Initialized per-core heaps");
 
-    // initialize window manager.
+    // Initialize the window manager, and also the PAT, if available.
+    // The PAT supports write-combining caching of graphics video memory for better performance
+    // and must be initialized explicitly on every CPU, 
+    // but it is not a fatal error if it doesn't exist.
+    if page_attribute_table::init().is_err() {
+        error!("This CPU does not support the Page Attribute Table");
+    }
     let (key_producer, mouse_producer) = window_manager::init()?;
 
     // initialize the rest of our drivers

--- a/kernel/framebuffer/src/lib.rs
+++ b/kernel/framebuffer/src/lib.rs
@@ -87,8 +87,7 @@ impl<P: Pixel> Framebuffer<P> {
                 .into();
 
             #[cfg(target_arch = "x86_64")] {
-                let use_pat = page_attribute_table::init().is_ok();
-                if use_pat {
+                if page_attribute_table::is_supported() {
                     flags = flags.pat_index(
                         page_attribute_table::MemoryCachingType::WriteCombining.pat_slot_index()
                     );

--- a/kernel/page_attribute_table/Cargo.toml
+++ b/kernel/page_attribute_table/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.8"
+spin = "0.9.4"
 x86_64 = "0.14.8"
 modular-bitfield = "0.11.2"
 


### PR DESCRIPTION
* PAT is now enabled once for each CPU upon CPU boot.

* The graphics stack (e.g., `framebuffer`) no longer needs to init the PAT itself, and can now simply check if it's supported.