### PR TITLE
Support the X2APIC MADT ACPI table entry (type 9)

### DIFF
--- a/kernel/acpi/madt/src/lib.rs
+++ b/kernel/acpi/madt/src/lib.rs
@@ -162,6 +162,9 @@ impl<'t> Iterator for MadtIter<'t> {
                     ENTRY_TYPE_LOCAL_APIC_ADDRESS_OVERRIDE if entry_size == size_of::<MadtLocalApicAddressOverride>() => {
                         self.mapped_pages.as_type(self.offset).ok().map(MadtEntry::LocalApicAddressOverride)
                     },
+                    ENTRY_TYPE_LOCAL_X2APIC if entry_size == size_of::<MadtLocalX2Apic>() => {
+                        self.mapped_pages.as_type(self.offset).ok().map(MadtEntry::LocalX2Apic)
+                    },
                     _ => None,
                 };
                 // move the offset to the end of this entry, i.e., the beginning of the next entry record
@@ -202,6 +205,8 @@ const ENTRY_TYPE_INT_SRC_OVERRIDE:            u8 = 2;
 // entry type 3 doesn't exist
 const ENTRY_TYPE_NON_MASKABLE_INTERRUPT:      u8 = 4;
 const ENTRY_TYPE_LOCAL_APIC_ADDRESS_OVERRIDE: u8 = 5;
+// entry types 6, 7, 8 are not used
+const ENTRY_TYPE_LOCAL_X2APIC:                u8 = 9;
 
 
 /// The set of possible MADT Entries.
