### PR TITLE
Fix "docs build" badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Theseus OS
 
-[![Documentation Action](https://img.shields.io/github/workflow/status/theseus-os/Theseus/Documentation?label=docs%20build)](https://github.com/theseus-os/Theseus/actions/workflows/docs.yaml)
+[![Documentation Action](https://img.shields.io/github/actions/workflow/status/theseus-os/Theseus/docs.yaml?label=docs%20build)](https://github.com/theseus-os/Theseus/actions/workflows/docs.yaml)
 [![Documentation](https://img.shields.io/badge/view-docs-blue)](https://theseus-os.github.io/Theseus/doc/___Theseus_Crates___/index.html)
 [![Book](https://img.shields.io/badge/view-book-blueviolet)](https://theseus-os.github.io/Theseus/book/index.html)
 [![Blog](https://img.shields.io/badge/view-blog-orange)](https://theseus-os.com)


### PR DESCRIPTION
Addresses breaking change in https://github.com/badges/shields/issues/8671