### PR TITLE
Add pci I/O bar access and use bitfields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,9 +2493,9 @@ version = "0.1.0"
 name = "pci"
 version = "0.1.0"
 dependencies = [
- "bit_field 0.7.0",
  "log",
  "memory",
+ "modular-bitfield",
  "port_io",
  "spin 0.9.4",
 ]

--- a/kernel/e1000/src/lib.rs
+++ b/kernel/e1000/src/lib.rs
@@ -36,7 +36,7 @@ use spin::Once;
 use alloc::{collections::VecDeque, format, sync::Arc, vec::Vec};
 use irq_safety::MutexIrqSafe;
 use memory::{PhysicalAddress, BorrowedMappedPages, BorrowedSliceMappedPages, Mutable};
-use pci::{PciDevice, PCI_INTERRUPT_LINE, PciConfigSpaceAccessMechanism};
+use pci::{PciDevice, PCI_INTERRUPT_LINE, PciConfigSpaceAccessMechanism, BaseAddress};
 use kernel_config::memory::PAGE_SIZE;
 use interrupts::eoi;
 use x86_64::structures::idt::InterruptStackFrame;
@@ -196,7 +196,11 @@ impl E1000Nic {
         }
   
         // memory mapped base address
-        let mem_base = e1000_pci_dev.determine_mem_base(0)?;
+        let mem_base = if let BaseAddress::Memory(base) = e1000_pci_dev.determine_mem_base(0)? {
+            base
+        } else {
+            return Err("Base Address should be memory-mapped.")
+        };
 
         // set the bus mastering bit for this PciDevice, which allows it to use DMA
         e1000_pci_dev.pci_set_command_bus_master_bit();

--- a/kernel/ixgbe/src/lib.rs
+++ b/kernel/ixgbe/src/lib.rs
@@ -56,7 +56,7 @@ use alloc::{
 };
 use irq_safety::MutexIrqSafe;
 use memory::{PhysicalAddress, MappedPages, Mutable, BorrowedSliceMappedPages, BorrowedMappedPages};
-use pci::{PciDevice, MSIX_CAPABILITY, PciConfigSpaceAccessMechanism, PciLocation};
+use pci::{PciDevice, MSIX_CAPABILITY, PciConfigSpaceAccessMechanism, PciLocation, BaseAddress};
 use bit_field::BitField;
 use interrupts::register_msi_interrupt;
 use x86_64::structures::idt::HandlerFunc;
@@ -309,7 +309,11 @@ impl IxgbeNic {
         }
 
         // 16-byte aligned memory mapped base address
-        let mem_base =  ixgbe_pci_dev.determine_mem_base(0)?;
+        let mem_base = if let BaseAddress::Memory(base) = ixgbe_pci_dev.determine_mem_base(0)? {
+            base
+        } else {
+            return Err("Base Address should be memory-mapped.")
+        };
 
         // set the bus mastering bit for this PciDevice, which allows it to use DMA
         ixgbe_pci_dev.pci_set_command_bus_master_bit();

--- a/kernel/pci/Cargo.toml
+++ b/kernel/pci/Cargo.toml
@@ -3,10 +3,11 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "pci"
 description = "Basic PCI support for Theseus, x86 only."
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 spin = "0.9.4"
-bit_field = "0.7.0"
+modular-bitfield = "0.11.2"
 
 [dependencies.log]
 version = "0.4.8"


### PR DESCRIPTION
* edition update/clippy as well

I added some TODOs because I'm not done with pci, will do more PRs. I actually stated a question there too: Do we / does the device author always know what kind of address a `determine_mem_base` call returns?
I can look that up in a pci spec, just asking if anybody knows.