@@ -217,6 +222,8 @@ pub enum MadtEntry<'t> {
     NonMaskableInterrupt(&'t MadtNonMaskableInterrupt),
     /// A Local APIC Address Override MADT entry.
     LocalApicAddressOverride(&'t MadtLocalApicAddressOverride),
+    /// A Local X2APIC MADT entry.
+    LocalX2Apic(&'t MadtLocalX2Apic),
     /// The MADT table had an entry of an unknown type or mismatched length,
     /// so the table entry was malformed and unusable.
     /// The entry type ID is included.
@@ -303,6 +310,22 @@ pub struct MadtLocalApicAddressOverride {
 const _: () = assert!(core::mem::size_of::<MadtLocalApicAddressOverride>() == 12);
 const _: () = assert!(core::mem::align_of::<MadtLocalApicAddressOverride>() == 1);
 
+/// MADT Local X2APIC
+#[derive(Copy, Clone, Debug, FromBytes)]
+#[repr(packed)]
+pub struct MadtLocalX2Apic {
+    _header: EntryRecord,
+    _reserved: u16,
+    /// Processor ID
+    pub processor: u32,
+    /// Flags. 1 means that the processor is enabled
+    pub flags: u32,
+    /// Local X2APIC ID
+    pub x2apic_id: u32,
+}
+const _: () = assert!(core::mem::size_of::<MadtLocalX2Apic>() == 16);
+const _: () = assert!(core::mem::align_of::<MadtLocalX2Apic>() == 1);
+
 /// Handles the BSP's (bootstrap processor, the first core to boot) entry in the given MADT iterator.
 /// This should be the first function invoked to initialize the BSP information, 
 /// and should come before any other entries in the MADT are handled.
@@ -311,11 +334,11 @@ fn handle_bsp_lapic_entry(madt_iter: MadtIter, page_table: &mut PageTable) -> Re
 
     for madt_entry in madt_iter.clone() {
         if let MadtEntry::LocalApic(lapic_entry) = madt_entry { 
-            let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(lapic_entry.processor, madt_iter.clone());
+            let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(lapic_entry.processor as u32, madt_iter.clone());
 
             match LocalApic::init(
                 page_table,
-                lapic_entry.processor,
+                lapic_entry.processor as u32,
                 None, // we don't know the hardware-assigned APIC ID of the BSP (this CPU) yet
                 true,
                 nmi_lint,
@@ -395,12 +418,12 @@ fn handle_ioapic_entries(madt_iter: MadtIter, page_table: &mut PageTable) -> Res
 /// Finds the Non-Maskable Interrupt (NMI) entry in the MADT ACPI table (i.e., the given `MadtIter`)
 /// corresponding to the given processor. 
 /// If no entry exists, it returns the default NMI entry value: `(lint = 1, flags = 0)`.
-pub fn find_nmi_entry_for_processor(processor: u8, madt_iter: MadtIter) -> (u8, u16) {
+pub fn find_nmi_entry_for_processor(processor: u32, madt_iter: MadtIter) -> (u8, u16) {
     for madt_entry in madt_iter {
         if let MadtEntry::NonMaskableInterrupt(nmi) = madt_entry {
             // NMI entries are based on the "processor" id, not the "apic_id"
             // Return this Nmi entry if it's for the given lapic, or if it's for all lapics
-            if nmi.processor == processor || nmi.processor == 0xFF  {
+            if nmi.processor as u32 == processor || nmi.processor == 0xFF  {
                 return (nmi.lint, nmi.flags);
             }
         }

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -35,7 +35,7 @@ pub fn insert_ap_stack(cpu_id: u32 , stack: Stack) {
 /// Entry to rust for an AP.
 /// The arguments must match the invocation order in "ap_boot.asm"
 pub fn kstart_ap(
-    processor_id: u8,
+    processor_id: u32,
     cpu_id: CpuId,
     _stack_start: VirtualAddress,
     _stack_end: VirtualAddress,

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -420,7 +420,7 @@ pub struct LocalApic {
     apic_id: ApicId,
     /// The processor ID of this APIC (from the `MADT` ACPI table entry).
     /// This is currently not used for anything in Theseus.
-    processor_id: u8,
+    processor_id: u32,
     /// Whether this Local APIC is the BootStrap Processor (the first CPU to boot up).
     is_bootstrap_cpu: bool,
     /// The value that should be written to the APIC timer's initial count register
@@ -468,7 +468,7 @@ impl LocalApic {
     /// the BSP cannot invoke this for other APs.
     pub fn init(
         page_table: &mut PageTable,
-        processor_id: u8,
+        processor_id: u32,
         expected_apic_id: Option<u32>,
         should_be_bsp: bool,
         nmi_lint: u8,
@@ -558,7 +558,7 @@ impl LocalApic {
     /// 
     /// This value comes from the `MADT` ACPI table entry that was used
     /// to boot up this CPU core.
-    pub fn processor_id(&self) -> u8 { self.processor_id }
+    pub fn processor_id(&self) -> u32 { self.processor_id }
 
     /// Returns `true` if this CPU core was the BootStrap Processor (BSP),
     /// i.e., the first CPU to boot and run the OS code.
@@ -644,7 +644,7 @@ impl LocalApic {
             }
             LapicType::XApic(regs) => {
                 regs.timer_divide.write(LapicTimerDivide::By16.as_register_value());
-                regs.timer_initial_count.write(INITIAL_COUNT as u32);
+                regs.timer_initial_count.write(INITIAL_COUNT);
 
                 // wait for the given period using the PIT clock
                 pit_wait(microseconds).unwrap();
@@ -686,7 +686,7 @@ impl LocalApic {
                 regs.timer_divide.write(LapicTimerDivide::By16.as_register_value());
                 // map APIC timer to an interrupt handler in the IDT
                 regs.lvt_timer.write(LOCAL_APIC_LVT_IRQ as u32 | APIC_TIMER_MODE_PERIODIC); 
-                regs.timer_initial_count.write(apic_period as u32); 
+                regs.timer_initial_count.write(apic_period); 
 
                 regs.lvt_thermal.write(0);
                 regs.lvt_error.write(0);

--- a/kernel/multicore_bringup/src/lib.rs
+++ b/kernel/multicore_bringup/src/lib.rs
@@ -36,7 +36,7 @@ use memory::{VirtualAddress, PhysicalAddress, MappedPages, PteFlags, MmiRef};
 use kernel_config::memory::{PAGE_SIZE, PAGE_SHIFT, KERNEL_STACK_SIZE_IN_PAGES};
 use apic::{LocalApic, get_lapics, current_cpu, has_x2apic, bootstrap_cpu, cpu_count};
 use ap_start::{kstart_ap, AP_READY_FLAG};
-use madt::{Madt, MadtEntry, MadtLocalApic, find_nmi_entry_for_processor};
+use madt::{Madt, MadtEntry, find_nmi_entry_for_processor};
 use pause::spin_loop_hint;
 
 
@@ -240,7 +240,6 @@ pub fn handle_ap_cores(
 
     let all_lapics = get_lapics();
     let this_cpu = current_cpu();
-    let this_cpu_as_u8: Result<u8, _> = this_cpu.value().try_into();
 
     // Copy the AP startup code (from the kernel's text section pages) into the AP_STARTUP physical address entry point.
     {
@@ -275,42 +274,47 @@ pub fn handle_ap_cores(
     let madt_iter = madt.iter();
 
     for madt_entry in madt_iter.clone() {
-        if let MadtEntry::LocalApic(lapic_entry) = madt_entry { 
-            if let Ok(this_cpu_as_u8) = this_cpu_as_u8 && this_cpu_as_u8 == lapic_entry.apic_id {
-                // debug!("skipping BSP's local apic");
-            }
-            else {
-                if lapic_entry.flags & 0x1 != 0x1 {
-                    warn!("Processor {} apic_id {} is disabled by the hardware, cannot initialize or use it.", 
-                            lapic_entry.processor, lapic_entry.apic_id);
-                    continue;
-                }
+        let (processor_id, apic_id, flags) = match madt_entry {
+            MadtEntry::LocalApic(entry) => (entry.processor as u32, entry.apic_id as u32, entry.flags),
+            MadtEntry::LocalX2Apic(entry) => (entry.processor, entry.x2apic_id, entry.flags),
+            _ => continue,
+        };
 
-                // start up this AP, and have it create a new LocalApic for itself. 
-                // This must be done by each core itself, and not called repeatedly by the BSP on behalf of other cores.
-                let bsp_lapic_ref = bootstrap_cpu()
-                    .and_then(|bsp_id| all_lapics.get(&bsp_id))
-                    .ok_or("Couldn't get BSP's LocalApic!")?;
-                let mut bsp_lapic = bsp_lapic_ref.write();
-                let ap_stack = stack::alloc_stack(
-                    KERNEL_STACK_SIZE_IN_PAGES,
-                    &mut kernel_mmi_ref.lock().page_table,
-                ).ok_or("could not allocate AP stack!")?;
-
-                let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(lapic_entry.processor, madt_iter.clone());
-
-                bring_up_ap(
-                    bsp_lapic.deref_mut(), 
-                    lapic_entry,
-                    ap_trampoline_data,
-                    page_table_phys_addr, 
-                    ap_stack, 
-                    nmi_lint,
-                    nmi_flags 
-                );
-                ap_count += 1;
-            }
+        // we already handled the BSP in a different functions
+        if this_cpu.value() == apic_id {
+            continue;
         }
+
+        if flags & 0x1 != 0x1 {
+            warn!("Processor {} apic_id {} is disabled by the hardware, cannot initialize or use it.", 
+                processor_id, apic_id);
+            continue;
+        }
+
+        // start up this AP, and have it create a new LocalApic for itself. 
+        // This must be done by each core itself, and not called repeatedly by the BSP on behalf of other cores.
+        let bsp_lapic_ref = bootstrap_cpu()
+            .and_then(|bsp_id| all_lapics.get(&bsp_id))
+            .ok_or("Couldn't get BSP's LocalApic!")?;
+        let mut bsp_lapic = bsp_lapic_ref.write();
+        let ap_stack = stack::alloc_stack(
+            KERNEL_STACK_SIZE_IN_PAGES,
+            &mut kernel_mmi_ref.lock().page_table,
+        ).ok_or("could not allocate AP stack!")?;
+
+        let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(processor_id, madt_iter.clone());
+
+        bring_up_ap(
+            bsp_lapic.deref_mut(), 
+            processor_id,
+            apic_id,
+            ap_trampoline_data,
+            page_table_phys_addr, 
+            ap_stack, 
+            nmi_lint,
+            nmi_flags 
+        );
+        ap_count += 1;
     }
 
     // Retrieve the graphic mode information written during the AP bootup sequence in `ap_realmode.asm`.
@@ -352,8 +356,8 @@ struct ApTrampolineData {
     /// The Rust setup code sets it to 0, and the AP boot code sets it to 1.
     ap_ready:          Volatile<u64>,
     /// The processor ID of the new AP that is being brought up.
-    ap_processor_id:   Volatile<u8>,
-    _padding0:         [u8; 7],
+    ap_processor_id:   Volatile<u32>,
+    _padding0:         [u8; 4],
     /// The CPU ID of the new AP that is being brought up.
     ap_cpu_id:         Volatile<u32>,
     _padding1:         [u8; 4],
@@ -387,19 +391,19 @@ const _: () = assert!(size_of::<ApTrampolineData>() == 12 * size_of::<u64>());
 
 
 /// Called by the BSP to initialize the given `new_lapic` using IPIs.
+#[allow(clippy::too_many_arguments)]
 fn bring_up_ap(
     bsp_lapic: &mut LocalApic,
-    new_lapic: &MadtLocalApic, 
+    new_apic_processor_id: u32,
+    new_apic_id: u32,
     ap_trampoline_data: &mut ApTrampolineData,
     page_table_paddr: PhysicalAddress, 
     ap_stack: stack::Stack,
     nmi_lint: u8, 
     nmi_flags: u16
 ) {
-    let new_apic_id = new_lapic.apic_id as u32; 
-
     ap_trampoline_data.ap_ready.write(0);
-    ap_trampoline_data.ap_processor_id.write(new_lapic.processor);
+    ap_trampoline_data.ap_processor_id.write(new_apic_processor_id);
     ap_trampoline_data.ap_cpu_id.write(new_apic_id);
     ap_trampoline_data.ap_page_table.write(page_table_paddr);
     ap_trampoline_data.ap_stack_start.write(ap_stack.bottom());
@@ -413,7 +417,7 @@ fn bring_up_ap(
     // in which the AP will take ownership of it once it boots up.
     ap_start::insert_ap_stack(new_apic_id, ap_stack); 
 
-    info!("Bringing up AP, proc: {} apic_id: {}", new_lapic.processor, new_apic_id);
+    info!("Bringing up AP, proc: {} apic_id: {}", new_apic_processor_id, new_apic_id);
     
     bsp_lapic.clear_error();
     let esr = bsp_lapic.error();


### PR DESCRIPTION
* Haven't yet found any processors that use this, but if we do, it is now supported.

* Also, all processor ID and apic ID fields from MADT table entries are now converted to `u32`.