### PR TITLE
Switch to storing run queues in boxed array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,7 @@ dependencies = [
  "ota_update_client",
  "page_attribute_table",
  "print",
+ "runqueue",
  "scheduler",
  "simd_personality",
  "spawn",
@@ -2888,10 +2889,10 @@ dependencies = [
 name = "runqueue_priority"
 version = "0.1.0"
 dependencies = [
- "atomic_linked_list",
  "log",
  "mutex_preemption",
  "single_simd_task_optimization",
+ "spin 0.9.4",
  "task",
 ]
 
@@ -2899,9 +2900,9 @@ dependencies = [
 name = "runqueue_realtime"
 version = "0.1.0"
 dependencies = [
- "atomic_linked_list",
  "log",
  "mutex_preemption",
+ "spin 0.9.4",
  "task",
 ]
 
@@ -2909,10 +2910,10 @@ dependencies = [
 name = "runqueue_round_robin"
 version = "0.1.0"
 dependencies = [
- "atomic_linked_list",
  "log",
  "mutex_preemption",
  "single_simd_task_optimization",
+ "spin 0.9.4",
  "task",
 ]
 

--- a/applications/scheduler_eval/src/lib.rs
+++ b/applications/scheduler_eval/src/lib.rs
@@ -10,7 +10,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 
-pub fn main(_args: Vec<String>) -> (){
+pub fn main(_args: Vec<String>) -> isize {
     let taskref1 = spawn::new_task_builder(test1 ,1)
         .name(String::from("test1"))
         .pin_on_core(1)
@@ -60,6 +60,8 @@ pub fn main(_args: Vec<String>) -> (){
     taskref1.join().expect("Task 1 join failed");
     taskref2.join().expect("Task 2 join failed");
     taskref3.join().expect("Task 3 join failed");
+
+    0
 }
 
 fn test1(_a: u32) -> u32 {

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -90,7 +90,6 @@ pub fn kstart_ap(
     // Now that the Local APIC has been initialized for this CPU, we can initialize the
     // task management subsystem and create the idle task for this CPU.
     let bootstrap_task = spawn::init(kernel_mmi_ref.clone(), apic_id, this_ap_stack).unwrap();
-    spawn::create_idle_task().unwrap();
 
     // The PAT must be initialized explicitly on every CPU,
     // but it is not a fatal error if it doesn't exist.
@@ -110,8 +109,8 @@ pub fn kstart_ap(
     // NOTE: nothing below here is guaranteed to run again!
     // ****************************************************
 
-    scheduler::schedule();
-    loop { 
-        error!("BUG: ap_start::kstart_ap(): CPU {} bootstrap task was rescheduled after being dead!", apic_id);
+    loop {
+        // The core may enter this loop for a bit prior to the captain creating the idle tasks.
+        spawn::idle_task_entry(apic_id);
     }
 }

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -103,5 +103,8 @@ path = "../task_fs"
 [dependencies.multiple_heaps]
 path = "../multiple_heaps"
 
+[dependencies.runqueue]
+path = "../runqueue"
+
 [lib]
 crate-type = ["rlib"]

--- a/kernel/runqueue/src/lib.rs
+++ b/kernel/runqueue/src/lib.rs
@@ -28,9 +28,11 @@ use task::TaskRef;
 use runqueue::RunQueue;
 
 
-/// Creates a new `RunQueue` for the given core, which is an `apic_id`.
-pub fn init(which_core: u8) -> Result<(), &'static str> {
-    RunQueue::init(which_core)
+/// Initialises `num_cores` runqueues.
+///
+/// `num_cores` must be equal to the largest CPU ID i.e. `num_cores` must include disabled cores.
+pub fn init(num_cores: u8) -> Result<(), &'static str> {
+    RunQueue::init(num_cores)
 }
 
 /// Returns the `RunQueue` of the given core, which is an `apic_id`.

--- a/kernel/runqueue_priority/Cargo.toml
+++ b/kernel/runqueue_priority/Cargo.toml
@@ -6,12 +6,10 @@ version = "0.1.0"
 
 [dependencies]
 log = "0.4.8"
+spin = "0.9"
 
 [dependencies.mutex_preemption]
 path = "../mutex_preemption"
-
-[dependencies.atomic_linked_list]
-path = "../../libs/atomic_linked_list"
 
 [dependencies.task]
 path = "../task"

--- a/kernel/runqueue_realtime/Cargo.toml
+++ b/kernel/runqueue_realtime/Cargo.toml
@@ -4,17 +4,15 @@ name = "runqueue_realtime"
 description = "Functions and types for handling runqueues in a realtime scheduling context"
 version = "0.1.0"
 
+[dependencies]
+log = "0.4.8"
+spin = "0.9"
+
 [dependencies.task]
 path = "../task"
 
 [dependencies.mutex_preemption]
 path = "../mutex_preemption"
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.atomic_linked_list]
-path = "../../libs/atomic_linked_list"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/runqueue_round_robin/Cargo.toml
+++ b/kernel/runqueue_round_robin/Cargo.toml
@@ -6,12 +6,10 @@ version = "0.1.0"
 
 [dependencies]
 log = "0.4.8"
+spin = "0.9"
 
 [dependencies.mutex_preemption]
 path = "../mutex_preemption"
-
-[dependencies.atomic_linked_list]
-path = "../../libs/atomic_linked_list"
 
 [dependencies.task]
 path = "../task"

--- a/kernel/runqueue_round_robin/src/lib.rs
+++ b/kernel/runqueue_round_robin/src/lib.rs
@@ -3,22 +3,24 @@
 //! that is used for scheduling purposes.
 //! 
 
+#![feature(new_uninit)]
 #![no_std]
 
 extern crate alloc;
 #[macro_use] extern crate log;
 extern crate mutex_preemption;
-extern crate atomic_linked_list;
 extern crate task;
+extern crate spin;
 
 #[cfg(single_simd_task_optimization)]
 extern crate single_simd_task_optimization;
 
+use alloc::boxed::Box;
 use alloc::collections::VecDeque;
 use mutex_preemption::RwLockPreempt;
-use atomic_linked_list::atomic_map::AtomicMap;
 use task::TaskRef;
 use core::ops::{Deref, DerefMut};
+use spin::Once;
 
 /// A cloneable reference to a `Taskref` that exposes more methods
 /// related to task scheduling
@@ -64,7 +66,7 @@ impl RoundRobinTaskRef {
     /// Creates a new `RoundRobinTaskRef` that wraps the given `TaskRef`.
     pub fn new(taskref: TaskRef) -> RoundRobinTaskRef {
         RoundRobinTaskRef {
-            taskref: taskref,
+            taskref,
             context_switches: 0,
         }
     }
@@ -77,7 +79,7 @@ impl RoundRobinTaskRef {
 
 /// There is one runqueue per core, each core only accesses its own private runqueue
 /// and allows the scheduler to select a task from that runqueue to schedule in.
-pub static RUNQUEUES: AtomicMap<u8, RwLockPreempt<RunQueue>> = AtomicMap::new();
+pub static RUNQUEUES: Once<Box<[RwLockPreempt<RunQueue>]>> = Once::new();
 
 /// A list of references to `Task`s (`RoundRobinTaskRef`s). 
 /// This is used to store the `Task`s (and associated scheduler related data) 
@@ -120,12 +122,22 @@ impl RunQueue {
         })
     }
 
-    /// Creates a new `RunQueue` for the given core, which is an `apic_id`.
-    pub fn init(which_core: u8) -> Result<(), &'static str> {
-        trace!("Created runqueue (round robin) for core {}", which_core);
-        let new_rq = RwLockPreempt::new(RunQueue {
-            core: which_core,
-            queue: VecDeque::new(),
+    /// Initialises `num_cores` runqueues.
+    ///
+    /// `num_cores` must be equal to the largest CPU ID i.e. `num_cores` must include disabled cores.
+    pub fn init(num_cores: u8) -> Result<(), &'static str> {
+        trace!("Created {} runqueues (round robin)", num_cores);
+        RUNQUEUES.call_once(|| {
+            let mut runqueues = Box::new_uninit_slice(num_cores.into());
+            for core in 0..num_cores {
+                let runqueue = RwLockPreempt::new(RunQueue {
+                    core,
+                    queue: VecDeque::new(),
+                });
+                runqueues[usize::from(core)].write(runqueue);
+            }
+            // SAFETY: We just initialised all the runqueues.
+            unsafe { runqueues.assume_init() }
         });
 
         #[cfg(runqueue_spillful)] 
@@ -133,19 +145,12 @@ impl RunQueue {
             task::RUNQUEUE_REMOVAL_FUNCTION.call_once(|| RunQueue::remove_task_from_within_task);
         }
 
-        if RUNQUEUES.insert(which_core, new_rq).is_some() {
-            error!("BUG: RunQueue::init(): runqueue already exists for core {}!", which_core);
-            Err("runqueue already exists for this core")
-        }
-        else {
-            // there shouldn't already be a RunQueue for this core
-            Ok(())
-        }
+        Ok(())
     }
 
     /// Returns the `RunQueue` for the given core, which is an `apic_id`.
     pub fn get_runqueue(which_core: u8) -> Option<&'static RwLockPreempt<RunQueue>> {
-        RUNQUEUES.get(&which_core)
+        RUNQUEUES.get()?.get(usize::from(which_core))
     }
 
 
@@ -160,7 +165,7 @@ impl RunQueue {
     fn get_least_busy_runqueue() -> Option<&'static RwLockPreempt<RunQueue>> {
         let mut min_rq: Option<(&'static RwLockPreempt<RunQueue>, usize)> = None;
 
-        for (_, rq) in RUNQUEUES.iter() {
+        for rq in RUNQUEUES.get()?.iter() {
             let rq_size = rq.read().queue.len();
 
             if let Some(min) = min_rq {
@@ -180,7 +185,7 @@ impl RunQueue {
     /// and adds the given `Task` reference to that core's runqueue.
     pub fn add_task_to_any_runqueue(task: TaskRef) -> Result<(), &'static str> {
         let rq = RunQueue::get_least_busy_runqueue()
-            .or_else(|| RUNQUEUES.iter().next().map(|r| r.1))
+            .or_else(|| RUNQUEUES.get()?.iter().next())
             .ok_or("couldn't find any runqueues to add the task to!")?;
 
         rq.write().add_task(task)
@@ -255,7 +260,7 @@ impl RunQueue {
     /// 
     /// This is a brute force approach that iterates over all runqueues. 
     pub fn remove_task_from_all(task: &TaskRef) -> Result<(), &'static str> {
-        for (_core, rq) in RUNQUEUES.iter() {
+        for rq in RUNQUEUES.get().ok_or("Run queues not initialised")?.iter() {
             rq.write().remove_task(task)?;
         }
         Ok(())
@@ -268,7 +273,10 @@ impl RunQueue {
         #[cfg(not(rq_eval))]
         warn!("remove_task_from_within_task(): core {}, task: {:?}", core, task);
         task.set_on_runqueue(None);
-        RUNQUEUES.get(&core)
+        RUNQUEUES
+            .get()
+            .ok_or("Run queues not initialised")?
+            .get(usize::from(core))
             .ok_or("Couldn't get runqueue for specified core")
             .and_then(|rq| {
                 // Instead of calling `remove_task`, we directly call `remove_internal`

--- a/kernel/scheduler_realtime/src/lib.rs
+++ b/kernel/scheduler_realtime/src/lib.rs
@@ -20,13 +20,7 @@ pub use runqueue_realtime::set_periodicity;
 /// This defines the realtime scheduler policy.
 /// Returns None if there is no schedule-able task
 pub fn select_next_task(apic_id: u8) -> Option<TaskRef> {
-    let mut runqueue_locked = match RunQueue::get_runqueue(apic_id) {
-        Some(rq) => rq.write(),
-        _ => {
-            error!("BUG: select_next_task_round_robin(): couldn't get runqueue for core {}", apic_id);
-            return None;
-        }
-    };
+    let mut runqueue_locked = RunQueue::get_runqueue(apic_id)?.write();
 
     let mut idle_task_index: Option<usize> = None;
     let mut chosen_task_index: Option<usize> = None;

--- a/kernel/scheduler_round_robin/src/lib.rs
+++ b/kernel/scheduler_round_robin/src/lib.rs
@@ -17,14 +17,7 @@ use runqueue_round_robin::RunQueue;
 /// This defines the round robin scheduler policy.
 /// Returns None if there is no schedule-able task
 pub fn select_next_task(apic_id: u8) -> Option<TaskRef> {
-
-    let mut runqueue_locked = match RunQueue::get_runqueue(apic_id) {
-        Some(rq) => rq.write(),
-        _ => {
-            error!("BUG: select_next_task_round_robin(): couldn't get runqueue for core {}", apic_id); 
-            return None;
-        }
-    };
+    let mut runqueue_locked = RunQueue::get_runqueue(apic_id)?.write();
     
     let mut idle_task_index: Option<usize> = None;
     let mut chosen_task_index: Option<usize> = None;


### PR DESCRIPTION
Removes the dependency on `atomic_linked_list` which we're trying to phase out. However, the change means we must to initialise the runqueues all at once. We do this after initialising the APs and so we can't add the APs' bootstrap tasks to the runqueue as it doesn't yet exist.

I'm not sure bootstrap tasks are strictly necessary any more, but I'll leave that for another PR.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>