### PR TITLE
Switch to relaxed ordering for the task ID counter

### DIFF
--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -480,7 +480,7 @@ impl Task {
 
         // we should re-use old task IDs again, instead of simply blindly counting up
         // TODO FIXME: or use random values to avoid state spill
-        let task_id = TASKID_COUNTER.fetch_add(1, Ordering::Acquire);
+        let task_id = TASKID_COUNTER.fetch_add(1, Ordering::Relaxed);
 
         // Obtain a new copied instance of the TLS data image for this task.
         let tls_area = namespace.get_tls_initializer_data();


### PR DESCRIPTION
Each task ID is guaranteed to see a unique value.

<https://en.cppreference.com/w/cpp/atomic/memory_order#Relaxed_ordering>
<https://www.reddit.com/r/rust/comments/aeii1i/is_memory_orderingrelaxed_sufficient_to_generate/>

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>