### PR TITLE
Return a task's `ExitValue` via the `join()` function

### DIFF
--- a/applications/bm/src/lib.rs
+++ b/applications/bm/src/lib.rs
@@ -341,7 +341,6 @@ fn do_spawn_inner(overhead_ct: u64, th: usize, nr: usize, _child_core: u8) -> Re
 	        .spawn()?;
 
 	    child.join()?;
-	    child.take_exit_value().ok_or("Couldn't retrieve exit value")?;
 	    end_hpet = hpet.get_counter();
 		delta_hpet += end_hpet - start_hpet - overhead_ct;		
 	}
@@ -429,10 +428,6 @@ fn do_ctx_inner(th: usize, nr: usize, child_core: u8) -> Result<u64, &'static st
 		taskref3.join()?;
 		taskref4.join()?;
 
-		taskref3.take_exit_value().ok_or("could not retrieve exit value")?;
-		taskref4.take_exit_value().ok_or("could not retrieve exit value")?;
-
-
 	overhead_end_hpet = hpet.get_counter();
 
 	// we then spawn them with yielding enabled
@@ -449,9 +444,6 @@ fn do_ctx_inner(th: usize, nr: usize, child_core: u8) -> Result<u64, &'static st
 
 		taskref1.join()?;
 		taskref2.join()?;
-
-		taskref1.take_exit_value().ok_or("could not retrieve exit value")?;
-		taskref2.take_exit_value().ok_or("could not retrieve exit value")?;
 
     end_hpet = hpet.get_counter();
 
@@ -606,7 +598,6 @@ fn do_ipc_rendezvous_inner(th: usize, nr: usize, child_core: Option<u8>) -> Resu
 		}
 		
 		taskref3.join()?;
-		taskref3.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let overhead = hpet.get_counter();
 
@@ -632,7 +623,6 @@ fn do_ipc_rendezvous_inner(th: usize, nr: usize, child_core: Option<u8>) -> Resu
 		rendezvous_task_receiver((sender2, receiver1));
 
 		taskref1.join()?;
-		taskref1.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let end = hpet.get_counter();
 
@@ -673,7 +663,6 @@ fn do_ipc_rendezvous_inner_cycles(th: usize, nr: usize, child_core: Option<u8>) 
 		}
 		
 		taskref3.join()?;
-		taskref3.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let overhead = counter.diff();
 	counter.start()?;
@@ -700,7 +689,6 @@ fn do_ipc_rendezvous_inner_cycles(th: usize, nr: usize, child_core: Option<u8>) 
 		rendezvous_task_receiver((sender2, receiver1));
 
 		taskref1.join()?;
-		taskref1.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let end = counter.end()?;
 
@@ -812,7 +800,6 @@ fn do_ipc_async_inner(th: usize, nr: usize, child_core: Option<u8>, blocking: bo
 		}
 		
 		taskref3.join()?;
-		taskref3.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let overhead = hpet.get_counter();
 
@@ -841,7 +828,6 @@ fn do_ipc_async_inner(th: usize, nr: usize, child_core: Option<u8>, blocking: bo
 		receiver_task((sender2, receiver1));
 
 		taskref1.join()?;
-		taskref1.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let end = hpet.get_counter();
 
@@ -888,7 +874,6 @@ fn do_ipc_async_inner_cycles(th: usize, nr: usize, child_core: Option<u8>, block
 		}
 		
 		taskref3.join()?;
-		taskref3.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let overhead = counter.diff();
 	counter.start()?;
@@ -918,7 +903,6 @@ fn do_ipc_async_inner_cycles(th: usize, nr: usize, child_core: Option<u8>, block
 		receiver_task((sender2, receiver1));
 
 		taskref1.join()?;
-		taskref1.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let end = counter.end()?;
 
@@ -1049,7 +1033,6 @@ fn do_ipc_simple_inner(th: usize, nr: usize, child_core: Option<u8>) -> Result<u
 		}
 		
 		taskref3.join()?;
-		taskref3.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let overhead = hpet.get_counter();
 
@@ -1075,7 +1058,6 @@ fn do_ipc_simple_inner(th: usize, nr: usize, child_core: Option<u8>) -> Result<u
 		simple_task_receiver((sender2, receiver1));
 
 		taskref1.join()?;
-		taskref1.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let end = hpet.get_counter();
 
@@ -1116,7 +1098,6 @@ fn do_ipc_simple_inner_cycles(th: usize, nr: usize, child_core: Option<u8>) -> R
 		}
 		
 		taskref3.join()?;
