### PR TITLE
Specify recursive copy when copying dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ endif
 	@rm -rf $(THESEUS_BUILD_TOML)
 	@cp -f $(CFG_DIR)/$(TARGET).json  $(DEPS_BUILD_DIR)/
 	@mkdir -p $(HOST_DEPS_DIR)
-	@cp -f ./target/$(BUILD_MODE)/deps/*  $(HOST_DEPS_DIR)/
+	@cp -rf ./target/$(BUILD_MODE)/deps/*  $(HOST_DEPS_DIR)/
 	@echo -e 'target = "$(TARGET)"' >> $(THESEUS_BUILD_TOML)
 	@echo -e 'sysroot = "./sysroot"' >> $(THESEUS_BUILD_TOML)
 	@echo -e 'rustflags = "$(RUSTFLAGS)"' >> $(THESEUS_BUILD_TOML)


### PR DESCRIPTION
The build sometimes fails with:
```
cp: -r not specified; omitting directory './target/release/deps/rmetaMwvJeM'
make: *** [Makefile:208: build] Error 1
```

This PR fixes that. I don't think the change has any impact on the operating system.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>