### PR TITLE
Clarify calculation of virtual addresses for recursive P4 page table entries

### DIFF
--- a/kernel/kernel_config/src/memory.rs
+++ b/kernel/kernel_config/src/memory.rs
@@ -1,14 +1,12 @@
-//! WARNING: DO NOT USE ANY ADDRESS THAT MAPS TO THE SAME P4 ENTRY AS THE ONE
-//! USED FOR THE RECURSIVE PAGE TABLE ENTRY (CURRENTLY 510). 
-//! Currently, that would be any address that starts with 0xFFFF_FF0*_****_****,
-//! so do not use that virtual address range for anything!!
-
+//! The basic virtual memory map that Theseus assumes.
+//!
 //! Current P4 (top-level page table) mappings:
-//! * 511: kernel text sections
+//! * 511: kernel text sections.
 //! * 510: recursive mapping for accessing the current P4 root page table frame.
-//! * 509: kernel heap
-//! * 508: recursive mapping for accessing the P4 root page table frame of an upcoming new page table.
-//! * 507 down to 0: available for general usage
+//! * 509: kernel heap.
+//! * 508: recursive mapping for accessing the P4 root page table frame
+//!        of an upcoming new page table.
+//! * 507 down to 0: available for general usage.
 
 /// 64-bit architecture results in 8 bytes per address.
 pub const BYTES_PER_ADDR: usize = core::mem::size_of::<usize>();

--- a/kernel/memory/src/paging/table.rs
+++ b/kernel/memory/src/paging/table.rs
@@ -12,30 +12,60 @@ use core::marker::PhantomData;
 use super::PageTableEntry;
 use crate::VirtualAddress;
 use pte_flags::PteFlagsArch;
-use kernel_config::memory::{PAGE_SHIFT, ENTRIES_PER_PAGE_TABLE};
+use kernel_config::memory::{
+    ENTRIES_PER_PAGE_TABLE,
+    PAGE_SHIFT,
+    P1_INDEX_SHIFT,
+    P2_INDEX_SHIFT,
+    P3_INDEX_SHIFT,
+    P4_INDEX_SHIFT,
+    RECURSIVE_P4_INDEX,
+    UPCOMING_PAGE_TABLE_RECURSIVE_P4_INDEX,
+};
 use zerocopy::FromBytes;
 
 
-/// Theseus uses the 511th entry of the P4 table for mapping the higher-half kernel, 
-/// so it uses the 510th entry of P4 for the recursive mapping.
-/// 
-/// NOTE: this must be kept in sync with the recursive index in `kernel_config/memory.rs`
-///       and `nano_core/<arch>/boot.asm`.
+/// The virtual address of the page table entry used to recursively map the
+/// root P4-level page table frame of the *currently-active* page table. 
 ///
-/// See these links for more: 
+/// Theseus currently uses the 511th entry of the P4 table for mapping the higher-half kernel
+/// so it uses the 510th entry of P4 for this recursive mapping.
+/// Thus, the value of this should be `0o177777_776_776_776_776_0000` (octal).
+///
+/// This works by being a virtual address that always results in the 510th entry
+/// of the page table being accessed, at all four levels of paging.
+///
+/// NOTE: this must be kept in sync with the recursive index used in
+///       and `nano_core/src/asm/bios/boot.asm`.
+///
+/// See these links for more info: 
 /// * <http://forum.osdev.org/viewtopic.php?f=1&p=176913>
 /// * <http://forum.osdev.org/viewtopic.php?f=15&t=25545>
-#[allow(clippy::inconsistent_digit_grouping)]
-pub const P4: *mut Table<Level4> = 0o177777_776_776_776_776_0000 as *mut _; 
-                                         // ^p4 ^p3 ^p2 ^p1 ^offset  
-                                         // ^ 0o776 means that we're always looking at the 510th entry recursively
+pub(crate) const P4: *mut Table<Level4> = VirtualAddress::new_canonical(
+    RECURSIVE_P4_INDEX << (PAGE_SHIFT + P1_INDEX_SHIFT)
+    | RECURSIVE_P4_INDEX << (PAGE_SHIFT + P2_INDEX_SHIFT)
+    | RECURSIVE_P4_INDEX << (PAGE_SHIFT + P3_INDEX_SHIFT)
+    | RECURSIVE_P4_INDEX << (PAGE_SHIFT + P4_INDEX_SHIFT)
+).value() as *mut _;
 
-/// By default this is an invalid address unless the upcoming page table recursive entry is modified.
+
+/// The virtual address of the page table entry used to recursively map the
+/// root P4-level page table frame of an upcoming (new) page table
+/// that is currently not active.
 ///
-/// NOTE: this must be kept in sync with the upcoming page table recursive index in `kernel_config/memory.rs`.
+/// Theseus currently uses the 508th entry of P4 for this recursive mapping.
 ///
-/// All four table indexes need to be set to 0o774 so that `Table::next_table_address` works properly.
-pub const UPCOMING_P4: *mut Table<Level4> = 0o177777_774_774_774_774_0000 as *mut _;
+/// This works by being a virtual address that always results in the 508th entry
+/// of the page table being accessed, at all four levels of paging.
+///
+/// Thus, the value of this should be `0o177777_774_774_774_774_0000` (octal).
+pub(crate) const UPCOMING_P4: *mut Table<Level4> = VirtualAddress::new_canonical(
+    UPCOMING_PAGE_TABLE_RECURSIVE_P4_INDEX << (PAGE_SHIFT + P1_INDEX_SHIFT)
+    | UPCOMING_PAGE_TABLE_RECURSIVE_P4_INDEX << (PAGE_SHIFT + P2_INDEX_SHIFT)
+    | UPCOMING_PAGE_TABLE_RECURSIVE_P4_INDEX << (PAGE_SHIFT + P3_INDEX_SHIFT)
+    | UPCOMING_PAGE_TABLE_RECURSIVE_P4_INDEX << (PAGE_SHIFT + P4_INDEX_SHIFT)
+).value() as *mut _;
+
 
 #[derive(FromBytes)]
 pub struct Table<L: TableLevel> {


### PR DESCRIPTION
We also use the virtual address canonicalization routine too,
which makes this architecture-independent instead of x86_64-specific.