### PR TITLE
Add option to use RSDP address provided by bootloader

### DIFF
--- a/kernel/acpi/rsdp/src/lib.rs
+++ b/kernel/acpi/rsdp/src/lib.rs
@@ -84,9 +84,8 @@ impl Rsdp {
         let pages = allocate_pages_by_bytes(size).ok_or("couldn't allocate pages")?;
         let frames = allocate_frames_by_bytes_at(address, size)
             .map_err(|_e| "couldn't allocate physical frames for RSDP")?;
-        let frames_start = frames.start_address().value();
         let mapped_pages = page_table.map_allocated_pages_to(pages, frames, PteFlags::new().valid(true))?;
-        mapped_pages.into_borrowed((address - frames_start).value()).map_err(|(_, e)| e)
+        mapped_pages.into_borrowed((address.frame_offset()).value()).map_err(|(_, e)| e)
     }
 
     /// Returns the `PhysicalAddress` of the RSDT or XSDT.

--- a/kernel/acpi/rsdp/src/lib.rs
+++ b/kernel/acpi/rsdp/src/lib.rs
@@ -85,7 +85,7 @@ impl Rsdp {
         let frames = allocate_frames_by_bytes_at(address, size)
             .map_err(|_e| "couldn't allocate physical frames for RSDP")?;
         let mapped_pages = page_table.map_allocated_pages_to(pages, frames, PteFlags::new().valid(true))?;
-        mapped_pages.into_borrowed((address.frame_offset()).value()).map_err(|(_, e)| e)
+        mapped_pages.into_borrowed(address.frame_offset()).map_err(|(_, e)| e)
     }
 
     /// Returns the `PhysicalAddress` of the RSDT or XSDT.

