### PR TITLE
Move preemptive task switching interrupt handler into `scheduler`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,8 +1515,6 @@ dependencies = [
  "log",
  "memory",
  "pic",
- "scheduler",
- "sleep",
  "spin 0.9.4",
  "tock-registers",
  "tss",
@@ -3127,17 +3125,17 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 name = "scheduler"
 version = "0.1.0"
 dependencies = [
- "apic",
  "cfg-if 1.0.0",
- "irq_safety",
+ "cpu",
+ "interrupts",
  "log",
  "preemption",
- "runqueue",
  "scheduler_priority",
  "scheduler_realtime",
  "scheduler_round_robin",
- "spin 0.9.4",
+ "sleep",
  "task",
+ "x86_64",
 ]
 
 [[package]]
@@ -3400,7 +3398,6 @@ dependencies = [
  "crossbeam-utils",
  "irq_safety",
  "lazy_static",
- "scheduler",
  "task",
  "time",
 ]

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -108,7 +108,7 @@ pub fn init(
 
     // Initialize the scheduler and create the initial `Task`,
     // which is bootstrapped from this current execution context.
-    scheduler::init();
+    scheduler::init()?;
     let bootstrap_task = spawn::init(kernel_mmi_ref.clone(), bsp_apic_id, bsp_initial_stack)?;
     info!("Created initial bootstrap task: {:?}", bootstrap_task);
 

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -18,8 +18,6 @@ cortex-a = "7.5.0"
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 exceptions_early = { path = "../exceptions_early" }
 vga_buffer = { path = "../vga_buffer" }
-scheduler = { path = "../scheduler" }
-sleep = { path = "../sleep" }
 apic = { path = "../apic" }
 gdt = { path = "../gdt" }
 pic = { path = "../pic" }

--- a/kernel/scheduler/Cargo.toml
+++ b/kernel/scheduler/Cargo.toml
@@ -6,33 +6,18 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-spin = "0.9.4"
 log = "0.4.8"
 cfg-if = "1.0.0"
 
-[dependencies.irq_safety]
-git = "https://github.com/theseus-os/irq_safety"
+cpu = { path = "../cpu" }
+interrupts = { path = "../interrupts" }
+preemption = { path = "../preemption" }
+sleep = { path = "../sleep" }
+task = { path = "../task" }
 
-[dependencies.apic]
-path= "../apic"
+scheduler_round_robin = { path = "../scheduler_round_robin" }
+scheduler_priority = { path = "../scheduler_priority" }
+scheduler_realtime = { path = "../scheduler_realtime" }
 
-[dependencies.task]
-path = "../task"
-
-[dependencies.preemption]
-path = "../preemption"
-
-[dependencies.runqueue]
-path = "../runqueue"
-
-[dependencies.scheduler_round_robin]
-path = "../scheduler_round_robin"
-
-[dependencies.scheduler_priority]
-path = "../scheduler_priority"
-
-[dependencies.scheduler_realtime]
-path = "../scheduler_realtime"
-
-[lib]
-crate-type = ["rlib"]
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+x86_64 = "0.14.8"

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -1,7 +1,11 @@
 //! Offers the ability to control or configure the active task scheduling policy.
 //!
-//! Note that actual task switching and preemptive scheduling are implemented
-//! in the [`task`] crate.
+//! ## What is and isn't in this crate?
+//! This crate also defines the timer interrupt handler used for preemptive
+//! task switching on each CPU. In [`init()`], it registers that handler
+//! with the [`interrupts`] subsystem.
+//!
+//! The actual task switching logic is implemented in the [`task`] crate.
 //! This crate re-exports that main [`schedule()`] function for convenience,
 //! legacy compatbility, and to act as an easy landing page for code search.
 //! That means that a caller need only depend on [`task`], not this crate,
@@ -20,8 +24,8 @@ cfg_if::cfg_if! {
     }
 }
 
-use interrupts::{CPU_LOCAL_TIMER_IRQ, eoi, register_interrupt};
-use task::TaskRef;
+use interrupts::{self, CPU_LOCAL_TIMER_IRQ, eoi, register_interrupt};
+use task::{self, TaskRef};
 
 /// A re-export of [`task::schedule()`] for convenience and legacy compatibility.
 pub use task::schedule;

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -8,6 +8,7 @@
 //! to invoke the scheduler (yield the CPU) to switch to another task.
 
 #![no_std]
+#![cfg_attr(target_arch = "x86_64", feature(abi_x86_interrupt))]
 
 cfg_if::cfg_if! {
     if #[cfg(priority_scheduler)] {
@@ -19,20 +20,61 @@ cfg_if::cfg_if! {
     }
 }
 
+use interrupts::{CPU_LOCAL_TIMER_IRQ, eoi, register_interrupt};
 use task::TaskRef;
 
 /// A re-export of [`task::schedule()`] for convenience and legacy compatibility.
 pub use task::schedule;
 
+
 /// Initializes the scheduler on this system using the policy set at compiler time.
+///
+/// Also registers a timer interrupt handler for preemptive scheduling.
 ///
 /// Currently, there is a single scheduler policy for the whole system.
 /// The policy is selected by specifying a Rust `cfg` value at build time, like so:
 /// * `make THESEUS_CONFIG=priority_scheduler` --> priority scheduler.
 /// * `make THESEUS_CONFIG=realtime_scheduler` --> "realtime" (rate monotonic) scheduler.
 /// * `make` --> basic round-robin scheduler, the default.
-pub fn init() {
+pub fn init() -> Result<(), &'static str> {
     task::set_scheduler_policy(scheduler::select_next_task);
+
+    #[cfg(target_arch = "x86_64")] {
+        register_interrupt(
+            CPU_LOCAL_TIMER_IRQ,
+            lapic_timer_handler,
+        ).map_err(|_handler| {
+            log::error!("BUG: interrupt {CPU_LOCAL_TIMER_IRQ} was already registered to handler {_handler:#X}");
+            "BUG: CPU-local timer interrupt was already registered to a handler"
+        })
+    }
+
+    #[cfg(not(target_arch = "x86_64"))] {
+        log::error!("TODO: scheduler::init() only supports registering a preemptive task switching timer interrupt on x86_64");
+        Err("TODO: scheduler::init() only supports registering a preemptive task switching timer interrupt on x86_64")
+    }
+}
+
+/// The handler for each CPU's local timer interrupt, used for preemptive task switching.
+#[cfg(target_arch = "x86_64")]
+extern "x86-interrupt" fn lapic_timer_handler(_stack_frame: x86_64::structures::idt::InterruptStackFrame) {
+    // tick count, only used for debugging
+    #[cfg(any())] { // cfg(any()) is always false
+        use core::sync::atomic::{AtomicUsize, Ordering};
+        static LAPIC_TIMER_TICKS: AtomicUsize = AtomicUsize::new(0);
+        let _ticks = LAPIC_TIMER_TICKS.fetch_add(1, Ordering::Relaxed);
+        log::info!("(CPU {}) LAPIC TIMER HANDLER! TICKS = {}", cpu::current_cpu(), _ticks);
+    }
+
+    // Inform the `sleep` crate that it should update its inner tick count
+    // in order to unblock any tasks that are done sleeping.
+    sleep::unblock_sleeping_tasks();
+
+    // We must acknowledge the interrupt before the end of this handler
+    // because we switch tasks here, which doesn't return.
+    eoi(None); // None, because IRQ 0x22 cannot possibly be a PIC interrupt
+
+    schedule();
 }
 
 /// Changes the priority of the given task with the given priority level.

