### PR TITLE
Use longer timeout for PS/2 keyboard reset command

### DIFF
--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -431,9 +431,14 @@ impl<'c> PS2Keyboard<'c> {
     
     /// Reset the keyboard.
     pub fn reset(&self) -> Result<(), &'static str> {
-        self.command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(ResetAndStartSelfTest))?; 
-        if let Ok(SelfTestPassed) = self.controller.read_data().try_into() {
-            return Ok(())
+        self.command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(ResetAndStartSelfTest))?;
+        // VirtualBox and presumably real hardware wants this. Qemu worked without this.
+        // Sadly self.controller.polling_receive doesn't work here, either.
+        const VERY_ARBITRARY_TIMEOUT_VALUE: u16 = u16::MAX;
+        for _ in 0..VERY_ARBITRARY_TIMEOUT_VALUE {
+            if let Ok(SelfTestPassed) = self.controller.read_data().try_into() {
+                return Ok(())
+            }
         }
         Err("failed to reset keyboard")
     }


### PR DESCRIPTION
This is either a fix for VirtualBox only or also fixes it on real hardware.
When the other real-hw bugs are fixed, I can try, otherwise someone else might.