-		taskref3.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let overhead = counter.diff();
 	counter.start()?;
@@ -1143,7 +1124,6 @@ fn do_ipc_simple_inner_cycles(th: usize, nr: usize, child_core: Option<u8>) -> R
 		simple_task_receiver((sender2, receiver1));
 
 		taskref1.join()?;
-		taskref1.take_exit_value().ok_or("could not retrieve exit value")?;
 
 	let end = counter.end()?;
 		

--- a/applications/channel_eval/src/lib.rs
+++ b/applications/channel_eval/src/lib.rs
@@ -102,8 +102,6 @@ fn test_multiple(iterations: usize) -> Result<(), &'static str> {
     t1.join()?;
     t2.join()?;
     info!("test_multiple(): Joined the sender and receiver tasks.");
-    let _t1_exit = t1.take_exit_value();
-    let _t2_exit = t2.take_exit_value();
     
     Ok(())
 }

--- a/applications/heap_eval/src/shbench.rs
+++ b/applications/heap_eval/src/shbench.rs
@@ -66,11 +66,6 @@ pub fn do_shbench() -> Result<(), &'static str> {
 
         let end = hpet.get_counter() - hpet_overhead;
 
-        // Don't want this to be part of the timing measurement
-        for thread in threads {
-            thread.take_exit_value();
-        }
-
         let diff = hpet_2_us(end - start);
         println!("[{}] shbench time: {} us", try, diff);
         tries.push(diff);

--- a/applications/heap_eval/src/threadtest.rs
+++ b/applications/heap_eval/src/threadtest.rs
@@ -61,11 +61,6 @@ pub fn do_threadtest() -> Result<(), &'static str> {
 
         let end = hpet.get_counter() - hpet_overhead;
 
-        // Don't want this to be part of the timing measurement
-        for thread in threads {
-            thread.take_exit_value();
-        }
-
         let diff = hpet_2_us(end - start);
         println!("[{}] threadtest time: {} us", try, diff);
         tries.push(diff);

--- a/applications/kill/src/lib.rs
+++ b/applications/kill/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate terminal_print;
-#[macro_use] extern crate debugit;
+// #[macro_use] extern crate debugit;
 
 extern crate task;
 extern crate runqueue;
