### PR TITLE
Clean up identity mappings

### DIFF
--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -50,14 +50,12 @@ extern crate console;
 #[cfg(simd_personality)] extern crate simd_personality;
 
 
-use alloc::vec::Vec;
 use core::ops::DerefMut;
-use memory::{VirtualAddress, MappedPages, MmiRef};
+use memory::{EarlyIdentityMappedPages, MmiRef, PhysicalAddress, VirtualAddress};
 use kernel_config::memory::KERNEL_STACK_SIZE_IN_PAGES;
 use irq_safety::enable_interrupts;
 use stack::Stack;
 use no_drop::NoDrop;
-use memory::PhysicalAddress;
 
 
 #[cfg(mirror_log_to_vga)]
@@ -83,7 +81,7 @@ pub fn mirror_to_vga_cb(args: core::fmt::Arguments) {
 /// * `ap_start_realmode_end`: the end bound (exlusive) of the AP's realmode boot code.
 pub fn init(
     kernel_mmi_ref: MmiRef,
-    identity_mapped_pages: NoDrop<Vec<MappedPages>>,
+    identity_mapped_pages: NoDrop<EarlyIdentityMappedPages>,
     bsp_initial_stack: NoDrop<Stack>,
     ap_start_realmode_begin: VirtualAddress,
     ap_start_realmode_end: VirtualAddress,

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -144,7 +144,6 @@ pub struct InitialMemoryMappings {
     /// The boot information mappings.
     pub boot_info: MappedPages,
     /// The list of identity mappings that should be dropped before starting the first application.
-    /// This should also be converted to a `Vec` after the heap is initialized.
     ///
     /// Currently there are only 4 identity mappings, used for the base kernel image:
     /// 1. the `.init` early text section,
@@ -153,7 +152,6 @@ pub struct InitialMemoryMappings {
     /// 4. the `.data` section, which includes `.bss` and all read-write data.
     pub identity: NoDrop<EarlyIdentityMappedPages>,
     /// The list of additional mappings that must be kept forever.
-    /// This should also be converted to a `Vec` after the heap is initialized.
     ///
     /// Currently, this contains only one mapping: the early VGA buffer.
     pub additional: NoDrop<MappedPages>,

--- a/kernel/memory_initialization/src/lib.rs
+++ b/kernel/memory_initialization/src/lib.rs
@@ -10,7 +10,7 @@ extern crate no_drop;
 extern crate bootloader_modules;
 extern crate boot_info;
 
-use memory::{MmiRef, MappedPages, VirtualAddress, InitialMemoryMappings};
+use memory::{MmiRef, MappedPages, VirtualAddress, InitialMemoryMappings, EarlyIdentityMappedPages};
 use kernel_config::memory::{KERNEL_HEAP_START, KERNEL_HEAP_INITIAL_SIZE};
 use boot_info::{BootInformation, Module};
 use alloc::{
@@ -49,7 +49,7 @@ pub fn init_memory_management(
         NoDrop<MappedPages>,
         NoDrop<Stack>,
         Vec<BootloaderModule>,
-        NoDrop<Vec<MappedPages>>,
+        NoDrop<EarlyIdentityMappedPages>,
     ), &'static str>
 {
     // Initialize memory management: paging (create a new page table), essential kernel mappings
@@ -98,10 +98,9 @@ pub fn init_memory_management(
     debug!("Mapped and initialized the initial heap");
 
     // Initialize memory management post heap intialization: set up kernel stack allocator and kernel memory management info.
-    let (kernel_mmi_ref, identity_mapped_pages) = memory::init_post_heap(
+    let kernel_mmi_ref = memory::init_post_heap(
         page_table,
-        additional_mapped_pages,
-        identity_mapped_pages,
+        additional_mapped_pages.into_inner(),
         heap_mapped_pages,
     );
 

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -184,11 +184,9 @@ where
         captain::init(kernel_mmi_ref, identity_mapped_pages, stack, ap_realmode_begin, ap_realmode_end, rsdp_address)?;
     }
     #[cfg(loadable)] {
-        extern crate alloc;
-
-        use alloc::vec::Vec;
-        use memory::{MmiRef, MappedPages, PhysicalAddress};
+        use memory::{EarlyIdentityMappedPages, MmiRef, PhysicalAddress};
         use no_drop::NoDrop;
+        use stack::Stack;
 
         let section = default_namespace
             .get_symbol_starting_with("captain::init::")
@@ -196,7 +194,7 @@ where
             .ok_or("no single symbol matching \"captain::init\"")?;
         log::info!("The nano_core (in loadable mode) is invoking the captain init function: {:?}", section.name);
 
-        type CaptainInitFunc = fn(MmiRef, NoDrop<Vec<MappedPages>>, NoDrop<stack::Stack>, VirtualAddress, VirtualAddress, Option<PhysicalAddress>) -> Result<(), &'static str>;
+        type CaptainInitFunc = fn(MmiRef, NoDrop<EarlyIdentityMappedPages>, NoDrop<Stack>, VirtualAddress, VirtualAddress, Option<PhysicalAddress>) -> Result<(), &'static str>;
         let func: &CaptainInitFunc = unsafe { section.as_func() }?;
 
         func(kernel_mmi_ref, identity_mapped_pages, stack, ap_realmode_begin, ap_realmode_end, rsdp_address)?;


### PR DESCRIPTION
* Avoid unnecessary stack and heap allocations for the
  set of initial identity-mapped kernel sections.
  The number of sections is fixed so there is no reason to
  use large static or dynamically-growable storage for that.

* Remove unnecessary `Option`s when mapping and populating
  the initial kernel sections, since they are required to exist.

* Allow a generic return type from `PageTable::with()`.