### PR TITLE
Partially port `cpu` to aarch64

### DIFF
--- a/kernel/cpu/Cargo.toml
+++ b/kernel/cpu/Cargo.toml
@@ -8,5 +8,9 @@ edition = "2021"
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 apic = { path = "../apic" }
 
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+tock-registers = "0.7.0"
+cortex-a = "7.5.0"
+
 [lib]
 crate-type = ["rlib"]

--- a/kernel/cpu/src/aarch64.rs
+++ b/kernel/cpu/src/aarch64.rs
@@ -63,12 +63,7 @@ impl CpuId {
 
 impl MpidrValue {
     /// Obtain the inner raw u64 that was read from the MPIDR_EL1 register
-    ///
-    /// This is not dangerous, the unsafe modifier is simply there to
-    /// indicate that this value should only be used when interacting with
-    /// hardware/peripherals, in driver code for instance; it should not be
-    /// used to identify/reference a CPU core.
-    pub unsafe fn get(self) -> u64 {
+    pub fn get(self) -> u64 {
         self.0
     }
 }

--- a/kernel/cpu/src/aarch64.rs
+++ b/kernel/cpu/src/aarch64.rs
@@ -1,0 +1,110 @@
+use cortex_a::registers::MPIDR_EL1;
+use tock_registers::interfaces::Readable;
+
+/// A unique identifier for a CPU core.
+#[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
+pub struct CpuId(u32);
+
+/// An equivalent top Option<CpuId>, which internally encodes None as
+/// `u32::MAX`, which is an invalid CpuId (bits [4:7] of affinity level
+/// 0 must always be cleared). This guarantees that it compiles down to
+/// lock-free native atomic instructions when using it inside of an atomic
+/// type like [`AtomicCell`], as u32 is atomic when running on ARMv8.
+#[derive(Clone, Copy)]
+pub struct OptionalCpuId(u32);
+
+/// A unique identifier for a CPU core.
+#[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
+pub struct MpidrValue(u64);
+
+/// Returns the number of CPUs (SMP cores) that exist and
+/// are currently initialized on this system.
+pub fn cpu_count() -> u32 {
+    // The ARM port doesn't start secondary cores for the moment.
+    1
+}
+
+/// Returns the ID of the bootstrap CPU (if known), which
+/// is the first CPU to run after system power-on.
+pub fn bootstrap_cpu() -> CpuId {
+    // The ARM port doesn't start secondary cores for the moment,
+    // so the current CPU can only be the "bootstrap" CPU.
+    current_cpu()
+}
+
+/// Returns true if the currently executing CPU is the bootstrap
+/// CPU, i.e., the first procesor to run after system power-on.
+pub fn is_bootstrap_cpu() -> bool {
+    // The ARM port doesn't start secondary cores for the moment,
+    // so the current CPU can only be the "bootstrap" CPU.
+    true
+}
+
+/// Returns the ID of the currently executing CPU.
+pub fn current_cpu() -> CpuId {
+    MpidrValue(MPIDR_EL1.get() as u64).into()
+}
+
+impl CpuId {
+    /// Reads an affinity level from this CpuId
+    ///
+    /// Valid affinity levels are 0, 1, 2, 3
+    pub fn affinity(self, level: u8) -> u8 {
+        assert!(level < 4, "Valid affinity levels are 0, 1, 2, 3");
+
+        (self.0 >> (level * 8)) as u8
+    }
+}
+
+impl MpidrValue {
+    pub unsafe fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<CpuId> for MpidrValue {
+    fn from(cpu_id: CpuId) -> Self {
+        // move aff3 from bits [24:31] to [32:39]
+        let aff_3     = (self.0 & 0xff000000) as u64 << 8;
+        let aff_0_1_2 = (self.0 & 0x00ffffff) as u64;
+
+        Self(aff_3 | aff_0_1_2)
+    }
+}
+
+impl From<MpidrValue> for CpuId {
+    fn from(cpu_id: MpidrValue) -> Self {
+        // move aff3 from bits [32:39] to [24:31]
+        let aff_3     = ((self.0 & 0xff00000000) >> 8) as u64;
+        let aff_0_1_2 =  (self.0 & 0x0000ffffff) as u64;
+
+        Self(aff_3 | aff_0_1_2)
+    }
+}
+
+impl From<Option<CpuId>> for OptionalCpuId {
+    fn from(opt: Option<CpuId>) -> Self {
+        match opt.map(|v| v.into()) {
+            Some(u32::MAX) => panic!("CpuId is too big!"),
+            Some(cpu_id) => OptionalCpuId(cpu_id),
+            None => OptionalCpuId(u32::MAX),
+        }
+    }
+}
+
+impl From<OptionalCpuId> for Option<CpuId> {
+    fn from(val: OptionalCpuId) -> Self {
+        match val.0 {
+            u32::MAX => None,
+            v => Some(v as CpuId),
+        }
+    }
+}
+
+impl fmt::Debug for OptionalCpuId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", Option::<CpuId>::from(*self))
+    }
+}

--- a/kernel/cpu/src/aarch64.rs
+++ b/kernel/cpu/src/aarch64.rs
@@ -8,7 +8,7 @@ use core::fmt;
 #[repr(transparent)]
 pub struct CpuId(u32);
 
-/// An equivalent top Option<CpuId>, which internally encodes None as
+/// An equivalent to Option<CpuId>, which internally encodes None as
 /// `u32::MAX`, which is an invalid CpuId (bits [4:7] of affinity level
 /// 0 must always be cleared). This guarantees that it compiles down to
 /// lock-free native atomic instructions when using it inside of an atomic

--- a/kernel/cpu/src/aarch64.rs
+++ b/kernel/cpu/src/aarch64.rs
@@ -4,7 +4,7 @@ use tock_registers::interfaces::Readable;
 use core::fmt;
 
 /// A unique identifier for a CPU core.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct CpuId(u32);
 
@@ -13,7 +13,7 @@ pub struct CpuId(u32);
 /// 0 must always be cleared). This guarantees that it compiles down to
 /// lock-free native atomic instructions when using it inside of an atomic
 /// type like [`AtomicCell`], as u32 is atomic when running on ARMv8.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct OptionalCpuId(u32);
 

--- a/kernel/cpu/src/aarch64.rs
+++ b/kernel/cpu/src/aarch64.rs
@@ -62,6 +62,12 @@ impl CpuId {
 }
 
 impl MpidrValue {
+    /// Obtain the inner raw u64 that was read from the MPIDR_EL1 register
+    ///
+    /// This is not dangerous, the unsafe modifier is simply there to
+    /// indicate that this value should only be used when interacting with
+    /// hardware/peripherals, in driver code for instance; it should not be
+    /// used to identify/reference a CPU core.
     pub unsafe fn get(self) -> u64 {
         self.0
     }

--- a/kernel/cpu/src/lib.rs
+++ b/kernel/cpu/src/lib.rs
@@ -6,11 +6,12 @@
 
 #![no_std]
 
-#[cfg(target_arch = "x86_64")]
-pub use apic::{
-    CpuId,
-    cpu_count,
-    bootstrap_cpu,
-    is_bootstrap_cpu,
-    current_cpu,
-};
+#[cfg_attr(target_arch = "x86_64", path = "x86_64.rs")]
+#[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
+mod arch;
+
+pub use arch::*;
+
+// Ensure that `OptionalCpuId` is atomic/lock-free.
+// This is expected by `task_struct`.
+const _: () = assert!(AtomicCell::<OptionalCpuId>::is_lock_free());

--- a/kernel/cpu/src/lib.rs
+++ b/kernel/cpu/src/lib.rs
@@ -11,7 +11,3 @@
 mod arch;
 
 pub use arch::*;
-
-// Ensure that `OptionalCpuId` is atomic/lock-free.
-// This is expected by `task_struct`.
-const _: () = assert!(AtomicCell::<OptionalCpuId>::is_lock_free());

--- a/kernel/cpu/src/lib.rs
+++ b/kernel/cpu/src/lib.rs
@@ -1,8 +1,12 @@
 //! An abstraction for querying about CPUs (cores) in an SMP multicore system.
 //!
 //! This crate contains no extra functionality.
-//! Currently it just re-exports types and functions from:
-//! * [`apic`] on x86_64
+//! Currently it consists of:
+//! * re-exports of items from [`apic`] on x86_64
+//! * canonical definitions on aarch64
+//!
+//! Note: This crate currently assumes there is only one available CPU core in
+//! the system on Arm, as secondary cores are currently unused in Theseus on Arm.
 
 #![no_std]
 

--- a/kernel/cpu/src/x86_64.rs
+++ b/kernel/cpu/src/x86_64.rs
@@ -1,0 +1,31 @@
+pub use apic::{
+    CpuId,
+    cpu_count,
+    bootstrap_cpu,
+    is_bootstrap_cpu,
+    current_cpu,
+};
+
+/// A wrapper around `Option<CpuId>` with a forced type alignment of 2 bytes,
+/// which guarantees that it compiles down to lock-free native atomic instructions
+/// when using it inside of an atomic type like [`AtomicCell`].
+#[derive(Copy, Clone)]
+#[repr(align(2))]
+pub struct OptionalCpuId(Option<CpuId>);
+impl From<Option<CpuId>> for OptionalCpuId {
+    fn from(opt: Option<CpuId>) -> Self {
+        OptionU8(opt)
+    }
+}
+
+impl From<OptionalCpuId> for Option<CpuId> {
+    fn from(val: OptionalCpuId) -> Self {
+        val.0
+    }
+}
+
+impl fmt::Debug for OptionalCpuId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}

--- a/kernel/cpu/src/x86_64.rs
+++ b/kernel/cpu/src/x86_64.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 pub use apic::{
     CpuId,
     cpu_count,
@@ -14,7 +16,7 @@ pub use apic::{
 pub struct OptionalCpuId(Option<CpuId>);
 impl From<Option<CpuId>> for OptionalCpuId {
     fn from(opt: Option<CpuId>) -> Self {
-        OptionU8(opt)
+        Self(opt)
     }
 }
 

--- a/kernel/interrupts/src/lib.rs
+++ b/kernel/interrupts/src/lib.rs
@@ -4,12 +4,8 @@
 #![cfg_attr(target_arch = "x86_64", feature(abi_x86_interrupt))]
 #![cfg_attr(target_arch = "x86_64", allow(dead_code))]
 
-#[cfg(target_arch = "x86_64")]
-#[path = "x86_64/mod.rs"]
-mod arch;
-
-#[cfg(target_arch = "aarch64")]
-#[path = "aarch64/mod.rs"]
+#[cfg_attr(target_arch = "x86_64", path = "x86_64/mod.rs")]
+#[cfg_attr(target_arch = "aarch64", path = "aarch64/mod.rs")]
 mod arch;
 
 pub use arch::*;

--- a/kernel/sleep/Cargo.toml
+++ b/kernel/sleep/Cargo.toml
@@ -14,7 +14,7 @@ version = "1.2.0"
 path = "../task"
 
 [dependencies.irq_safety]
-git = "https://github.com/theseus-os/irq_safety"
+git = "https://github.com/theseus-os/irq_safety" 
 
 [dependencies.scheduler]
 path = "../scheduler"

--- a/kernel/sleep/Cargo.toml
+++ b/kernel/sleep/Cargo.toml
@@ -14,7 +14,7 @@ version = "1.2.0"
 path = "../task"
 
 [dependencies.irq_safety]
-git = "https://github.com/theseus-os/irq_safety" 
+git = "https://github.com/theseus-os/irq_safety"
 
 [dependencies.scheduler]
 path = "../scheduler"


### PR DESCRIPTION
This PR implements CpuId for aarch64. Some other `cpu` functions were temporarily implemented as dummies: I think the multicore ARM switch should happen in another PR.

Three CpuId flavors are implemented:
- CpuId: an opaque type wrapping a u32, the compact representation
- MpidrValue: a wrapper for the value which is read from the MPIDR_EL1 register. The inner u64 can be obtained through an unsafe method; this should be used by PSCI code when we want to bring another core up.
- OptionalCpuId, which is used by `task_struct`:
```rust
/// An equivalent to Option<CpuId>, which internally encodes None as
/// `u32::MAX`, which is an invalid CpuId (bits [4:7] of affinity level
/// 0 must always be cleared). This guarantees that it compiles down to
/// lock-free native atomic instructions when using it inside of an atomic
/// type like [`AtomicCell`], as u32 is atomic when running on ARMv8.
```

The PR also contains two unrelated & unimportant modifications which are:
- ~~the removal of a whitespace character at the end of a line in `sleep`'s manifest~~
- the switch to more compact arch gates in `interrupt`