### PR TITLE
Move `schedule()` from `scheduler` into `task`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,6 +3644,7 @@ name = "task"
 version = "0.1.0"
 dependencies = [
  "context_switch",
+ "crossbeam-utils",
  "environment",
  "irq_safety",
  "log",

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -106,7 +106,9 @@ pub fn init(
     // get BSP's apic id
     let bsp_apic_id = cpu::bootstrap_cpu().ok_or("captain::init(): couldn't get ID of bootstrap CPU!")?;
 
-    // create the initial `Task`, which is bootstrapped from this execution context.
+    // Initialize the scheduler and create the initial `Task`,
+    // which is bootstrapped from this current execution context.
+    scheduler::init();
     let bootstrap_task = spawn::init(kernel_mmi_ref.clone(), bsp_apic_id, bsp_initial_stack)?;
     info!("Created initial bootstrap task: {:?}", bootstrap_task);
 

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -1,7 +1,7 @@
 //! Offers the ability to control or configure the active task scheduling policy.
 //!
-//! Note that actual task switching and preemptive scheduling are actually
-//! implemented in the [`task`] crate.
+//! Note that actual task switching and preemptive scheduling are implemented
+//! in the [`task`] crate.
 //! This crate re-exports that main [`schedule()`] function for convenience,
 //! legacy compatbility, and to act as an easy landing page for code search.
 //! That means that a caller need only depend on [`task`], not this crate,

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -1,3 +1,12 @@
+//! Offers the ability to control or configure the active task scheduling policy.
+//!
+//! Note that actual task switching and preemptive scheduling are actually
+//! implemented in the [`task`] crate.
+//! This crate re-exports that main [`schedule()`] function for convenience,
+//! legacy compatbility, and to act as an easy landing page for code search.
+//! That means that a caller need only depend on [`task`], not this crate,
+//! to invoke the scheduler (yield the CPU) to switch to another task.
+
 #![no_std]
 
 cfg_if::cfg_if! {
@@ -12,41 +21,18 @@ cfg_if::cfg_if! {
 
 use task::TaskRef;
 
-/// Yields the current CPU by selecting a new `Task` to run 
-/// and then switching to that new `Task`.
+/// A re-export of [`task::schedule()`] for convenience and legacy compatibility.
+pub use task::schedule;
+
+/// Initializes the scheduler on this system using the policy set at compiler time.
 ///
-/// Preemption will be disabled while this function runs,
-/// but interrupts are not disabled because it is not necessary.
-///
-/// ## Return
-/// * `true` if a new task was selected and switched to.
-/// * `false` if no new task was selected,
-///    meaning the current task will continue running.
-pub fn schedule() -> bool {
-    let preemption_guard = preemption::hold_preemption();
-    // If preemption was not previously enabled (before we disabled it above),
-    // then we shouldn't perform a task switch here.
-    if !preemption_guard.preemption_was_enabled() {
-        // trace!("Note: preemption was disabled on CPU {}, skipping scheduler.", current_cpu());
-        return false;
-    }
-
-    let cpu_id = preemption_guard.cpu_id();
-
-    let Some(next_task) = scheduler::select_next_task(cpu_id) else {
-        return false; // keep running the same current task
-    };
-
-    let (did_switch, recovered_preemption_guard) = task::task_switch(
-        next_task,
-        cpu_id,
-        preemption_guard,
-    ); 
-
-    // trace!("AFTER TASK_SWITCH CALL (CPU {}) new current: {:?}, interrupts are {}", cpu_id, task::get_my_current_task(), irq_safety::interrupts_enabled());
-
-    drop(recovered_preemption_guard);
-    did_switch
+/// Currently, there is a single scheduler policy for the whole system.
+/// The policy is selected by specifying a Rust `cfg` value at build time, like so:
+/// * `make THESEUS_CONFIG=priority_scheduler` --> priority scheduler.
+/// * `make THESEUS_CONFIG=realtime_scheduler` --> "realtime" (rate monotonic) scheduler.
+/// * `make` --> basic round-robin scheduler, the default.
+pub fn init() {
+    task::set_scheduler_policy(scheduler::select_next_task);
 }
 
 /// Changes the priority of the given task with the given priority level.

--- a/kernel/task/Cargo.toml
+++ b/kernel/task/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 log = "0.4.8"
 spin = "0.9.4"
 static_assertions = "1.1.0"
+crossbeam-utils = { version = "0.8.2", default-features = false }
 
 irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
 

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -20,7 +20,7 @@
 //! 3. Yield the current CPU and schedule in another task -- [`schedule()`].
 //! 4. Switch from the current task to another specific "next" task -- [`task_switch()`].
 //!
-//! To create new task, use the task builder functions in the [`spawn`](../spawn/index.html) crate
+//! To create new task, use the task builder functions in [`spawn`](../spawn/index.html)
 //! rather than attempting to manually instantiate a `TaskRef`.
 
 #![no_std]
@@ -580,8 +580,8 @@ pub use scheduler::*;
 mod scheduler {
     use super::*;
 
-    /// Yields the current CPU by selecting a new `Task` to run next
-    /// and then switching to that new `Task`.
+    /// Yields the current CPU by selecting a new `Task` to run next,
+    /// and then switches to that new `Task`.
     ///
     /// The new "next" `Task` to run will be selected by the currently-active
     /// scheduler policy.
@@ -626,11 +626,11 @@ mod scheduler {
     /// This is used when the [`schedule()`] function is invoked.
     pub type SchedulerFunc = fn(u8) -> Option<TaskRef>;
 
-    /// The function currently registered system-wide scheduler policy.
+    /// The function currently registered as the system-wide scheduler policy.
     ///
     /// This is initialized to a dummy function that returns no "next" task,
     /// meaning that no scheduling will occur until it is initialized.
-    /// Currently this occurs in `scheduler::init()`.
+    /// Currently, this is initialized from within `scheduler::init()`.
     static SELECT_NEXT_TASK_FUNC: AtomicCell<SchedulerFunc> = AtomicCell::new(|_| None);
 
     /// Sets the active scheduler policy used by [`schedule()`] to select the next task.

--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -11,15 +11,17 @@
 //! 1. Obtain the current task:
 //!    * [`with_current_task()`] is the preferred way, which accepts a closure
 //!      that is invoked with access to the current task. This is preferred because
-//!      it doesn't need to clone the current task reference.
+//!      it doesn't need to clone the current task reference and is thus most efficient.
 //!    * [`get_my_current_task()`] returns a cloned reference to the current task
 //!      and is thus slightly more expensive [`with_current_task()`].
 //!    * [`get_my_current_task_id()`] is fastest if you just want the ID of the current task.
+//!      Note that it is fairly expensive to obtain a task reference from a task ID.
 //! 2. Register a kill handler for the current task -- [`set_kill_handler()`].
-//! 3. Switch from the current task to another "next" task -- [`task_switch()`].
+//! 3. Yield the current CPU and schedule in another task -- [`schedule()`].
+//! 4. Switch from the current task to another specific "next" task -- [`task_switch()`].
 //!
-//! To create new task, use the [`spawn`](../spawn/index.html) crate rather than
-//! attempting to manually instantiate a `TaskRef`.
+//! To create new task, use the task builder functions in the [`spawn`](../spawn/index.html) crate
+//! rather than attempting to manually instantiate a `TaskRef`.
 
 #![no_std]
 #![feature(negative_impls)]
@@ -41,6 +43,7 @@ use core::{
     sync::atomic::{AtomicBool, fence, Ordering},
     task::Waker,
 };
+use crossbeam_utils::atomic::AtomicCell;
 use irq_safety::{hold_interrupts, MutexIrqSafe};
 use log::error;
 use environment::Environment;
@@ -573,6 +576,74 @@ pub fn take_kill_handler() -> Option<KillHandler> {
 }
 
 
+pub use scheduler::*;
+mod scheduler {
+    use super::*;
+
+    /// Yields the current CPU by selecting a new `Task` to run next
+    /// and then switching to that new `Task`.
+    ///
+    /// The new "next" `Task` to run will be selected by the currently-active
+    /// scheduler policy.
+    ///
+    /// Preemption will be disabled while this function runs,
+    /// but interrupts are not disabled because it is not necessary.
+    ///
+    /// ## Return
+    /// * `true` if a new task was selected and switched to.
+    /// * `false` if no new task was selected,
+    ///    meaning the current task will continue running.
+    #[doc(alias("yield"))]
+    pub fn schedule() -> bool {
+        let preemption_guard = preemption::hold_preemption();
+        // If preemption was not previously enabled (before we disabled it above),
+        // then we shouldn't perform a task switch here.
+        if !preemption_guard.preemption_was_enabled() {
+            // trace!("Note: preemption was disabled on CPU {}, skipping scheduler.", current_cpu());
+            return false;
+        }
+
+        let cpu_id = preemption_guard.cpu_id();
+
+        let Some(next_task) = (SELECT_NEXT_TASK_FUNC.load())(cpu_id) else {
+            return false; // keep running the same current task
+        };
+
+        let (did_switch, recovered_preemption_guard) = task_switch(
+            next_task,
+            cpu_id,
+            preemption_guard,
+        ); 
+
+        // trace!("AFTER TASK_SWITCH CALL (CPU {}) new current: {:?}, interrupts are {}", cpu_id, task::get_my_current_task(), irq_safety::interrupts_enabled());
+
+        drop(recovered_preemption_guard);
+        did_switch
+    }
+
+    /// The signature for the function that selects the next task for the given CPU.
+    ///
+    /// This is used when the [`schedule()`] function is invoked.
+    pub type SchedulerFunc = fn(u8) -> Option<TaskRef>;
+
+    /// The function currently registered system-wide scheduler policy.
+    ///
+    /// This is initialized to a dummy function that returns no "next" task,
+    /// meaning that no scheduling will occur until it is initialized.
+    /// Currently this occurs in `scheduler::init()`.
+    static SELECT_NEXT_TASK_FUNC: AtomicCell<SchedulerFunc> = AtomicCell::new(|_| None);
+
+    /// Sets the active scheduler policy used by [`schedule()`] to select the next task.
+    ///
+    /// Currently, we only support one scheduler policy for the whole system,
+    /// but supporting different policies on a per-CPU, per-namespace, or per-arbitrary domain basis
+    /// would be a relatively simple immprovement.
+    pub fn set_scheduler_policy(select_next_task_func: SchedulerFunc) {
+        SELECT_NEXT_TASK_FUNC.store(select_next_task_func);
+    }
+}
+
+
 /// Switches from the current task to the given `next` task.
 ///
 /// ## Arguments
@@ -1008,7 +1079,7 @@ mod tls_current_task {
 }
 
 
-/// Bootstrap a new task from the current thread of execution.
+/// Bootstraps a new task from the current thread of execution.
 ///
 /// Returns a tuple of:
 /// 1. a [`JoinableTaskRef`], which allows another task to join this bootstrapped task,
@@ -1076,6 +1147,7 @@ fn bootstrap_task_cleanup_failure(current_task: ExitableTaskRef, kill_reason: Ki
         kill_reason,
     );
     // If an initial bootstrap task fails, there's nothing else we can do.
-    #[allow(clippy::empty_loop)]
-    loop { }
+    loop { 
+        core::hint::spin_loop();
+    }
 }


### PR DESCRIPTION
* Allows the `task` crate itself to directly invoke `schedule()`, which is important for upcoming efficiency improvements to regular and async task management (e.g., waking a task that was blocked on another task for the purpose of `join`).

* Allows future PRs to avoid cyclic dependencies when a crate depends on both task and scheduling functionality.

* The `scheduler` crate still provides the same scheduling functionality by re-exporting the same function from `task`.