@@ -18,7 +18,7 @@ pub fn main(args: Vec<String>) -> isize {
     opts.optflag("r", "reap", 
         "reap the task (consume its exit value) in addition to killing it, removing it from the task list."
     );
-    
+
     let matches = match opts.parse(&args) {
         Ok(m) => m,
         Err(_f) => {
@@ -26,11 +26,16 @@ pub fn main(args: Vec<String>) -> isize {
             return -1; 
         }
     };
-    
+
     if matches.opt_present("h") {
         return print_usage(opts);
     }
-    
+
+    println!("`kill` has temporarily been disabled because it needs to be reimplemented.");
+    return -1;
+}
+
+/*
     let reap = matches.opt_present("r");
 
     for task_id_str in matches.free.iter() {
@@ -98,8 +103,9 @@ fn kill_task(task_id: usize, reap: bool) -> Result<(), String> {
         Err(format!("Task ID {} does not exist", task_id))
     }
 }
+*/
 
-
+#[allow(dead_code)]
 fn print_usage(opts: Options) -> isize {
     let brief = format!("Usage: kill [OPTS] TASK_ID");
     println!("{}", opts.usage(&brief));

--- a/applications/rq_eval/src/lib.rs
+++ b/applications/rq_eval/src/lib.rs
@@ -132,7 +132,6 @@ fn run_whole(num_tasks: usize) -> Result<(), &'static str> {
 
     for t in &tasks {
         t.join()?;
-        let _ = t.take_exit_value();
     }
 
     let end = hpet.get_counter();
@@ -191,7 +190,7 @@ fn run_single(iterations: usize) -> Result<(), &'static str> {
 
     // cleanup the dummy task we created earlier
     taskref.mark_as_exited(Box::new(0usize))?;
-    taskref.take_exit_value();
+    taskref.join()?;
     
     Ok(())
 }

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -4,11 +4,11 @@
 //! To create new `Task`s, use the [`spawn`](../spawn/index.html) crate.
 //! 
 //! # Examples
-//! How to wait for a `Task` to complete (using `join()`) and get its exit value.
+//! How to wait for a `Task` to finish (using `join()`) and get its exit value.
 //! ```
-//! taskref.join(); // taskref is the task that we're waiting on
-//! if let Some(exit_result) = taskref.take_exit_value() {
-//!     match exit_result {
+//! // `taskref` is the task that we're waiting on
+//! if let Ok(exit_value) = taskref.join() {
+//!     match exit_value {
 //!         ExitValue::Completed(exit_value) => {
 //!             // here: the task ran to completion successfully, so it has an exit value.
 //!             // We should know the return type of this task, e.g., if `isize`,
@@ -23,7 +23,6 @@
 //!     }
 //! }
 //! ```
-//! 
 
 #![no_std]
 #![feature(panic_info_message)]
@@ -63,7 +62,7 @@ use alloc::{
     sync::Arc,
 };
 use crossbeam_utils::atomic::AtomicCell;
-use irq_safety::{MutexIrqSafe, interrupts_enabled, hold_interrupts};
+use irq_safety::{MutexIrqSafe, hold_interrupts};
 use memory::MmiRef;
 use stack::Stack;
 use kernel_config::memory::KERNEL_STACK_SIZE_IN_PAGES;
@@ -550,7 +549,7 @@ impl Task {
     /// * If `true`, another task holds the [`JoinableTaskRef`] object that was created
     ///   by [`TaskRef::new()`], which indicates that that other task is able to
     ///   wait for this task to exit and thus be able to obtain this task's exit value.
-    /// * If `false`, the `TaskJoiner` object was dropped, and therefore no other task
+    /// * If `false`, the [`JoinableTaskRef`] object was dropped, and therefore no other task
     ///   can join this task or obtain its exit value.
     /// 
     /// When a task is not joinable, it is considered to be an orphan
@@ -658,7 +657,9 @@ impl Task {
         self.inner.lock().restart_info.is_some()
     }
 
-    /// Takes ownership of this `Task`'s exit value and returns it,
+    /// An internal function intended for use cleaning up exited tasks.
+    ///
+    /// Retrieves and removes the `ExitValue` from this `Task` and returns it,
     /// if and only if this `Task` was in the `Exited` runstate.
     ///
     /// If this `Task` was in the `Exited` runstate, after invoking this,
@@ -670,8 +671,8 @@ impl Task {
     ///
     /// # Locking / Deadlock
     /// Obtains the lock on this `Task`'s inner state in order to mutate it.    
-    #[doc(alias("reap"))]
-    pub fn take_exit_value(&self) -> Option<ExitValue> {
+    #[doc(hidden)]
+    pub fn retrieve_exit_value(&self) -> Option<ExitValue> {
         if self.runstate.compare_exchange(RunState::Exited, RunState::Reaped).is_ok() {
             TASKLIST.lock().remove(&self.id);
             self.inner.lock().exit_value.take()
@@ -1114,27 +1115,27 @@ fn task_switch_inner(
 }
 
 
-/// Represents a joinable [`TaskRef`], created by [`TaskRef::new()`].
-/// Auto-derefs into a [`TaskRef`].
+/// A reference to a `Task` that can be `join`ed; auto-derefs into [`TaskRef`].
 ///
-/// This allows another task to:
-/// * [`join`] this task, i.e., wait for this task to finish executing,
-/// * to obtain its [exit value] after it has completed.
-/// 
+/// This allows another task to [`join`] this task, i.e., wait for this task
+/// to finish executing, and to obtain its [`ExitValue`] thereafter.
+///
 /// ## [`Drop`]-based Behavior
 /// The contained [`Task`] is joinable until this object is dropped.
 /// When dropped, this task will be marked as non-joinable and treated as an "orphan" task.
 /// This means that there is no way for another task to wait for it to complete
 /// or obtain its exit value.
 /// As such, this task will be auto-reaped after it exits (in order to avoid zombie tasks).
-/// 
+///
 /// ## Not `Clone`-able
-/// Due to the above drop-based behavior, this type must not implement `Clone`
+/// Due to the above drop-based behavior, this type does not implement `Clone`
 /// because it assumes there is only ever one `JoinableTaskRef` per task.
-/// 
-/// However, this type auto-derefs into an inner [`TaskRef`], which *can* be cloned,
-/// so you can easily call `.clone()` on it thanks to auto-deref semantics.
-/// 
+///
+/// However, this type auto-derefs into an inner [`TaskRef`],
+/// which *can* be cloned, so you can easily call `.clone()` on it.
+///
+/// [`join`]: [JoinableTaskRef::join]
+//
 // /// Note: this type is considered an internal implementation detail.
 // /// Instead, use the `TaskJoiner` type from the `spawn` crate, 
 // /// which is intended to be the public-facing interface for joining a task.
@@ -1152,32 +1153,23 @@ impl Deref for JoinableTaskRef {
 impl JoinableTaskRef {
     /// Busy-waits (spins in a loop) until this task has exited or has been killed.
     ///
-    /// Returns `Ok()` once this task has exited,
-    /// and `Err()` if there is a problem or interruption while waiting for it to exit. 
-    /// 
-    /// # Note
-    /// * You cannot call `join()` on the current task, because a task cannot wait for itself to finish running. 
-    ///   This will result in an `Err()` being immediately returned.
-    /// * You cannot call `join()` with interrupts disabled, because it will result in permanent deadlock
-    ///   (well, this is only true if the requested `task` is running on the same cpu...  but good enough for now).
-    pub fn join(&self) -> Result<(), &'static str> {
-        let self_is_current_task = with_current_task(|t| t == &self.task) 
-            .map_err(|_| "join(): failed to check what current task is")?;
-        if self_is_current_task {
-            return Err("BUG: cannot call `join()` on yourself (the current task)");
-        }
-
-        if !interrupts_enabled() {
-            return Err("BUG: cannot call join() with interrupts disabled; it will cause deadlock.")
-        }
-        
+    /// # Return
+    /// * `Ok` containing this `Task`'s [`ExitValue`] once this task has exited.
+    ///   * This includes cases where this `Task` failed or was killed.
+    /// * `Err` if there was a problem while waiting for this task to exit.
+    ///   * This does *not* include cases where this `Task` failed or was killed,
+    ///     rather only cases where the `join` operation itself failed.
+    #[doc(alias("reap", "exit"))]
+    pub fn join(&self) -> Result<ExitValue, &'static str> {
         // First, wait for this Task to be marked as Exited (no longer runnable).
         while !self.0.has_exited() { }
 
         // Then, wait for it to actually stop running on any CPU core.
         while self.0.is_running() { }
 
-        Ok(())
+        self.task
+            .retrieve_exit_value()
+            .ok_or("BUG: `join()` could not retrieve `ExitValue` after task had exited.")
     }
 }
 impl Drop for JoinableTaskRef {
@@ -1312,9 +1304,13 @@ impl TaskRef {
             // Corner case: if the task isn't currently running (as with killed tasks), 
             // we must clean it up now rather than in `task_switch()`, as it will never be scheduled in again.
             if !self.0.is_running() {
-                warn!("\n\ninternal_exit(): [untested] de-initing current task TLS variable for non-running task {}", &*self.0);
-                let _taskref_in_tls = deinit_current_task();
-                drop(_taskref_in_tls);
+                todo!("Unhandled scenario: internal_exit(): task {:?} wasn't running \
+                    but its current task TLS variable needs to be cleaned up!", self.0);
+                // Note: we cannot call `deinit_current_task()` here because if this task
+                //       isn't running, then it's definitely not the current task.
+                //
+                // let _taskref_in_tls = deinit_current_task();
+                // drop(_taskref_in_tls);
             }
         }
 
@@ -1554,33 +1550,5 @@ mod tls_current_task {
         } else {
             Err(value)
         }
-    }
-
-    /// De-initializes the current task TLS variable, ensuring that the task can be dropped.
-    ///
-    /// This function being public is completely safe, as it will only ever execute
-    /// once per task, typically after the task has exited and is being cleaned up.
-    ///
-    /// This returns an error if:
-    /// * The current task has not yet exited.
-    /// * The current task TLS variable hasn't been initialized.
-    /// * The current task TLS variable is already currently borrowed.
-    #[doc(hidden)]
-    pub(crate) fn deinit_current_task() -> Result<TaskRef, ()> {
-        if with_current_task(|t| !t.has_exited()).unwrap_or(true) {
-            return Err(());
-        }
-        CURRENT_TASK.try_borrow_mut()
-            .map_err(|_| {
-                error!("deinit_current_task(): couldn't mutably borrow CURRENT_TASK, task ID {}", get_my_current_task_id());
-                ()
-            })
-            .and_then(|mut t_opt| t_opt
-                .take()
-                .ok_or_else(|| {
-                    warn!("deinit_current_task(): CURRENT_TASK was `None`, task ID {}", get_my_current_task_id());
-                    ()
-                })
-            )
     }
 }


### PR DESCRIPTION
* This removes the `take_exit_value()` function, and instead combines that functionality directy into `join()`.