--- a/kernel/acpi/src/lib.rs
+++ b/kernel/acpi/src/lib.rs
@@ -42,7 +42,7 @@ pub fn init(rsdp_address: Option<PhysicalAddress>, page_table: &mut PageTable) -
     // which contains the physical address of the RSDT/XSDG (Root/Extended System Descriptor Table).
     let rsdp = match rsdp_address {
         Some(rsdp_address) => {
-            debug!("using provided rsdp address {:#X}", rsdp_address);
+            debug!("Using bootloader-provided RSDP address {:#X}", rsdp_address);
             Rsdp::from_address(rsdp_address, page_table)
         },
         None => Rsdp::get_rsdp(page_table),

--- a/kernel/acpi/src/lib.rs
+++ b/kernel/acpi/src/lib.rs
@@ -40,13 +40,11 @@ pub fn get_acpi_tables() -> &'static Mutex<AcpiTables> {
 pub fn init(rsdp_address: Option<PhysicalAddress>, page_table: &mut PageTable) -> Result<(), &'static str> {
     // The first step is to search for the RSDP (Root System Descriptor Pointer),
     // which contains the physical address of the RSDT/XSDG (Root/Extended System Descriptor Table).
-    let rsdp = match rsdp_address {
-        Some(rsdp_address) => {
-            debug!("Using bootloader-provided RSDP address {:#X}", rsdp_address);
-            Rsdp::from_address(rsdp_address, page_table)
-        },
-        None => Rsdp::get_rsdp(page_table),
-    }?;
+    let rsdp = rsdp_address
+        // This error message will be overwritten by the or_else statement.
+        .ok_or("")
+        .and_then(|rsdp_address| Rsdp::from_address(rsdp_address, page_table))
+        .or_else(|_| Rsdp::get_rsdp(page_table))?;
     let rsdt_phys_addr = rsdp.sdt_address();
     debug!("RXSDT is located in Frame {:#X}", rsdt_phys_addr);
 

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -57,6 +57,7 @@ use kernel_config::memory::KERNEL_STACK_SIZE_IN_PAGES;
 use irq_safety::enable_interrupts;
 use stack::Stack;
 use no_drop::NoDrop;
+use memory::PhysicalAddress;
 
 
 #[cfg(mirror_log_to_vga)]
@@ -86,6 +87,7 @@ pub fn init(
     bsp_initial_stack: NoDrop<Stack>,
     ap_start_realmode_begin: VirtualAddress,
     ap_start_realmode_end: VirtualAddress,
+    rsdp_address: Option<PhysicalAddress>,
 ) -> Result<(), &'static str> {
     #[cfg(mirror_log_to_vga)]
     {
@@ -99,7 +101,7 @@ pub fn init(
     // info!("TSC frequency calculated: {}", _tsc_freq);
 
     // now we initialize early driver stuff, like APIC/ACPI
-    device_manager::early_init(kernel_mmi_ref.lock().deref_mut())?;
+    device_manager::early_init(rsdp_address, kernel_mmi_ref.lock().deref_mut())?;
 
     // initialize the rest of the BSP's interrupt stuff, including TSS & GDT
     let (double_fault_stack, privilege_stack) = {

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -37,6 +37,7 @@ use alloc::vec::Vec;
 use io::{ByteReaderWriterWrapper, LockableIo, ReaderWriter};
 use serial_port::{SerialPortAddress, take_serial_port_basic};
 use storage_manager::StorageDevice;
+use memory::PhysicalAddress;
 
 /// A randomly chosen IP address that must be outside of the DHCP range.
 /// TODO: use DHCP to acquire an IP address.
@@ -51,13 +52,16 @@ const DEFAULT_GATEWAY_IP: [u8; 4] = [10, 0, 2, 2]; // the default QEMU user-slir
 /// This includes:
 /// * local APICs ([`apic`]),
 /// * [`acpi`] tables for system configuration info, including the IOAPIC.
-pub fn early_init(kernel_mmi: &mut MemoryManagementInfo) -> Result<(), &'static str> {
+pub fn early_init(
+    rsdp_address: Option<PhysicalAddress>,
+    kernel_mmi: &mut MemoryManagementInfo
+) -> Result<(), &'static str> {
     // First, initialize the local APIC hardware such that we can populate
     // and initialize each LocalAPIC discovered in the ACPI table initialization routine below.
     apic::init();
     
     // Then, parse the ACPI tables to acquire system configuration info.
-    acpi::init(&mut kernel_mmi.page_table)?;
+    acpi::init(rsdp_address, &mut kernel_mmi.page_table)?;
 
     Ok(())
 }

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -139,7 +139,7 @@ pub extern "C" fn nano_core_start(
         .map(|signature| signature as *const _ as *const () as usize)
         .and_then(|rsdp_address| PhysicalAddress::new(rsdp_address));
 
-    println_raw!("nano_core_start(): acquired RSDP address: {:#?}", rsdp_address);
+    println_raw!("nano_core_start(): bootloader-provided RSDP address: {:X?}", rsdp_address);
 
     // init memory management: set up stack with guard page, heap, kernel text/data mappings, etc
     let (

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -41,6 +41,7 @@ use core::ops::DerefMut;
 use memory::VirtualAddress;
 use kernel_config::memory::KERNEL_OFFSET;
 use serial_port_basic::{take_serial_port, SerialPortAddress};
+use memory::PhysicalAddress;
 
 /// Used to obtain information about this build of Theseus.
 mod build_info {
@@ -130,6 +131,16 @@ pub extern "C" fn nano_core_start(
     );
     println_raw!("nano_core_start(): booted via multiboot2 with boot info at {:#X}.", multiboot_information_virtual_address); 
 
+    let rsdp_address = boot_info
+        .rsdp_v2_tag()
+        .map(|tag| tag.signature())
+        .or_else(|| boot_info.rsdp_v1_tag().map(|tag| tag.signature()))
+        .and_then(|utf8_result| utf8_result.ok())
+        .map(|signature| signature as *const _ as *const () as usize)
+        .and_then(|rsdp_address| PhysicalAddress::new(rsdp_address));
+
+    println_raw!("nano_core_start(): acquired RSDP address: {:#?}", rsdp_address);
+
     // init memory management: set up stack with guard page, heap, kernel text/data mappings, etc
     let (
         kernel_mmi_ref,
@@ -214,7 +225,7 @@ pub extern "C" fn nano_core_start(
     println_raw!("nano_core_start(): invoking the captain...");     
     #[cfg(not(loadable))] {
         try_exit!(
-            captain::init(kernel_mmi_ref, identity_mapped_pages, stack, ap_realmode_begin, ap_realmode_end)
+            captain::init(kernel_mmi_ref, identity_mapped_pages, stack, ap_realmode_begin, ap_realmode_end, rsdp_address)
         );
     }
     #[cfg(loadable)] {
@@ -229,11 +240,11 @@ pub extern "C" fn nano_core_start(
         );
         info!("The nano_core (in loadable mode) is invoking the captain init function: {:?}", section.name);
 
-        type CaptainInitFunc = fn(MmiRef, NoDrop<Vec<MappedPages>>, NoDrop<stack::Stack>, VirtualAddress, VirtualAddress) -> Result<(), &'static str>;
+        type CaptainInitFunc = fn(MmiRef, NoDrop<Vec<MappedPages>>, NoDrop<stack::Stack>, VirtualAddress, VirtualAddress, Option<PhysicalAddress>) -> Result<(), &'static str>;
         let func: &CaptainInitFunc = try_exit!(unsafe { section.as_func() });
 
         try_exit!(
-            func(kernel_mmi_ref, identity_mapped_pages, stack, ap_realmode_begin, ap_realmode_end)
+            func(kernel_mmi_ref, identity_mapped_pages, stack, ap_realmode_begin, ap_realmode_end, rsdp_address)
         );
     }
 


### PR DESCRIPTION
I wasn't able to actually test the changes since GRUB doesn't provide the RSDP address.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>