### PR TITLE
Safer logger on aarch64

### DIFF
--- a/aarch64/Cargo.lock
+++ b/aarch64/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
 name = "logger"
 version = "0.1.0"
 dependencies = [
+ "irq_safety",
  "log",
  "pl011_qemu",
 ]
@@ -300,7 +301,6 @@ dependencies = [
 name = "page_table_entry"
 version = "0.1.0"
 dependencies = [
- "bit_field 0.7.0",
  "frame_allocator",
  "kernel_config",
  "memory_structs",

--- a/aarch64/kernel/logger/Cargo.toml
+++ b/aarch64/kernel/logger/Cargo.toml
@@ -8,4 +8,5 @@ path = "lib.rs"
 
 [dependencies]
 log = "0.4.17"
+irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
 pl011_qemu = { git = "https://github.com/theseus-os/pl011/", branch = "aarch64-qemu-virt-test" }

--- a/aarch64/kernel/logger/lib.rs
+++ b/aarch64/kernel/logger/lib.rs
@@ -7,12 +7,14 @@ use irq_safety::MutexIrqSafe;
 
 type QemuVirtUart = PL011<UART1>;
 
-pub struct Logger {
+/// This wraps a UART channel handle.
+pub struct QemuVirtUartLogger {
     pub(crate) uart: MutexIrqSafe<QemuVirtUart>,
 }
 
-impl Log for Logger {
+impl Log for QemuVirtUartLogger {
     fn enabled(&self, _metadata: &Metadata) -> bool {
+        // allow all messages
         true
     }
 
@@ -20,6 +22,9 @@ impl Log for Logger {
         let mut mutable_uart = self.uart.lock();
 
         if self.enabled(record.metadata()) {
+            // result is discarded because we
+            // have no alternative way to signal
+            // an issue to the user
             let _ = write!(&mut mutable_uart, "{} - {}\r\n", record.level(), record.args());
         }
     }
@@ -27,13 +32,21 @@ impl Log for Logger {
     fn flush(&self) {}
 }
 
-static mut LOGGER: Option<Logger> = None;
+// Global logger Singleton
+static mut LOGGER: Option<QemuVirtUartLogger> = None;
 
+/// Initialize the internal global "LOGGER" singleton
+/// and sets it as the system-wide logger for the `log`
+/// crate.
+///
+/// Bootstrapping code must call this as early
+/// as possible for all log messages to show up
+/// on the UART output of Qemu.
 pub fn init() -> Result<(), &'static str> {
     set_max_level(STATIC_MAX_LEVEL);
 
     let uart1 = UART1::take().unwrap();
-    let logger = Logger {
+    let logger = QemuVirtUartLogger {
         uart: MutexIrqSafe::new(QemuVirtUart::new(uart1)),
     };
 


### PR DESCRIPTION
Fixes #772; new code makes use of `irq_safety` and its `MutexIrqSafe` struct.
Also includes minimal documentation for this code.

It doesn't use `MaybeUninit` anymore; this has been replaced by wrapping the logger in an option, initially `None`, as suggested by @tsoutsman.