### PR TITLE
Bootstrap initial page table from `CR3`, not `.page_table` section

### DIFF
--- a/kernel/memory/src/paging/mod.rs
+++ b/kernel/memory/src/paging/mod.rs
@@ -234,7 +234,7 @@ pub fn init(
     debug!("{:X?}\n{:X?}", aggregated_section_memory_bounds, _sections_memory_bounds);
     
     // bootstrap a PageTable from the currently-loaded page table
-    let current_active_p4 = frame_allocator::allocate_frames_at(aggregated_section_memory_bounds.page_table.start.1, 1)?;
+    let current_active_p4 = frame_allocator::allocate_frames_at(get_current_p4().start_address(), 1)?;
     let mut page_table = PageTable::from_current(current_active_p4)?;
     debug!("Bootstrapped initial {:?}", page_table);
 

--- a/kernel/memory/src/paging/mod.rs
+++ b/kernel/memory/src/paging/mod.rs
@@ -234,7 +234,8 @@ pub fn init(
     debug!("{:X?}\n{:X?}", aggregated_section_memory_bounds, _sections_memory_bounds);
     
     // bootstrap a PageTable from the currently-loaded page table
-    let current_active_p4 = frame_allocator::allocate_frames_at(get_current_p4().start_address(), 1)?;
+    let current_active_p4 = frame_allocator::allocate_frames_at(get_current_p4().start_address(), 1)
+        .map_err(|_| "Failed to allocate frame for initial page table; is it merged with another section?")?;
     let mut page_table = PageTable::from_current(current_active_p4)?;
     debug!("Bootstrapped initial {:?}", page_table);
 


### PR DESCRIPTION
Change the paging initialiser to bootstrap the bootloader page table from the `CR3` register rather than the `.page_table` section as that won't be present in the upcoming UEFI port.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>