### PR TITLE
Only identity map (not higher-half map) the early VGA buffer

### DIFF
--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -67,6 +67,7 @@ pub fn get_kernel_mmi_ref() -> Option<&'static MmiRef> {
 /// This holds all the information for a `Task`'s memory mappings and address space
 /// (this is basically the equivalent of Linux's mm_struct)
 #[derive(Debug)]
+#[doc(alias("mmi"))]
 pub struct MemoryManagementInfo {
     /// the PageTable that should be switched to when this Task is switched to.
     pub page_table: PageTable,

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -71,8 +71,9 @@ pub struct MemoryManagementInfo {
     /// the PageTable that should be switched to when this Task is switched to.
     pub page_table: PageTable,
     
-    /// a list of additional virtual-mapped Pages that have the same lifetime as this MMI
-    /// and are thus owned by this MMI, but is not all-inclusive (e.g., Stacks are excluded).
+    /// The list of additional memory mappings that have the same lifetime as this MMI
+    /// and are thus owned by this MMI.
+    /// This currently includes only the mappings for the heap and the early VGA buffer.
     pub extra_mapped_pages: Vec<MappedPages>,
 }
 
@@ -140,10 +141,11 @@ pub struct InitialMemoryMappings {
     pub stack: NoDrop<MappedPages>,
     /// The boot information mappings.
     pub boot_info: MappedPages,
-    /// The list of other higher-half mapping that must be converted to a vec after heap initialization, and kept forever e.g. VGA buffer.
-    pub higher_half: [Option<NoDrop<MappedPages>>; 32],
     /// The list of identity mappings that must be converted to a vec after heap initialization, and dropped before starting the first userspace program.
     pub identity: [Option<NoDrop<MappedPages>>; 32],
+    /// The list of additional mappings that must be converted to a vec after heap initialization and kept forever.
+    /// Currently, this contains only the mapping of the early VGA buffer.
+    pub additional: [Option<NoDrop<MappedPages>>; 32],
 }
 
 /// Initializes the virtual memory management system.
@@ -210,11 +212,11 @@ pub fn init(
 /// Returns the following tuple:
 ///  * The kernel's new [`MemoryManagementInfo`], representing the initial virtual address space,
 ///  * The kernel's list of identity-mapped [`MappedPages`],
-///    which must not be dropped until all AP (additional CPUs) are fully booted,
-///    but *should* be dropped before starting the first user application. 
+///    which must not be dropped until all secondary CPUs are fully booted,
+///    but *should* be dropped before starting the first application.
 pub fn init_post_heap(
     page_table: PageTable,
-    mut higher_half_mapped_pages: [Option<NoDrop<MappedPages>>; 32],
+    mut additional_mapped_pages: [Option<NoDrop<MappedPages>>; 32],
     mut identity_mapped_pages: [Option<NoDrop<MappedPages>>; 32],
     heap_mapped_pages: MappedPages
 ) -> (MmiRef, NoDrop<Vec<MappedPages>>) {
@@ -223,11 +225,11 @@ pub fn init_post_heap(
     page_allocator::convert_to_heap_allocated();
     frame_allocator::convert_to_heap_allocated();
 
-    let mut higher_half_mapped_pages: Vec<MappedPages> = higher_half_mapped_pages
+    let mut additional_mapped_pages: Vec<MappedPages> = additional_mapped_pages
         .iter_mut()
         .filter_map(|opt| opt.take().map(NoDrop::into_inner))
         .collect();
-    higher_half_mapped_pages.push(heap_mapped_pages);
+    additional_mapped_pages.push(heap_mapped_pages);
     let identity_mapped_pages: Vec<MappedPages> = identity_mapped_pages
         .iter_mut()
         .filter_map(|opt| opt.take().map(NoDrop::into_inner))
@@ -237,7 +239,7 @@ pub fn init_post_heap(
     // Construct the kernel's memory mgmt info, i.e., its address space info
     let kernel_mmi = MemoryManagementInfo {
         page_table,
-        extra_mapped_pages: higher_half_mapped_pages,
+        extra_mapped_pages: additional_mapped_pages,
     };
 
     let kernel_mmi_ref = KERNEL_MMI.call_once( || {

--- a/kernel/memory_initialization/src/lib.rs
+++ b/kernel/memory_initialization/src/lib.rs
@@ -38,7 +38,7 @@ use bootloader_modules::BootloaderModule;
 ///  6. the list of bootloader modules obtained from the given `boot_info`,
 ///  7. the kernel's list of identity-mapped [`MappedPages`],
 ///     which must not be dropped until all AP (additional CPUs) are fully booted,
-///     but *should* be dropped before starting the first user application.
+///     but *should* be dropped before starting the first application.
 pub fn init_memory_management(
     boot_info: impl BootInformation,
     kernel_stack_start: VirtualAddress,
@@ -61,8 +61,8 @@ pub fn init_memory_management(
         stack_guard: stack_guard_page,
         stack: stack_pages,
         boot_info: boot_info_mapped_pages,
-        higher_half: higher_half_mapped_pages,
-        identity: identity_mapped_pages
+        identity: identity_mapped_pages,
+        additional: additional_mapped_pages,
     } = memory::init(&boot_info, kernel_stack_start)?;
     // After this point, at which `memory::init()` has returned new objects that represent
     // the currently-executing code/data/stack, we must ensure they aren't dropped if an error occurs,
@@ -100,7 +100,7 @@ pub fn init_memory_management(
     // Initialize memory management post heap intialization: set up kernel stack allocator and kernel memory management info.
     let (kernel_mmi_ref, identity_mapped_pages) = memory::init_post_heap(
         page_table,
-        higher_half_mapped_pages,
+        additional_mapped_pages,
         identity_mapped_pages,
         heap_mapped_pages,
     );

--- a/kernel/nano_core/src/asm/ap_boot.asm
+++ b/kernel/nano_core/src/asm/ap_boot.asm
@@ -117,9 +117,9 @@ long_mode_start_ap:
 	
 %ifdef BIOS
 	; each character is reversed in the dword cuz of little endianness
-	mov dword [0xFFFFFFFF800b8038], 0x4f2E4f2E ; ".."
-    mov dword [0xFFFFFFFF800b803c], 0x4f4f4f4c ; "LO"
-	mov dword [0xFFFFFFFF800b8040], 0x4f474f4e ; "NG"
+	mov dword [0xb8038], 0x4f2E4f2E ; ".."
+    mov dword [0xb803c], 0x4f4f4f4c ; "LO"
+	mov dword [0xb8040], 0x4f474f4e ; "NG"
 %endif ; BIOS
 
 	; Long jump to the higher half. Because `jmp` does not take
@@ -165,10 +165,10 @@ start_high_ap:
 	
 %ifdef BIOS
 	; each character is reversed in the dword cuz of little endianness
-	mov dword [0xb8048 + KERNEL_OFFSET], 0x4f2E4f2E ; ".."
-    mov dword [0xb804c + KERNEL_OFFSET], 0x4f494f48 ; "HI"
-	mov dword [0xb8050 + KERNEL_OFFSET], 0x4f484f47 ; "GH"
-	mov dword [0xb8054 + KERNEL_OFFSET], 0x4f524f45 ; "ER"
+	mov dword [0xb8048], 0x4f2E4f2E ; ".."
+    mov dword [0xb804c], 0x4f494f48 ; "HI"
+	mov dword [0xb8050], 0x4f484f47 ; "GH"
+	mov dword [0xb8054], 0x4f524f45 ; "ER"
 %endif ; BIOS
 
 	; move to the new stack that was alloc'd for this AP

--- a/kernel/vga_buffer/src/lib.rs
+++ b/kernel/vga_buffer/src/lib.rs
@@ -15,11 +15,11 @@ use core::fmt;
 use core::ptr::Unique;
 use spin::Mutex;
 use volatile::Volatile;
-use kernel_config::memory::KERNEL_OFFSET;
 
 
-/// defined by x86's physical memory maps
-const VGA_BUFFER_VIRTUAL_ADDR: usize = 0xb8000 + KERNEL_OFFSET;
+/// The VBE/VESA standard defines the text mode VGA buffer to start at this address.
+/// We must rely on the early bootstrap code to identity map this address.
+const VGA_BUFFER_VIRTUAL_ADDR: usize = 0xb8000;
 
 /// height of the VGA text window
 const BUFFER_HEIGHT: usize = 25;


### PR DESCRIPTION
There's actually no need to map it both as an identity mapping and as
a higher-half mapping, this is wasteful. 
It also allows us to avoid the inherent unsafety of a duplicate mapping.

Change the language of higher-half mapping to just be additional mappings,
since they're not all higher half.

Change the virtual address of the early text mode VGA buffer to be
identity mapped (at `0xb8000`) with no addition of `KERNEL_OFFSET`;
also change the assembly files accordingly.