--- a/kernel/sleep/Cargo.toml
+++ b/kernel/sleep/Cargo.toml
@@ -16,9 +16,6 @@ path = "../task"
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety" 
 
-[dependencies.scheduler]
-path = "../scheduler"
-
 [dependencies.time]
 path = "../time"
 

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -13,7 +13,6 @@ extern crate task;
 extern crate irq_safety;
 extern crate alloc;
 #[macro_use] extern crate lazy_static;
-extern crate scheduler;
 extern crate time;
 extern crate crossbeam_utils;
 
@@ -131,7 +130,7 @@ pub fn sleep(duration: Duration) -> Result<(), RunState> {
     // Add the current task to the delayed tasklist and then block it.
     add_to_delayed_tasklist(SleepingTaskNode{action: Action::Sync(current_task.clone()), resume_time});
     current_task.block()?;
-    scheduler::schedule();
+    task::schedule();
     Ok(())
 }
 


### PR DESCRIPTION
* Now, the `scheduler` defines the CPU-local timer interrupt handler, which is used for preemptive task switching.
  * The `scheduler` also registers that interrupt in its `init()` function.

* Avoids a direct dependency from `interrupts` --> `scheduler`, which would cause a future cyclic dependency when changing the `preemption` crate to depend on `interrupts` instead of the x86_64-specific `apic` crate (for enabling or disabling the CPU-local timer interrupt).

* Define a `CPU_LOCAL_TIMER_IRQ` const on both x86_64 and aarch64.