### PR TITLE
Use `theseus_features/everything` to specify a full build of all crates

### DIFF
--- a/.github/workflows/check-clippy.yaml
+++ b/.github/workflows/check-clippy.yaml
@@ -21,6 +21,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: .
         run: |
-          printf "cargo clippy -q -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target cfg/x86_64-unknown-theseus.json --workspace --all-features -- -A clippy::all " > cmd.txt;
+          printf "cargo clippy -q -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target cfg/x86_64-unknown-theseus.json --workspace --features theseus_features/everything -- -A clippy::all " > cmd.txt;
           grep -v "#" lints.txt | sed 's/^/-D clippy::/g' | tr -d '\r' | tr '\n' ' ' >> cmd.txt
           bash cmd.txt;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "ota_update_client"

--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,10 @@ export override RUSTFLAGS += $(patsubst %,--cfg %, $(THESEUS_CONFIG))
 
 
 ### Convenience targets for building the entire Theseus workspace
-### with all optional features enabled. 
+### with all optional components included. 
 ### See `theseus_features/src/lib.rs` for more details on what this includes.
 all: full
-full : export override FEATURES += --all-features
+full : export override FEATURES += --features theseus_features/everything
 ifeq (,$(findstring --workspace,$(FEATURES)))
 full : export override FEATURES += --workspace
 endif
@@ -647,7 +647,7 @@ help:
 
 	@echo -e "   all:"
 	@echo -e "   full:"
-	@echo -e "\t Same as 'iso', but builds all Theseus OS crates by enabling all Cargo features ('--all-features')."
+	@echo -e "\t Same as 'iso', but builds all Theseus OS crates by enabling the 'theseus_features/everything' feature."
 
 	@echo -e "   run:"
 	@echo -e "\t Builds Theseus (via the 'iso' target) and runs it using QEMU."

--- a/applications/test_channel/src/lib.rs
+++ b/applications/test_channel/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-#[macro_use] extern crate alloc;
+extern crate alloc;
 #[macro_use] extern crate log;
 #[macro_use] extern crate app_io;
 extern crate getopts;

--- a/theseus_features/Cargo.toml
+++ b/theseus_features/Cargo.toml
@@ -88,6 +88,15 @@ default = [
     "unwind_test",  ## used for regular testing
 ]
 
+## Includes all optional components.
+everything = [
+    "theseus_apps",
+    "theseus_benchmarks",
+    "theseus_std",
+    "theseus_tests",
+    "wasmtime",
+]
+
 ## Includes `wasmtime`, the WebAssembly (WASM) runtime, in the build.
 wasmtime = [ "test_wasmtime" ]
 

--- a/theseus_features/src/lib.rs
+++ b/theseus_features/src/lib.rs
@@ -13,6 +13,7 @@
 //!    * You can optionally add it to the `default` set of features,
 //!      or create a new group of features that includes it, 
 //!      or even add it to an existing set of features.
+//!    * If you do so, add that new feature or feature group to the `everything` feature.
 //!
 //! 
 //! ## How to customize what is included in a Theseus build
@@ -31,11 +32,11 @@
 //! make FEATURES=--no-default-features
 //! 
 //! # Build the bare minimum `default-members` of the Theseus workspace, plus all optional crates.
-//! make FEATURES=--all-features
+//! make FEATURES="--features everything"
 //! 
 //! # Build the standard Theseus workspace plus all optional crates. 
 //! # This is what `make full` or `make all` does.
-//! make FEATURES="--workspace --all-features"
+//! make FEATURES="--workspace --features theseus_features/everything"
 //! 
 //! # Build the bare minimum `default-members` of the Theseus workspace, plus the `ps` crate.
 //! make FEATURES="--features ps"


### PR DESCRIPTION
* The previous approach used '--all-features` instead, which has unintended effects when relying on Cargo features to choose between BIOS and UEFI builds.