### PR TITLE
Synchronize memory when spawning and joining tasks

### DIFF
--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -16,7 +16,7 @@
 #[macro_use] extern crate alloc;
 #[macro_use] extern crate log;
 
-use core::{marker::PhantomData, mem, ops::Deref};
+use core::{marker::PhantomData, mem, ops::Deref, sync::atomic::{fence, Ordering}};
 use alloc::{
     boxed::Box,
     string::{String, ToString},
@@ -347,6 +347,8 @@ impl<F, A, R> TaskBuilder<F, A, R>
 
     /// Finishes this `TaskBuilder` and spawns the new task as described by its builder functions.
     ///
+    /// Synchronizes memory with respect to the spawned task.
+    ///
     /// This merely creates the new task and makes it `Runnable`.
     /// It does not switch to it immediately; that will happen on the next scheduler invocation.
     #[inline(never)]
@@ -405,6 +407,8 @@ impl<F, A, R> TaskBuilder<F, A, R>
             error!("BUG: TaskBuilder::spawn(): Fatal Error: TASKLIST already contained a task with the new task's ID! {:?}", _existing_task);
             return Err("BUG: TASKLIST a contained a task with the new task's ID");
         }
+
+        fence(Ordering::Release);
         
         if let Some(core) = self.pin_on_core {
             runqueue::add_task_to_specific_runqueue(core, task_ref.clone())?;
@@ -684,6 +688,7 @@ where
     drop(recovered_preemption_guard);
     enable_interrupts();
 
+    fence(Ordering::Acquire);
     // Now we actually invoke the entry point function that this Task was spawned for,
     // catching a panic if one occurs.
     catch_unwind::catch_unwind_with_arg(task_entry_func, task_arg)
@@ -852,6 +857,9 @@ fn task_cleanup_final_internal(current_task: &TaskRef) {
         let _exit_value = current_task.retrieve_exit_value();
         // trace!("Reaped orphaned task {:?}, {:?}", current_task, _exit_value);
     }
+
+    // Fourth, synchronise memory.
+    fence(Ordering::Release)
 }
 
 

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -53,7 +53,7 @@ use core::{
     hash::{Hash, Hasher},
     ops::Deref,
     panic::PanicInfo,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence},
     task::Waker,
 };
 use alloc::{
@@ -1193,6 +1193,8 @@ impl Deref for JoinableTaskRef {
 impl JoinableTaskRef {
     /// Busy-waits (spins in a loop) until this task has exited or has been killed.
     ///
+    /// Synchronizes memory with respect to the joined task.
+    ///
     /// # Return
     /// * `Ok` containing this `Task`'s [`ExitValue`] once this task has exited.
     ///   * This includes cases where this `Task` failed or was killed.
@@ -1206,6 +1208,8 @@ impl JoinableTaskRef {
 
         // Then, wait for it to actually stop running on any CPU core.
         while self.0.is_running() { }
+
+        fence(Ordering::Acquire);
 
         self.task
             .retrieve_exit_value()

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -1209,7 +1209,8 @@ impl JoinableTaskRef {
         // Then, wait for it to actually stop running on any CPU core.
         while self.0.is_running() { }
 
-        // This synchronises with the release fence in the thread's entry.
+        // This synchronizes with the release fence from when this task first ran
+        // (in `spawn::task_wrapper()`).
         fence(Ordering::Acquire);
 
         self.task

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -53,7 +53,7 @@ use core::{
     hash::{Hash, Hasher},
     ops::Deref,
     panic::PanicInfo,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence},
     task::Waker,
 };
 use alloc::{
@@ -1193,6 +1193,8 @@ impl Deref for JoinableTaskRef {
 impl JoinableTaskRef {
     /// Busy-waits (spins in a loop) until this task has exited or has been killed.
     ///
+    /// Synchronizes memory with respect to the joined task.
+    ///
     /// # Return
     /// * `Ok` containing this `Task`'s [`ExitValue`] once this task has exited.
     ///   * This includes cases where this `Task` failed or was killed.
@@ -1206,6 +1208,8 @@ impl JoinableTaskRef {
 
         // Then, wait for it to actually stop running on any CPU core.
         while self.0.is_running() { }
+
+        fence(Ordering::SeqCst);
 
         self.task
             .retrieve_exit_value()


### PR DESCRIPTION
This is necessary for the following to always work:
```rust
static COUNTER: AtomicUsize = AtomicUsize::new(0);
COUNTER.fetch_add(1, Ordering::Relaxed);
spawn(|| {
    let value = COUNTER.load(1, Ordering::Relaxed);
    assert_eq!(value, 1);
    COUNTER.store(2, Ordering::Relaxed);
}).join();
assert_eq!(COUNTER.load(Ordering::Relaxed), 2);
```

As a side note, if the spawned closure used `fetch_add`, the assert
inside the closure would always succeed even without this PR, as read-
modify-write are [always guaranteed to read the last value][1].

The fence in the task cleanup is only necessary if the task is being
joined on but shrug.

TBH, I'm not sure about the fence orderings, so I've made them all
`SeqCst`.

A bunch of related links:
<https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_12>:
> The following functions synchronize memory with respect to other
> threads:
> pthread_create()
> pthread_join()

<https://en.cppreference.com/w/cpp/thread/thread/thread>
> The completion of the invocation of the constructor synchronizes-with
> (as defined in std::memory_order) the beginning of the invocation of
> the copy of f on the new thread of execution.

<https://en.cppreference.com/w/cpp/thread/thread/join>
> The completion of the thread identified by *this synchronizes with the
> corresponding successful return from join().

<https://www.modernescpp.com/index.php/relaxed-semantic>
> Thread creation is one synchronisation point. The other
> synchronisation point is the t.join() call in line 24. 

<https://comp.programming.threads.narkive.com/qS8xuYea/memory-barrier-implicit-in-pthread-create>
> According to the unwritten rules, all memory actions visible before
> pthread_create are visible to the created thread. And all memory
> actions visible before pthread_exit are visible to the thread that
> executed the pthread_join.

<https://stackoverflow.com/questions/9224542/is-a-memory-barrier-required-if-a-second-thread-waits-for-termination-of-the-fir>
> the API used to wait for thread termination would need to use memory
> barriers for its own purposes

<https://stackoverflow.com/questions/22347856/pthread-create3-and-memory-synchronization-guarantee-in-smp-architectures>
>> is there implied memory barrier before the thread starts running the
>> thread function so that it unfailingly sees the memory modifications
>> synchronized by pthread_create()?
>
> Yes.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>

[1]: https://eel.is/c++draft/atomics#order-10