### PR TITLE
Enable multiboot2 conditionally in `nano_core`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ boot_spec ?= bios
 ifeq ($(boot_spec), bios)
 	ISO_EXTENSION := iso
 else ifeq ($(boot_spec), uefi)
+	## Disable the default "bios" feature of the nano_core
+	export override FEATURES+=--no-default-features
 	ISO_EXTENSION := efi
 else
 $(error Error:unsupported option "boot_spec=$(boot_spec)". Options are 'bios' or 'uefi')

--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -58,7 +58,6 @@ path = "../memory_initialization"
 
 [dependencies.boot_info]
 path = "../boot_info"
-features = ["multiboot2"]
 
 [dependencies.uefi-bootloader-api]
 git = "https://github.com/theseus-os/uefi-bootloader"

--- a/kernel/nano_core/build.rs
+++ b/kernel/nano_core/build.rs
@@ -21,14 +21,17 @@ const CARGO_CFG_PREFIX: &str = "CARGO_CFG_";
 // https://doc.rust-lang.org/cargo/reference/features.html#mutually-exclusive-features
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "bios")] {
-        const BOOT_SPECIFICATION: &str = "bios";
-    } else if #[cfg(feature = "uefi")] {
+    if #[cfg(feature = "uefi")] {
         const BOOT_SPECIFICATION: &str = "uefi";
+    } else if #[cfg(feature = "bios")] {
+        const BOOT_SPECIFICATION: &str = "bios";
     } else {
         compile_error!("either the bios or uefi features must be enabled");
     }
 }
+
+#[cfg(all(feature = "uefi", feature = "bios"))]
+compile_error!("Both the 'bios' and 'uefi' features cannot be jointly enabled");
 
 /// The set of built-in environment variables defined by cargo.
 static NON_CUSTOM_CFGS: [&str; 12] = [

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -27,10 +27,10 @@ use kernel_config::memory::KERNEL_OFFSET;
 use vga_buffer::println_raw;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "bios")] {
-        mod bios;
-    } else if #[cfg(feature = "uefi")] {
+    if #[cfg(feature = "uefi")] {
         mod uefi;
+    } else if #[cfg(feature = "bios")] {
+        mod bios;
     } else {
         compile_error!("either the 'bios' or 'uefi' feature must be enabled");
     }


### PR DESCRIPTION
* Refactor `uefi_loader` to add more space to the FAT filesystem when needed.

* Ensure that both `uefi` and `bios` features cannot be enabled simultaneously, since it doesn't work properly anyways.