### PR TITLE
Remove static_assertions from most places

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,6 @@ dependencies = [
  "pit_clock_basic",
  "raw-cpuid",
  "spin 0.9.4",
- "static_assertions",
  "volatile 0.2.7",
  "x86_64",
  "zerocopy",
@@ -155,7 +154,6 @@ dependencies = [
  "log",
  "mpmc",
  "spin 0.9.4",
- "static_assertions",
  "task",
  "wait_queue",
 ]
@@ -621,7 +619,6 @@ dependencies = [
  "qp-trie",
  "serde",
  "spin 0.9.4",
- "static_assertions",
  "str_ref",
  "xmas-elf",
 ]
@@ -937,7 +934,6 @@ dependencies = [
  "nic_queues",
  "pci",
  "spin 0.9.4",
- "static_assertions",
  "task",
  "volatile 0.2.7",
  "x86_64",
@@ -1531,7 +1527,6 @@ dependencies = [
  "log",
  "memory",
  "spin 0.9.4",
- "static_assertions",
  "volatile 0.2.7",
  "zerocopy",
 ]
@@ -1583,7 +1578,6 @@ dependencies = [
  "rand",
  "runqueue",
  "spin 0.9.4",
- "static_assertions",
  "virtual_nic",
  "volatile 0.2.7",
  "x86_64",
@@ -1991,7 +1985,6 @@ dependencies = [
  "nic_buffers",
  "nic_initialization",
  "num_enum",
- "static_assertions",
  "volatile 0.2.7",
  "zerocopy",
 ]
@@ -2132,7 +2125,6 @@ dependencies = [
  "slabmalloc_safe",
  "slabmalloc_unsafe",
  "spin 0.9.4",
- "static_assertions",
 ]
 
 [[package]]
@@ -2720,7 +2712,6 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
- "static_assertions",
 ]
 
 [[package]]
@@ -3197,7 +3188,6 @@ dependencies = [
  "log",
  "serial_port_basic",
  "spin 0.9.4",
- "static_assertions",
  "x86_64",
 ]
 
@@ -3972,9 +3962,6 @@ dependencies = [
 [[package]]
 name = "thread_local_macro"
 version = "0.1.0"
-dependencies = [
- "static_assertions",
-]
 
 [[package]]
 name = "time"
@@ -3982,7 +3969,6 @@ version = "0.1.0"
 dependencies = [
  "crossbeam-utils",
  "log",
- "static_assertions",
 ]
 
 [[package]]

--- a/kernel/apic/Cargo.toml
+++ b/kernel/apic/Cargo.toml
@@ -12,7 +12,6 @@ x86_64 = "0.14.8"
 crossbeam-utils = { version = "0.8.12", default-features = false }
 bit_field = "0.7.0"
 zerocopy = "0.5.0"
-static_assertions = "1.1.0"
 log = "0.4.8"
 
 [dependencies.irq_safety]

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -14,7 +14,6 @@ use atomic_linked_list::atomic_map::AtomicMap;
 use crossbeam_utils::atomic::AtomicCell;
 use pit_clock_basic::pit_wait;
 use bit_field::BitField;
-use static_assertions::{const_assert, const_assert_eq};
 use log::{error, info, debug, trace};
 
 /// A unique identifier for a CPU core.
@@ -39,7 +38,7 @@ pub enum InterruptChip {
 }
 
 // Ensure that `AtomicCell<InterruptChip>` is actually a lock-free atomic.
-const_assert!(AtomicCell::<InterruptChip>::is_lock_free());
+const _: () = assert!(AtomicCell::<InterruptChip>::is_lock_free());
 
 /// The set of system-wide `LocalApic`s, one per CPU core.
 static LOCAL_APICS: AtomicMap<CpuId, RwLockIrqSafe<LocalApic>> = AtomicMap::new();
@@ -244,7 +243,7 @@ pub struct ApicRegisters {
     _padding23:                       [u32; 3 + 4],
     // ends at 0x400
 }
-const_assert_eq!(core::mem::size_of::<ApicRegisters>(), 0x400);
+const _: () = assert!(core::mem::size_of::<ApicRegisters>() == 0x400);
 
 
 #[derive(FromBytes)]
@@ -267,7 +266,7 @@ pub struct RegisterArray {
     reg7:                             ReadOnly<u32>,
     _padding7:                        [u32; 3],
 }
-const_assert_eq!(core::mem::size_of::<RegisterArray>(), 8 * (4 + 12));
+const _: () = assert!(core::mem::size_of::<RegisterArray>() == 8 * (4 + 12));
 
 /// The Local APIC's vector table local interrupt pins.
 #[doc(alias("lvt", "lint", "lint0", "lint1"))]

--- a/kernel/async_channel/Cargo.toml
+++ b/kernel/async_channel/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 [dependencies]
 spin = "0.9.4"
 crossbeam-utils = { version = "0.8.12", default-features = false }
-static_assertions = "1.1.0"
 mpmc = "0.1.6"
 
 [dependencies.log]

--- a/kernel/async_channel/src/lib.rs
+++ b/kernel/async_channel/src/lib.rs
@@ -12,7 +12,6 @@
 #![no_std]
 
 extern crate alloc;
-#[macro_use] extern crate static_assertions;
 #[cfg(trace_channel)] #[macro_use] extern crate log;
 #[cfg(trace_channel)] #[macro_use] extern crate debugit;
 extern crate wait_queue;
@@ -114,7 +113,7 @@ struct Channel<T: Send> {
 }
 
 // Ensure that `AtomicCell<ChannelStatus>` is actually a lock-free atomic.
-const_assert!(AtomicCell::<ChannelStatus>::is_lock_free());
+const _: () = assert!(AtomicCell::<ChannelStatus>::is_lock_free());
 
 impl <T: Send> Channel<T> {
     /// Returns true if the channel is disconnected.

--- a/kernel/crate_metadata/Cargo.toml
+++ b/kernel/crate_metadata/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 spin = "0.9.4"
 xmas-elf = { version = "0.6.2", git = "https://github.com/theseus-os/xmas-elf.git" }
 qp-trie = "0.8.0"
-static_assertions = "1.1.0"
 
 [dependencies.str_ref]
 path = "../../libs/str_ref"

--- a/kernel/crate_metadata/src/lib.rs
+++ b/kernel/crate_metadata/src/lib.rs
@@ -65,7 +65,6 @@ use cow_arc::{CowArc, CowWeak};
 use fs_node::{FileRef, WeakFileRef};
 use hashbrown::HashMap;
 use goblin::elf::reloc::*;
-use static_assertions::const_assert;
 
 pub use str_ref::StrRef;
 pub use crate_metadata_serde::{
@@ -108,9 +107,9 @@ pub const DATA_BSS_SECTION_FLAGS: PteFlags = PteFlags::from_bits_truncate(
 );
 
 // Double-check section flags were defined correctly.
-const_assert!(TEXT_SECTION_FLAGS.is_executable() && !TEXT_SECTION_FLAGS.is_writable());
-const_assert!(!RODATA_SECTION_FLAGS.is_writable() && !RODATA_SECTION_FLAGS.is_executable());
-const_assert!(DATA_BSS_SECTION_FLAGS.is_writable() && !DATA_BSS_SECTION_FLAGS.is_executable());
+const _: () = assert!(TEXT_SECTION_FLAGS.is_executable() && !TEXT_SECTION_FLAGS.is_writable());
+const _: () = assert!(!RODATA_SECTION_FLAGS.is_writable() && !RODATA_SECTION_FLAGS.is_executable());
+const _: () = assert!(DATA_BSS_SECTION_FLAGS.is_writable() && !DATA_BSS_SECTION_FLAGS.is_executable());
 
 
 /// The Theseus Makefile appends prefixes onto bootloader module names,

--- a/kernel/e1000/Cargo.toml
+++ b/kernel/e1000/Cargo.toml
@@ -9,7 +9,6 @@ spin = "0.9.4"
 volatile = "0.2.7"
 x86_64 = "0.14.8"
 zerocopy = "0.5.0"
-static_assertions = "1.1.0"
 mpmc = "0.1.6"
 
 

--- a/kernel/e1000/src/lib.rs
+++ b/kernel/e1000/src/lib.rs
@@ -7,7 +7,6 @@
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate lazy_static;
-#[macro_use] extern crate static_assertions;
 extern crate volatile;
 extern crate zerocopy;
 extern crate alloc;

--- a/kernel/e1000/src/regs.rs
+++ b/kernel/e1000/src/regs.rs
@@ -86,8 +86,13 @@ pub struct E1000MacRegisters {
 const _: () = assert!(core::mem::size_of::<E1000MacRegisters>() == 28 * 4096);
 
 // check that the sum of all the register structs is equal to the memory of the e1000 device (128 KiB).
-const _: () = assert!(core::mem::size_of::<E1000Registers>() + core::mem::size_of::<E1000RxRegisters>() +   
-    core::mem::size_of::<E1000TxRegisters>() + core::mem::size_of::<E1000MacRegisters>() == 0x20000);
+const _: () = assert!(
+    core::mem::size_of::<E1000Registers>()
+    + core::mem::size_of::<E1000RxRegisters>()
+    + core::mem::size_of::<E1000TxRegisters>()
+    + core::mem::size_of::<E1000MacRegisters>()
+    == 0x20000
+);
 
 
 /// Struct that holds registers related to one receive queue.

--- a/kernel/e1000/src/regs.rs
+++ b/kernel/e1000/src/regs.rs
@@ -40,7 +40,7 @@ pub struct E1000Registers {
     
 } // 2 4KiB pages
 
-const_assert_eq!(core::mem::size_of::<E1000Registers>(), 2 * 4096);
+const _: () = assert!(core::mem::size_of::<E1000Registers>() == 2 * 4096);
 
 /// The layout in memory of e1000 receive registers. 
 #[derive(FromBytes)]
@@ -52,7 +52,7 @@ pub struct E1000RxRegisters {
     _padding7:                      [u8; 2020],             // 0x281C - 0x2FFF
 } // 1 4KiB page
 
-const_assert_eq!(core::mem::size_of::<E1000RxRegisters>(), 4096);
+const _: () = assert!(core::mem::size_of::<E1000RxRegisters>() == 4096);
 
 
 /// The layout in memory of e1000 transmit registers. 
@@ -65,7 +65,7 @@ pub struct E1000TxRegisters {
     _padding9:                      [u8; 2020],             // 0x381C - 0x3FFF
 } // 1 4KiB page
 
-const_assert_eq!(core::mem::size_of::<E1000TxRegisters>(), 4096);
+const _: () = assert!(core::mem::size_of::<E1000TxRegisters>() == 4096);
 
 
 /// The layout in memory of e1000 MAC address registers. 
@@ -83,11 +83,11 @@ pub struct E1000MacRegisters {
 
 } // 28 4KiB pages
 
-const_assert_eq!(core::mem::size_of::<E1000MacRegisters>(), 28 * 4096);
+const _: () = assert!(core::mem::size_of::<E1000MacRegisters>() == 28 * 4096);
 
 // check that the sum of all the register structs is equal to the memory of the e1000 device (128 KiB).
-const_assert_eq!(core::mem::size_of::<E1000Registers>() + core::mem::size_of::<E1000RxRegisters>() +   
-    core::mem::size_of::<E1000TxRegisters>() + core::mem::size_of::<E1000MacRegisters>(), 0x20000);
+const _: () = assert!(core::mem::size_of::<E1000Registers>() + core::mem::size_of::<E1000RxRegisters>() +   
+    core::mem::size_of::<E1000TxRegisters>() + core::mem::size_of::<E1000MacRegisters>() == 0x20000);
 
 
 /// Struct that holds registers related to one receive queue.

--- a/kernel/iommu/Cargo.toml
+++ b/kernel/iommu/Cargo.toml
@@ -9,7 +9,6 @@ log = "0.4.8"
 spin = "0.9.4"
 volatile = "0.2.7"
 zerocopy = "0.5.0"
-static_assertions = "1.1.0"
 bitflags = "1.3.2"
 
 [dependencies.irq_safety]

--- a/kernel/iommu/src/lib.rs
+++ b/kernel/iommu/src/lib.rs
@@ -7,7 +7,6 @@
 
 extern crate irq_safety;
 #[macro_use] extern crate log;
-#[macro_use] extern crate static_assertions;
 extern crate memory;
 extern crate spin;
 extern crate volatile;

--- a/kernel/iommu/src/regs.rs
+++ b/kernel/iommu/src/regs.rs
@@ -27,7 +27,7 @@ pub struct IntelIommuRegisters {
 // TODO: Hardware may use more than 4kB, which means the registers may occupy
 //       more than one contiguous page.
 //       Currently we assume the IOMMU registers occupy only a single page.
-const_assert_eq!(core::mem::size_of::<IntelIommuRegisters>(), 4096);
+const _: () = assert!(core::mem::size_of::<IntelIommuRegisters>() == 4096);
 
 /// Helper struct for decoding and printing capability register
 pub struct Capability(pub u64);

--- a/kernel/ixgbe/Cargo.toml
+++ b/kernel/ixgbe/Cargo.toml
@@ -10,7 +10,6 @@ volatile = "0.2.4"
 x86_64 = "0.14.8"
 bit_field = "0.7.0"
 zerocopy = "0.5.0"
-static_assertions = "1.1.0"
 mpmc = "0.1.6"
 
 [dependencies.hashbrown]

--- a/kernel/ixgbe/src/lib.rs
+++ b/kernel/ixgbe/src/lib.rs
@@ -12,7 +12,6 @@
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate lazy_static;
-#[macro_use] extern crate static_assertions;
 extern crate alloc;
 extern crate spin;
 extern crate irq_safety;

--- a/kernel/ixgbe/src/regs.rs
+++ b/kernel/ixgbe/src/regs.rs
@@ -298,10 +298,16 @@ pub struct IntelIxgbeRegisters3 {
 const _: () = assert!(core::mem::size_of::<IntelIxgbeRegisters3>() == 18 * 4096);
 
 // check that the sum of all the register structs is equal to the memory of the ixgbe device (128 KiB).
-const _: () = assert!(core::mem::size_of::<IntelIxgbeRegisters1>() + core::mem::size_of::<IntelIxgbeRxRegisters1>() +
-    core::mem::size_of::<IntelIxgbeRegisters2>() + core::mem::size_of::<IntelIxgbeTxRegisters>() + 
-    core::mem::size_of::<IntelIxgbeMacRegisters>() + core::mem::size_of::<IntelIxgbeRxRegisters2>() +
-    core::mem::size_of::<IntelIxgbeRegisters3>() == 0x20000);
+const _: () = assert!(
+    core::mem::size_of::<IntelIxgbeRegisters1>()
+    + core::mem::size_of::<IntelIxgbeRxRegisters1>()
+    + core::mem::size_of::<IntelIxgbeRegisters2>()
+    + core::mem::size_of::<IntelIxgbeTxRegisters>()
+    + core::mem::size_of::<IntelIxgbeMacRegisters>()
+    + core::mem::size_of::<IntelIxgbeRxRegisters2>()
+    + core::mem::size_of::<IntelIxgbeRegisters3>()
+    == 0x20000
+);
 
 /// Set of registers associated with one transmit descriptor queue.
 #[derive(FromBytes)]

--- a/kernel/ixgbe/src/regs.rs
+++ b/kernel/ixgbe/src/regs.rs
@@ -72,7 +72,7 @@ pub struct IntelIxgbeRegisters1 {
 
 } // 1 4KiB page
 
-const_assert_eq!(core::mem::size_of::<IntelIxgbeRegisters1>(), 4096);
+const _: () = assert!(core::mem::size_of::<IntelIxgbeRegisters1>() == 4096);
 
 /// The layout in memory of the first set of receive queue registers of the 82599 device.
 #[derive(FromBytes)]
@@ -83,7 +83,7 @@ pub struct IntelIxgbeRxRegisters1 {
 
 } // 1 4KiB page
 
-const_assert_eq!(core::mem::size_of::<IntelIxgbeRxRegisters1>(), 4096);
+const _: () = assert!(core::mem::size_of::<IntelIxgbeRxRegisters1>() == 4096);
 
 /// The layout in memory of the second set of general registers of the 82599 device.
 #[derive(FromBytes)]
@@ -190,7 +190,7 @@ pub struct IntelIxgbeRegisters2 {
     _padding21:                         [u8; 3768],             // 0x5148 - 0x5FFF
 } // 4 4KiB page
 
-const_assert_eq!(core::mem::size_of::<IntelIxgbeRegisters2>(), 4 * 4096);
+const _: () = assert!(core::mem::size_of::<IntelIxgbeRegisters2>() == 4 * 4096);
 
 /// The layout in memory of the transmit queue registers of the 82599 device.
 #[derive(FromBytes)]
@@ -200,7 +200,7 @@ pub struct IntelIxgbeTxRegisters {
     pub tx_regs:                        [RegistersTx; 128],     // 0x6000 - 0x7FFF
 } // 2 4KiB page
 
-const_assert_eq!(core::mem::size_of::<IntelIxgbeTxRegisters>(), 2 * 4096);
+const _: () = assert!(core::mem::size_of::<IntelIxgbeTxRegisters>() == 2 * 4096);
 
 /// The layout in memory of the set of registers containing the MAC address of the 82599 device.
 #[derive(FromBytes)]
@@ -223,7 +223,7 @@ pub struct IntelIxgbeMacRegisters {
     _padding4:                          [u8; 992],              // 0xCC20 - 0xCFFF
 } // 5 4KiB page
 
-const_assert_eq!(core::mem::size_of::<IntelIxgbeMacRegisters>(), 5 * 4096);
+const _: () = assert!(core::mem::size_of::<IntelIxgbeMacRegisters>() == 5 * 4096);
 
 /// The layout in memory of the second set of receive queue registers of the 82599 device.
 #[derive(FromBytes)]
@@ -233,7 +233,7 @@ pub struct IntelIxgbeRxRegisters2 {
     pub rx_regs2:                       [RegistersRx; 64],      // 0xD000 - 0xDFFF, for 64 queues
 } // 1 4KiB page
 
-const_assert_eq!(core::mem::size_of::<IntelIxgbeRxRegisters2>(), 4096);
+const _: () = assert!(core::mem::size_of::<IntelIxgbeRxRegisters2>() == 4096);
 
 /// The layout in memory of the third set of general registers of the 82599 device.
 #[derive(FromBytes)]
@@ -295,13 +295,13 @@ pub struct IntelIxgbeRegisters3 {
 
 } // 18 4KiB page (total NIC mem = 128 KB)
 
-const_assert_eq!(core::mem::size_of::<IntelIxgbeRegisters3>(), 18 * 4096);
+const _: () = assert!(core::mem::size_of::<IntelIxgbeRegisters3>() == 18 * 4096);
 
 // check that the sum of all the register structs is equal to the memory of the ixgbe device (128 KiB).
-const_assert_eq!(core::mem::size_of::<IntelIxgbeRegisters1>() + core::mem::size_of::<IntelIxgbeRxRegisters1>() +
+const _: () = assert!(core::mem::size_of::<IntelIxgbeRegisters1>() + core::mem::size_of::<IntelIxgbeRxRegisters1>() +
     core::mem::size_of::<IntelIxgbeRegisters2>() + core::mem::size_of::<IntelIxgbeTxRegisters>() + 
     core::mem::size_of::<IntelIxgbeMacRegisters>() + core::mem::size_of::<IntelIxgbeRxRegisters2>() +
-    core::mem::size_of::<IntelIxgbeRegisters3>(), 0x20000);
+    core::mem::size_of::<IntelIxgbeRegisters3>() == 0x20000);
 
 /// Set of registers associated with one transmit descriptor queue.
 #[derive(FromBytes)]
@@ -338,7 +338,7 @@ pub struct RegistersTx {
     pub tdwbah:                         Volatile<u32>,          // 0x603C
 } // 64B
 
-const_assert_eq!(core::mem::size_of::<RegistersTx>(), 64);
+const _: () = assert!(core::mem::size_of::<RegistersTx>() == 64);
 
 /// Set of registers associated with one receive descriptor queue.
 #[derive(FromBytes)]
@@ -371,7 +371,7 @@ pub struct RegistersRx {
     _padding2:                          [u8;20],                // 0x102C - 0x103F                                            
 } // 64B
 
-const_assert_eq!(core::mem::size_of::<RegistersRx>(), 64);
+const _: () = assert!(core::mem::size_of::<RegistersRx>() == 64);
 
 /// Offset where the RDT register starts for the first 64 rx queues
 pub const RDT_1:                        usize = 0x1018;

--- a/kernel/mlx_ethernet/Cargo.toml
+++ b/kernel/mlx_ethernet/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Ramla-I <ijazramla@gmail.com>"]
 volatile = "0.2.7"
 bit_field = "0.7.0"
 zerocopy = "0.5.0"
-static_assertions = "1.1.0"
 byteorder = { version = "1.4.3", default-features = false }
 libm = "0.2.1"
 mpmc = "0.1.6"

--- a/kernel/mlx_ethernet/src/command_queue.rs
+++ b/kernel/mlx_ethernet/src/command_queue.rs
@@ -438,7 +438,7 @@ struct NicVportContext {
     permanent_address_l: Volatile<U32<BigEndian>>,
 }
 
-const_assert_eq!(core::mem::size_of::<NicVportContext>(), 252);
+const _: () = assert!(core::mem::size_of::<NicVportContext>() == 252);
 
 /// A struct storing a 4KiB page that can be used as an input or output mailbox
 struct MailboxBuffer {
@@ -1481,7 +1481,7 @@ pub struct CommandQueueEntry {
     token_signature_status_own:     Volatile<U32<BigEndian>>
 }
 
-const_assert_eq!(core::mem::size_of::<CommandQueueEntry>(), 64);
+const _: () = assert!(core::mem::size_of::<CommandQueueEntry>() == 64);
 
 impl fmt::Debug for CommandQueueEntry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1669,7 +1669,7 @@ struct CommandInterfaceMailbox {
     /// Should have the same value in the command and the mailbox blocks.
     token_ctrl_signature:   Volatile<U32<BigEndian>>
 }
-const_assert_eq!(core::mem::size_of::<CommandInterfaceMailbox>(), MAILBOX_SIZE_IN_BYTES);
+const _: () = assert!(core::mem::size_of::<CommandInterfaceMailbox>() == MAILBOX_SIZE_IN_BYTES);
 
 impl CommandInterfaceMailbox {
     /// Sets all fields of the mailbox to 0.
@@ -1781,7 +1781,7 @@ struct HCACapabilitiesLayout {
     match_definer:                  ReadOnly<U32<BigEndian>>, 
 }
 
-const_assert_eq!(core::mem::size_of::<HCACapabilitiesLayout>(), 256);
+const _: () = assert!(core::mem::size_of::<HCACapabilitiesLayout>() == 256);
 
 /// The HCA capabilities are stored in this struct after being extracted from [`HCACapabilitiesLayout`]
 #[allow(dead_code)]

--- a/kernel/mlx_ethernet/src/completion_queue.rs
+++ b/kernel/mlx_ethernet/src/completion_queue.rs
@@ -62,7 +62,7 @@ pub(crate) struct CompletionQueueContext {
     dbr_addr_l:             Volatile<U32<BigEndian>>,
 }
 
-const_assert_eq!(core::mem::size_of::<CompletionQueueContext>(), 64);
+const _: () = assert!(core::mem::size_of::<CompletionQueueContext>() == 64);
 
 impl fmt::Debug for CompletionQueueContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -175,7 +175,7 @@ pub struct CompletionQueueEntry {
     owner:                  Volatile<U32<BigEndian>>,
 }
 
-const_assert_eq!(core::mem::size_of::<CompletionQueueEntry>(), 64);
+const _: () = assert!(core::mem::size_of::<CompletionQueueEntry>() == 64);
 
 #[allow(unused)]
 impl CompletionQueueEntry {
@@ -242,7 +242,7 @@ pub struct CompletionQueueDoorbellRecord {
     arm_ci:             Volatile<U32<BigEndian>>,
 }
 
-const_assert_eq!(core::mem::size_of::<CompletionQueueDoorbellRecord>(), 8);
+const _: () = assert!(core::mem::size_of::<CompletionQueueDoorbellRecord>() == 8);
 
 /// A data structure that contains the CQ buffer 
 /// and is used to interact with the CQ once initialized.

--- a/kernel/mlx_ethernet/src/event_queue.rs
+++ b/kernel/mlx_ethernet/src/event_queue.rs
@@ -46,7 +46,7 @@ pub(crate) struct EventQueueContext {
     _padding4:          [u8;16],
 }
 
-const_assert_eq!(core::mem::size_of::<EventQueueContext>(), 64);
+const _: () = assert!(core::mem::size_of::<EventQueueContext>() == 64);
 
 impl EventQueueContext {
     /// Create and initialize the fields of the EQ context.
@@ -89,7 +89,7 @@ pub struct EventQueueEntry {
     signature_owner: Volatile<U32<BigEndian>>
 }
 
-const_assert_eq!(core::mem::size_of::<EventQueueEntry>(), 64);
+const _: () = assert!(core::mem::size_of::<EventQueueEntry>() == 64);
 
 impl EventQueueEntry {
     pub fn init(&mut self) {

--- a/kernel/mlx_ethernet/src/flow_table.rs
+++ b/kernel/mlx_ethernet/src/flow_table.rs
@@ -27,7 +27,7 @@ pub(crate) struct FlowTableContext {
     pub(crate) log_size:                    Volatile<U32<BigEndian>>,
 }
 
-const_assert_eq!(core::mem::size_of::<FlowTableContext>(), 4);
+const _: () = assert!(core::mem::size_of::<FlowTableContext>() == 4);
 
 impl fmt::Debug for FlowTableContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -84,7 +84,7 @@ pub(crate) struct FlowGroupInput {
     pub(crate) match_criteria_enable:           Volatile<U32<BigEndian>>,
 }
 
-const_assert_eq!(core::mem::size_of::<FlowGroupInput>(), 48);
+const _: () = assert!(core::mem::size_of::<FlowGroupInput>() == 48);
 
 impl FlowGroupInput {
     pub(crate) fn init(
@@ -134,7 +134,7 @@ pub(crate) struct FlowEntryInput {
     _padding2:                              [u8; 28]
 }
 
-const_assert_eq!(core::mem::size_of::<FlowEntryInput>(), 48);
+const _: () = assert!(core::mem::size_of::<FlowEntryInput>() == 48);
 
 impl FlowEntryInput {
     pub(crate) fn init(table_type: FlowTableType, table_id: u32, flow_index: u32) -> FlowEntryInput {
@@ -180,7 +180,7 @@ pub(crate) struct FlowContext {
     _padding3:                              [u8; 20] 
 }
 
-const_assert_eq!(core::mem::size_of::<FlowContext>(), 40);
+const _: () = assert!(core::mem::size_of::<FlowContext>() == 40);
 
 impl Default for FlowContext {
     fn default() -> FlowContext {
@@ -232,7 +232,7 @@ pub(crate) struct DestinationEntry {
 
 }
 
-const_assert_eq!(core::mem::size_of::<DestinationEntry>(), 8);
+const _: () = assert!(core::mem::size_of::<DestinationEntry>() == 8);
 
 impl DestinationEntry {
     pub(crate) fn init(dest_type: DestinationType, dest_id: u32) -> DestinationEntry {

--- a/kernel/mlx_ethernet/src/initialization_segment.rs
+++ b/kernel/mlx_ethernet/src/initialization_segment.rs
@@ -52,7 +52,7 @@ pub struct InitializationSegment {
     _padding6:                  [u8; 12228],
 }
 
-const_assert_eq!(core::mem::size_of::<InitializationSegment>(), 16396);
+const _: () = assert!(core::mem::size_of::<InitializationSegment>() == 16396);
 
 impl InitializationSegment {
     /// Returns the maximum number of entries that can be in the command queue

--- a/kernel/mlx_ethernet/src/lib.rs
+++ b/kernel/mlx_ethernet/src/lib.rs
@@ -15,7 +15,6 @@
 
 #[macro_use]extern crate log;
 #[macro_use] extern crate alloc;
-#[macro_use] extern crate static_assertions;
 extern crate memory;
 extern crate volatile;
 extern crate bit_field;

--- a/kernel/mlx_ethernet/src/receive_queue.rs
+++ b/kernel/mlx_ethernet/src/receive_queue.rs
@@ -36,7 +36,7 @@ pub(crate) struct TransportInterfaceReceiveContext {
     _padding4:              [u8; 20],
 }
 
-const_assert_eq!(core::mem::size_of::<TransportInterfaceReceiveContext>(), 92);
+const _: () = assert!(core::mem::size_of::<TransportInterfaceReceiveContext>() == 92);
 
 impl TransportInterfaceReceiveContext {
     /// Initialize the TIR object
@@ -93,7 +93,7 @@ pub(crate) struct ReceiveQueueContext {
     _padding1:                          [u8; 20],
 }
 
-const_assert_eq!(core::mem::size_of::<ReceiveQueueContext>(), 48);
+const _: () = assert!(core::mem::size_of::<ReceiveQueueContext>() == 48);
 
 impl fmt::Debug for ReceiveQueueContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/kernel/mlx_ethernet/src/send_queue.rs
+++ b/kernel/mlx_ethernet/src/send_queue.rs
@@ -39,7 +39,7 @@ pub(crate) struct TransportInterfaceSendContext {
     _padding3:          [u32; 28]
 }
 
-const_assert_eq!(core::mem::size_of::<TransportInterfaceSendContext>(), 160);
+const _: () = assert!(core::mem::size_of::<TransportInterfaceSendContext>() == 160);
 
 impl TransportInterfaceSendContext {
     /// Create and initialize a TIS object
@@ -87,7 +87,7 @@ pub(crate) struct SendQueueContext {
     tis_num_0:                          Volatile<U32<BigEndian>>,
 }
 
-const_assert_eq!(core::mem::size_of::<SendQueueContext>(), 48);
+const _: () = assert!(core::mem::size_of::<SendQueueContext>() == 48);
 
 impl fmt::Debug for SendQueueContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/kernel/mlx_ethernet/src/uar.rs
+++ b/kernel/mlx_ethernet/src/uar.rs
@@ -46,7 +46,7 @@ pub(crate) struct UserAccessRegion {
     db_blueflame_buffer3_odd_fast_path: Volatile<[U32<BigEndian>; 64]>,
 }
 
-const_assert_eq!(core::mem::size_of::<UserAccessRegion>(), 4096);
+const _: () = assert!(core::mem::size_of::<UserAccessRegion>() == 4096);
 
 impl UserAccessRegion {
     pub(crate) fn write_wqe_to_doorbell(&mut self, current_doorbell: &CurrentUARDoorbell, wqe_value: [U32<BigEndian>; 64]) {

--- a/kernel/mlx_ethernet/src/work_queue.rs
+++ b/kernel/mlx_ethernet/src/work_queue.rs
@@ -29,7 +29,7 @@ pub struct DoorbellRecord {
     pub(crate) send_counter:   Volatile<U32<BigEndian>>,
 }
 
-const_assert_eq!(core::mem::size_of::<DoorbellRecord>(), 8);
+const _: () = assert!(core::mem::size_of::<DoorbellRecord>() == 8);
 
 /// The possible formats for a WQ buffer.
 #[derive(Debug, TryFromPrimitive)]
@@ -79,7 +79,7 @@ pub(crate) struct WorkQueue {
     _padding1:                          [u64; 19],
 }
 
-const_assert_eq!(core::mem::size_of::<WorkQueue>(), 192);
+const _: () = assert!(core::mem::size_of::<WorkQueue>() == 192);
 
 impl WorkQueue {
     /// Create and initialize the fields of the WQ for a SQ or RQ context.
@@ -177,7 +177,7 @@ pub struct WorkQueueEntrySend {
     data: MemoryPointerDataSegment
 }
 
-const_assert_eq!(core::mem::size_of::<WorkQueueEntrySend>(), 64);
+const _: () = assert!(core::mem::size_of::<WorkQueueEntrySend>() == 64);
 
 impl WorkQueueEntrySend {
     /// set a WQE to an initial state
@@ -230,7 +230,7 @@ pub struct WorkQueueEntryReceive {
     data: MemoryPointerDataSegment
 }
 
-const_assert_eq!(core::mem::size_of::<WorkQueueEntryReceive>(), 16);
+const _: () = assert!(core::mem::size_of::<WorkQueueEntryReceive>() == 16);
 
 impl WorkQueueEntryReceive {
     /// set a WQE to an initial state
@@ -294,7 +294,7 @@ pub(crate) struct ControlSegment {
     ctrl_general_id:                Volatile<U32<BigEndian>>,
 }
 
-const_assert_eq!(core::mem::size_of::<ControlSegment>(), 16);
+const _: () = assert!(core::mem::size_of::<ControlSegment>() == 16);
 
 impl ControlSegment {
     /// Initialize the fields of the control segment.
@@ -358,7 +358,7 @@ pub(crate) struct EthSegment {
     inline_headers_4:       Volatile<U32<BigEndian>>,
 }
 
-const_assert_eq!(core::mem::size_of::<EthSegment>(), 32);
+const _: () = assert!(core::mem::size_of::<EthSegment>() == 32);
 
 impl EthSegment {
     /// Initialize the fields of the eth segment to send a packet.
@@ -391,7 +391,7 @@ pub(crate) struct MemoryPointerDataSegment {
     local_address_l:    Volatile<U32<BigEndian>>,
 }
 
-const_assert_eq!(core::mem::size_of::<MemoryPointerDataSegment>(), 16);
+const _: () = assert!(core::mem::size_of::<MemoryPointerDataSegment>() == 16);
 
 impl MemoryPointerDataSegment {
     /// Initialize the fields of the data segment to send or receive a packet.

--- a/kernel/multiple_heaps/Cargo.toml
+++ b/kernel/multiple_heaps/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 
 [dependencies]
 intrusive-collections = "0.9.0"
-static_assertions = "1.1.0"
 cfg-if = "0.1.6"
 spin = "0.9.4"
 

--- a/kernel/multiple_heaps/src/lib.rs
+++ b/kernel/multiple_heaps/src/lib.rs
@@ -576,7 +576,6 @@ if #[cfg(unsafe_large_allocations)] {
 
 } else {
     extern crate intrusive_collections;
-    #[macro_use] extern crate static_assertions;
 
     use intrusive_collections::{intrusive_adapter,RBTree, RBTreeLink, KeyAdapter, PointerOps};
 
@@ -589,7 +588,7 @@ if #[cfg(unsafe_large_allocations)] {
 
     // Our design depends on the fact that on the large allocation path, only objects smaller than the max allocation size will be allocated from the heap.
     // Otherwise we will have a recursive loop of large allocations.
-    const_assert!(core::mem::size_of::<LargeAllocation>() < ZoneAllocator::MAX_ALLOC_SIZE); 
+    const _: () = assert!(core::mem::size_of::<LargeAllocation>() < ZoneAllocator::MAX_ALLOC_SIZE);
 
     intrusive_adapter!(LargeAllocationAdapter = Box<LargeAllocation>: LargeAllocation { link: RBTreeLink });
 

--- a/kernel/pte_flags/Cargo.toml
+++ b/kernel/pte_flags/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2021"
 [dependencies]
 cfg-if = "1.0.0"
 bitflags = "1.3.2"
-static_assertions = "1.1.0"

--- a/kernel/pte_flags/src/lib.rs
+++ b/kernel/pte_flags/src/lib.rs
@@ -30,7 +30,6 @@
 
 use cfg_if::cfg_if;
 use bitflags::bitflags;
-use static_assertions::const_assert_ne;
 
 cfg_if!{ if #[cfg(any(target_arch = "x86_64", doc))] {
     mod pte_flags_x86_64;
@@ -159,9 +158,9 @@ cfg_if!{ if #[cfg(target_arch = "x86_64")] {
 
 // Due to the way that the `bitflags` crate works, we can only use
 // non-zero bit flag values for the above definitions.
-const_assert_ne!(DEVICE_MEMORY_BITS.bits(), 0);
-const_assert_ne!(WRITABLE_BIT.bits(), 0);
-const_assert_ne!(GLOBAL_BIT.bits(), 0);
+const _: () = assert!(DEVICE_MEMORY_BITS.bits() != 0);
+const _: () = assert!(WRITABLE_BIT.bits() != 0);
+const _: () = assert!(GLOBAL_BIT.bits() != 0);
 
 
 /// See [`PteFlags::new()`] for what bits are set by default.

--- a/kernel/pte_flags/src/pte_flags_aarch64.rs
+++ b/kernel/pte_flags/src/pte_flags_aarch64.rs
@@ -2,14 +2,12 @@
 
 use crate::PteFlags;
 use bitflags::bitflags;
-use static_assertions::const_assert_eq;
 
 /// A mask for the bits of a page table entry that contain the physical frame address.
 pub const PTE_FRAME_MASK: u64 = 0x0000_FFFF_FFFF_F000;
 
 // Ensure that we never expose reserved bits [12:47] as part of the `PteFlagsAarch64` interface.
-const_assert_eq!(PteFlagsAarch64::all().bits() & PTE_FRAME_MASK, 0);
-
+const _: () = assert!(PteFlagsAarch64::all().bits() & PTE_FRAME_MASK == 0);
 
 bitflags! {
     /// Page table entry (PTE) flags on aarch64.

--- a/kernel/pte_flags/src/pte_flags_x86_64.rs
+++ b/kernel/pte_flags/src/pte_flags_x86_64.rs
@@ -2,13 +2,12 @@
 
 use crate::PteFlags;
 use bitflags::bitflags;
-use static_assertions::const_assert_eq;
 
 /// A mask for the bits of a page table entry that contain the physical frame address.
 pub const PTE_FRAME_MASK: u64 = 0x000F_FFFF_FFFF_F000;
 
 // Ensure that we never expose reserved bits [12:51] as part of the `PteFlagsX86_64` interface.
-const_assert_eq!(PteFlagsX86_64::all().bits() & PTE_FRAME_MASK, 0);
+const _: () = assert!(PteFlagsX86_64::all().bits() & PTE_FRAME_MASK == 0);
 
 
 bitflags! {

--- a/kernel/serial_port/Cargo.toml
+++ b/kernel/serial_port/Cargo.toml
@@ -9,7 +9,6 @@ log = "0.4.8"
 spin = "0.9.4"
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 x86_64 = "0.14.8"
-static_assertions = "1.1.0"
 
 [dependencies.serial_port_basic]
 path = "../serial_port_basic"

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -17,7 +17,6 @@
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate alloc;
-#[macro_use] extern crate static_assertions;
 extern crate spin;
 extern crate irq_safety;
 extern crate interrupts;
@@ -351,8 +350,9 @@ pub struct DataChunk {
     pub len: u8,
     pub data: [u8; (64 - 1)],
 }
-const_assert_eq!(core::mem::size_of::<DataChunk>(), 64);
-const_assert_eq!(core::mem::align_of::<DataChunk>(), 64);
+const _: () = assert!(core::mem::size_of::<DataChunk>() == 64);
+const _: () = assert!(core::mem::align_of::<DataChunk>() == 64);
+
 impl DataChunk {
     /// Returns a new `DataChunk` filled with zeroes that can be written into.
     pub const fn empty() -> Self {

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -388,8 +388,8 @@ pub struct Task {
 }
 
 // Ensure that atomic fields in the `Tast` struct are actually lock-free atomics.
-const_assert!(AtomicCell::<OptionU8>::is_lock_free());
-const_assert!(AtomicCell::<RunState>::is_lock_free());
+const _: () = assert!(AtomicCell::<OptionU8>::is_lock_free());
+const _: () = assert!(AtomicCell::<RunState>::is_lock_free());
 
 impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/kernel/thread_local_macro/Cargo.toml
+++ b/kernel/thread_local_macro/Cargo.toml
@@ -5,7 +5,6 @@ description = "Implementation of the thread_local!() macro, similar to Rust libs
 version = "0.1.0"
 
 [dependencies]
-static_assertions = "1.1.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/thread_local_macro/src/lib.rs
+++ b/kernel/thread_local_macro/src/lib.rs
@@ -36,7 +36,6 @@
 #![allow(unused_unsafe)]
 
 extern crate alloc;
-#[macro_use] extern crate static_assertions;
 
 use core::cell::RefCell;
 
@@ -68,7 +67,7 @@ pub struct TlsObjectDestructor {
     pub dtor: unsafe extern "C" fn(*mut u8),
 }
 // See the above [`TLS_DESTRUCTORS`] docs for why this is necessary.
-const_assert!(!core::mem::needs_drop::<TlsObjectDestructor>());
+const _: () = assert!(!core::mem::needs_drop::<TlsObjectDestructor>());
 
 /// Takes ownership of the list of [`TlsObjectDestructor`]s
 /// for TLS objects that have been initialized in this current task's TLS area.

--- a/kernel/time/Cargo.toml
+++ b/kernel/time/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 log = "0.4.8"
-static_assertions = "1.1.0"
 
 [dependencies.crossbeam-utils]
 version = "0.8.2"

--- a/kernel/time/src/dummy.rs
+++ b/kernel/time/src/dummy.rs
@@ -3,8 +3,8 @@ use core::time::Duration;
 use log::error;
 
 type _AtomicFn = crossbeam_utils::atomic::AtomicCell<fn()>;
-static_assertions::const_assert!(_AtomicFn::is_lock_free());
-static_assertions::const_assert_eq!(core::mem::size_of::<_AtomicFn>(), 8);
+const _: () = assert!(_AtomicFn::is_lock_free());
+const _: () = assert!(core::mem::size_of::<_AtomicFn>() == 8);
 
 pub(crate) fn early_sleep(_: Duration) {
     error!("called early_sleep dummy function");


### PR DESCRIPTION
* it is still needed for assert_not_impl_any

I used this search & replace:
`const_assert_eq!\(core::mem::size_of::<([A-Za-z0-9_]*)>\(\),\s`
`const _: () = assert!(core::mem::size_of::<$1>() == `
and changed the others by hand.
We can do something similar if assert_eq ever becomes const.