### PR TITLE
Make the `mirror_log_to_vga` feature work again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "task_fs",
  "tlb_shootdown",
  "tsc",
+ "vga_buffer",
  "window_manager",
 ]
 
@@ -1762,10 +1763,10 @@ dependencies = [
 name = "logger"
 version = "0.1.0"
 dependencies = [
+ "crossbeam-utils",
  "irq_safety",
  "log",
  "serial_port_basic",
- "spin 0.9.4",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -965,6 +965,7 @@ ifneq ($(IS_WSL), )
 	@echo -e "The ISO file is available at \"$(iso)\"."
 else
 ## building on Linux or macOS
+	@echo -e "\n\033[1;32mThe build finished successfully.\033[0m Writing Theseus OS ISO to /dev/$(drive)..."
 	@$(UNMOUNT) /dev/$(drive)* 2> /dev/null  |  true  ## force it to return true
 	@sudo dd bs=4194304 if=$(iso) of=/dev/$(drive)    ## use 4194304 instead of 4M because macOS doesn't support 4M
 	@sync

--- a/kernel/acpi/src/lib.rs
+++ b/kernel/acpi/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use log::{debug, warn, info, error};
+use log::{debug, warn, info};
 use spin::Mutex;
 use memory::{PageTable, PhysicalAddress};
 use rsdp::Rsdp;

--- a/kernel/app_io/src/lib.rs
+++ b/kernel/app_io/src/lib.rs
@@ -219,7 +219,7 @@ pub fn print_to_stdout_args(fmt_args: core::fmt::Arguments) {
             }
         }
         None => {
-            let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
+            // let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
         }
     };
 }

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -3,11 +3,10 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "captain"
 description = "The main driver of Theseus. Controls the loading and initialization of all subsystems and other crates."
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
-
-[dependencies.log]
-version = "0.4.8"
+log = "0.4.8"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"
@@ -84,6 +83,9 @@ path = "../console"
 
 [dependencies.app_io]
 path = "../app_io"
+
+[dependencies.vga_buffer]
+path = "../vga_buffer"
 
 [dependencies.network_manager]
 path = "../network_manager"

--- a/kernel/logger/Cargo.toml
+++ b/kernel/logger/Cargo.toml
@@ -4,8 +4,8 @@ name = "logger"
 version = "0.1.0"
 
 [dependencies]
-spin = "0.9.4"
 log = "0.4.8"
+crossbeam-utils = { version = "0.8.12", default-features = false }
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"

--- a/kernel/logger/src/lib.rs
+++ b/kernel/logger/src/lib.rs
@@ -9,18 +9,20 @@
 #![no_std]
 #![feature(trait_alias)]
 
-extern crate log;
 extern crate alloc;
-extern crate spin;
+extern crate crossbeam_utils;
+extern crate log;
 extern crate irq_safety;
 extern crate serial_port_basic;
 
 use log::{Record, Level, SetLoggerError, Metadata, Log};
 use core::{borrow::Borrow, fmt::{self, Write}, ops::Deref};
-use spin::Once;
 use irq_safety::MutexIrqSafe;
 use serial_port_basic::SerialPort;
 use alloc::{sync::Arc, vec::Vec};
+
+#[cfg(mirror_log_to_vga)]
+pub use mirror_log::set_log_mirror_function;
 
 
 /// By default, Theseus will print all log levels, including `Trace` and above.
@@ -131,7 +133,8 @@ impl Log for DummyLogger {
         // If there was an error above, there's literally nothing we can do but ignore it,
         // because there is no other lower-level way to log errors than the serial port.
         
-        if let Some(func) = MIRROR_VGA_FUNC.get() {
+        #[cfg(mirror_log_to_vga)]
+        if let Some(func) = mirror_log::get_log_mirror_function() {
             // Currently printing to the VGA terminal doesn't support ANSI color escape sequences,
             // so we exclude the first and the last elements that set those colors.
             func(format_args!("{}{}:{}: {}",
@@ -269,14 +272,23 @@ impl LogColor {
     }
 }
 
+#[cfg(mirror_log_to_vga)]
+mod mirror_log {
+    use core::fmt;
+    use crossbeam_utils::atomic::AtomicCell;
 
-/// Call this to enable mirroring logging macros to the screen
-pub fn mirror_to_vga(func: LogOutputFunc) {
-    MIRROR_VGA_FUNC.call_once(|| func);
+    /// Call this to enable mirroring of logger output (e.g., via logging macros)
+    /// to another output sink, such as the VGA screen.
+    pub fn set_log_mirror_function(func: fn(fmt::Arguments)) {
+        MIRROR_LOG_FUNC.store(Some(func));
+    }
+
+    pub(crate) fn get_log_mirror_function() -> Option<fn(fmt::Arguments)> {
+        MIRROR_LOG_FUNC.load()
+    }
+
+    /// The callback function that will optionally be invoked
+    /// on every log statement to be printed, which enables log mirroring.
+    pub(crate) static MIRROR_LOG_FUNC: AtomicCell<Option<fn(fmt::Arguments)>> = AtomicCell::new(None);
+    const _: () = assert!(AtomicCell::<fn(fmt::Arguments)>::is_lock_free());
 }
-
-/// The signature of a callback function that will optionally be invoked
-/// on every log statement to be printed, which enables log mirroring.
-/// See [`mirror_to_vga()`].
-pub type LogOutputFunc = fn(fmt::Arguments);
-static MIRROR_VGA_FUNC: Once<LogOutputFunc> = Once::new();


### PR DESCRIPTION
* This is an old feature that mirrors Theseus's log output to the screen. It now supports both early VGA output and later, more fully-featured terminal displays.

* The logger now allows the log-mirroring function callback to be replaced, which we use after graphical terminal displays have been initialized.

* Currently, not all log messages are mirrored, it is done on a best-effort basis.