### PR TITLE
Set up an early dummy TLS data image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,6 +2006,7 @@ dependencies = [
  "lz4_flex",
  "memfs",
  "memory",
+ "no_drop",
  "path",
  "qp-trie",
  "rangemap",
@@ -2014,6 +2015,7 @@ dependencies = [
  "serde",
  "spin 0.9.4",
  "vfs_node",
+ "x86_64",
  "xmas-elf",
 ]
 

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -24,6 +24,7 @@ use log::{error, info};
 use memory::{EarlyIdentityMappedPages, MmiRef, PhysicalAddress, VirtualAddress};
 use kernel_config::memory::KERNEL_STACK_SIZE_IN_PAGES;
 use irq_safety::enable_interrupts;
+use mod_mgmt::TlsDataImage;
 use stack::Stack;
 use no_drop::NoDrop;
 
@@ -39,6 +40,18 @@ mod mirror_log_callbacks {
     /// fully-featured terminal-based display.
     pub(crate) fn mirror_to_terminal(args: core::fmt::Arguments) {
         app_io::println!("{}", args);
+    }
+}
+
+/// Items that must be held until the end of [`init()`] and should be dropped after.
+pub struct DropAfterInit {
+    pub identity_mappings: NoDrop<EarlyIdentityMappedPages>,
+    pub initial_tls_image: NoDrop<TlsDataImage>,
+}
+impl DropAfterInit {
+    fn drop_all(self) {
+        drop(self.identity_mappings.into_inner());
+        drop(self.initial_tls_image.into_inner());
     }
 }
 
@@ -61,8 +74,8 @@ mod mirror_log_callbacks {
 ///    if available and provided by the bootloader.
 pub fn init(
     kernel_mmi_ref: MmiRef,
-    identity_mapped_pages: NoDrop<EarlyIdentityMappedPages>,
     bsp_initial_stack: NoDrop<Stack>,
+    drop_after_init: DropAfterInit,
     ap_start_realmode_begin: VirtualAddress,
     ap_start_realmode_end: VirtualAddress,
     ap_gdt: VirtualAddress,
@@ -147,11 +160,6 @@ pub fn init(
     device_manager::init(key_producer, mouse_producer)?;
     task_fs::init()?;
 
-
-    // We can drop and unmap the identity mappings after the initial bootstrap is complete.
-    // We could probably do this earlier, but we definitely can't do it until after the APs boot.
-    drop(identity_mapped_pages.into_inner());
-    
     // create a SIMD personality
     #[cfg(simd_personality)] {
         #[cfg(simd_personality_sse)]
@@ -164,8 +172,11 @@ pub fn init(
             .spawn()?;
     }
 
-    // Now that key subsystems are initialized, we can spawn various system tasks/daemons
-    // and then the first application(s).
+    // Now that key subsystems are initialized, we can:
+    // 1. Drop the items that needed to be held through initialization,
+    // 2. Spawn various system tasks/daemons,
+    // 3. Start the first application(s).
+    drop_after_init.drop_all();
     console::start_connection_detection()?;
     first_application::start()?;
 

--- a/kernel/mod_mgmt/Cargo.toml
+++ b/kernel/mod_mgmt/Cargo.toml
@@ -52,6 +52,9 @@ path = "../root"
 [dependencies.fs_node]
 path = "../fs_node"
 
+[dependencies.no_drop]
+path = "../no_drop"
+
 [dependencies.hashbrown]
 version = "0.11.2"
 features = ["nightly"]
@@ -74,6 +77,9 @@ features = ["derive", "alloc"]
 version = "2.0.0-rc.1"
 default-features = false
 features = ["serde", "alloc"]
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+x86_64 = "0.14.8"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -38,7 +38,7 @@ pub struct NanoCoreItems {
     /// of TLS variables (before tasking is initialized) do not cause exceptions.
     ///
     /// After the task management subsystem has been initialized, this can be dropped.
-    pub tls_data: NoDrop<TlsDataImage>,
+    pub tls_image: NoDrop<TlsDataImage>,
 }
 
 /// Parses and/or deserializes the file containing details about the already loaded
@@ -149,11 +149,11 @@ pub fn parse_nano_core(
 
     // Now that we've initialized the nano_core, i.e., set up its sections,
     // we can obtain a new TLS data image and initialize the TLS register to point to it.
-    let tls_data = namespace.get_tls_initializer_data();
+    let tls_image = namespace.get_tls_initializer_data();
     {
         #[cfg(target_arch = "x86_64")]
         x86_64::registers::model_specific::FsBase::write(
-            x86_64::VirtAddr::new(tls_data.pointer_value() as u64)
+            x86_64::VirtAddr::new(tls_image.pointer_value() as u64)
         );
 
         #[cfg(not(target_arch = "x86_64"))]
@@ -164,7 +164,7 @@ pub fn parse_nano_core(
         nano_core_crate_ref,
         init_symbol_values,
         num_new_symbols,
-        tls_data: NoDrop::new(tls_data),
+        tls_image: NoDrop::new(tls_image),
     })
 }
 

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -199,7 +199,7 @@ where
         let (_pw_crate, _num_pw_syms) = default_namespace.load_crate(&panic_wrapper_file, None, &kernel_mmi_ref, false)?;
     }
 
-    // Now we load and jump directly to the Captain, which will take over from here.
+    // Now we invoke the Captain, which will take over from here.
     // That's it, the nano_core is done! That's really all it does! 
     let drop_after_init = captain::DropAfterInit {
         identity_mappings: identity_mapped_pages,

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -128,19 +128,23 @@ where
 
     // Parse the nano_core crate (the code we're already running) since we need it to load and run applications.
     println_raw!("nano_core(): parsing nano_core crate, please wait ...");
-    let (nano_core_crate_ref, ap_realmode_begin, ap_realmode_end, ap_gdt) = match mod_mgmt::parse_nano_core::parse_nano_core(
+    let (
+        nano_core_crate_ref,
+        initial_tls_image,
+        ap_realmode_begin,
+        ap_realmode_end,
+        ap_gdt,
+    ) = match mod_mgmt::parse_nano_core::parse_nano_core(
         default_namespace,
         text_mapped_pages.into_inner(),
         rodata_mapped_pages.into_inner(),
         data_mapped_pages.into_inner(),
         false,
     ) {
-        //
-        // TODO: FIXME: pass the `tls_data` item through to the captain such that
-        //              it can be dropped along with the identity_mapped_pages.
-        //
-        Ok(NanoCoreItems { nano_core_crate_ref, init_symbol_values, .. }) => {
-            // Get symbols from the boot assembly code that defines where the ap_start code are.
+        Ok(NanoCoreItems { nano_core_crate_ref, init_symbol_values, num_new_symbols, tls_image }) => {
+            println_raw!("nano_core(): finished parsing the nano_core crate, {} new symbols.", num_new_symbols);
+
+            // Get symbols from the boot assembly code that define where the ap_start code is.
             // They will be present in the ".init" sections, i.e., in the `init_symbols` list. 
             let ap_realmode_begin = init_symbol_values
                 .get("ap_start_realmode")
@@ -171,11 +175,10 @@ where
                 .ok_or("couldn't convert \"GDT_AP\" physical address to virtual")?
             };
             // debug!("ap_realmode_begin: {:#X}, ap_realmode_end: {:#X}", ap_realmode_begin, ap_realmode_end);
-            (nano_core_crate_ref, ap_realmode_begin, ap_realmode_end, ap_gdt)
+            (nano_core_crate_ref, tls_image, ap_realmode_begin, ap_realmode_end, ap_gdt)
         }
         Err((msg, _mapped_pages_array)) => return Err(msg),
     };
-    println_raw!("nano_core(): finished parsing the nano_core crate.");
 
     #[cfg(loadable)] {
         // This isn't currently necessary; we can always add it in back later if/when needed.
@@ -196,15 +199,19 @@ where
         let (_pw_crate, _num_pw_syms) = default_namespace.load_crate(&panic_wrapper_file, None, &kernel_mmi_ref, false)?;
     }
 
-
-    // at this point, we load and jump directly to the Captain, which will take it from here. 
+    // Now we load and jump directly to the Captain, which will take over from here.
     // That's it, the nano_core is done! That's really all it does! 
+    let drop_after_init = captain::DropAfterInit {
+        identity_mappings: identity_mapped_pages,
+        initial_tls_image,
+    };
     println_raw!("nano_core(): invoking the captain...");
     #[cfg(not(loadable))] {
-        captain::init(kernel_mmi_ref, identity_mapped_pages, stack, ap_realmode_begin, ap_realmode_end, ap_gdt, rsdp_address)?;
+        captain::init(kernel_mmi_ref, stack, drop_after_init, ap_realmode_begin, ap_realmode_end, ap_gdt, rsdp_address)?;
     }
     #[cfg(loadable)] {
-        use memory::{EarlyIdentityMappedPages, MmiRef, PhysicalAddress};
+        use captain::DropAfterInit;
+        use memory::{MmiRef, PhysicalAddress};
         use no_drop::NoDrop;
         use stack::Stack;
 
@@ -214,10 +221,10 @@ where
             .ok_or("no single symbol matching \"captain::init\"")?;
         log::info!("The nano_core (in loadable mode) is invoking the captain init function: {:?}", section.name);
 
-        type CaptainInitFunc = fn(MmiRef, NoDrop<EarlyIdentityMappedPages>, NoDrop<Stack>, VirtualAddress, VirtualAddress, VirtualAddress, Option<PhysicalAddress>) -> Result<(), &'static str>;
+        type CaptainInitFunc = fn(MmiRef, NoDrop<Stack>, DropAfterInit, VirtualAddress, VirtualAddress, VirtualAddress, Option<PhysicalAddress>) -> Result<(), &'static str>;
         let func: &CaptainInitFunc = unsafe { section.as_func() }?;
 
-        func(kernel_mmi_ref, identity_mapped_pages, stack, ap_realmode_begin, ap_realmode_end, ap_gdt, rsdp_address)?;
+        func(kernel_mmi_ref, stack, drop_after_init, ap_realmode_begin, ap_realmode_end, ap_gdt, rsdp_address)?;
     }
 
     // the captain shouldn't return ...

--- a/kernel/panic_entry/src/lib.rs
+++ b/kernel/panic_entry/src/lib.rs
@@ -62,8 +62,8 @@ fn panic_entry_point(info: &PanicInfo) -> ! {
 
     if let Err(_e) = res {
         // basic early panic printing with no dependencies
-        println_raw!("\nPANIC: {}", info);
-        error!("PANIC: {}", info);
+        println_raw!("\nHalting due to early panic: {}", info);
+        error!("Halting due to early panic: {}", info);
     }
 
     // If we failed to handle the panic, there's not really much we can do about it,

--- a/kernel/preemption/src/lib.rs
+++ b/kernel/preemption/src/lib.rs
@@ -44,10 +44,10 @@ pub fn hold_preemption() -> PreemptionGuard {
         
         // When transitioning from preemption being enabled to disabled,
         // we must disable the local APIC timer used for preemptive task switching.
-        // apic::get_my_apic()
-        //     .expect("BUG: hold_preemption() couldn't get local APIC")
-        //     .write()
-        //     .enable_lvt_timer(false);
+        apic::get_my_apic()
+            .expect("BUG: hold_preemption() couldn't get local APIC")
+            .write()
+            .enable_lvt_timer(false);
     } else if prev_val == u8::MAX {
         // Overflow occurred and the counter value wrapped around, which is a bug.
         panic!("BUG: Overflow occurred in the preemption counter for CPU {}", cpu_id);
@@ -120,10 +120,10 @@ impl Drop for PreemptionGuard {
             // If the previous counter value was 1, that means the current value is 1,
             // which indicates we are transitioning from preemption disabled to enabled on this CPU.
             // Thus, we re-enable the local APIC timer used for preemptive task switching.
-            // apic::get_my_apic()
-            //     .expect("BUG: PreemptionGuard::drop() couldn't get local APIC")
-            //     .write()
-            //     .enable_lvt_timer(true);
+            apic::get_my_apic()
+                .expect("BUG: PreemptionGuard::drop() couldn't get local APIC")
+                .write()
+                .enable_lvt_timer(true);
         } else if prev_val == 0 {
             // Underflow occurred and the counter value wrapped around, which is a bug.
             panic!("BUG: Underflow occurred in the preemption counter for CPU {}", cpu_id);

--- a/kernel/preemption/src/lib.rs
+++ b/kernel/preemption/src/lib.rs
@@ -44,10 +44,10 @@ pub fn hold_preemption() -> PreemptionGuard {
         
         // When transitioning from preemption being enabled to disabled,
         // we must disable the local APIC timer used for preemptive task switching.
-        apic::get_my_apic()
-            .expect("BUG: hold_preemption() couldn't get local APIC")
-            .write()
-            .enable_lvt_timer(false);
+        // apic::get_my_apic()
+        //     .expect("BUG: hold_preemption() couldn't get local APIC")
+        //     .write()
+        //     .enable_lvt_timer(false);
     } else if prev_val == u8::MAX {
         // Overflow occurred and the counter value wrapped around, which is a bug.
         panic!("BUG: Overflow occurred in the preemption counter for CPU {}", cpu_id);
@@ -120,10 +120,10 @@ impl Drop for PreemptionGuard {
             // If the previous counter value was 1, that means the current value is 1,
             // which indicates we are transitioning from preemption disabled to enabled on this CPU.
             // Thus, we re-enable the local APIC timer used for preemptive task switching.
-            apic::get_my_apic()
-                .expect("BUG: PreemptionGuard::drop() couldn't get local APIC")
-                .write()
-                .enable_lvt_timer(true);
+            // apic::get_my_apic()
+            //     .expect("BUG: PreemptionGuard::drop() couldn't get local APIC")
+            //     .write()
+            //     .enable_lvt_timer(true);
         } else if prev_val == 0 {
             // Underflow occurred and the counter value wrapped around, which is a bug.
             panic!("BUG: Underflow occurred in the preemption counter for CPU {}", cpu_id);

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -754,7 +754,11 @@ impl Task {
     /// 
     /// This updates the current TLS area, which is written to the `FS_BASE` MSR on x86_64.
     fn set_as_current_task(&self) {
+        #[cfg(target_arch = "x86_64")]
         FsBase::write(x86_64::VirtAddr::new(self.tls_area.pointer_value() as u64));
+
+        #[cfg(not(target_arch = "x86_64"))]
+        todo!("Task::set_as_current_task() is not yet implemented for this platform!");
     }
 
     /// Perform any actions needed after a context switch.


### PR DESCRIPTION
This fixes a rare issue where a page fault occurs upon a very early panic or error, only when the `mirror_log_to_vga` cfg option is enabled.

This stemmed from the TLS variables that hold the current task and current task ID being accessed (for fault recovery purposes) upon a panic, but those TLS data sections aren't generally available until the tasking subsystem is initialized.

Now, we initialize the TLS data image (using `FsBase` on x86_64`) as soon as we possibly can, which is right after the `nano_core` is parsed and first initialized.
We use a dummy/empty TLS data image for this, which ensures that the TLS register points to a real initialized TLS data image, avoiding weird problems like an unexpected page fault.

Note that the prior behavior wasn't a real problem or had any safety implications, it's just caused an annoying issue where you couldn't get a clean error message when an early error happened on real hardware.