### PR TITLE
aarch64: handle static TLS sections in base kernel image

### DIFF
--- a/kernel/crate_metadata_serde/src/lib.rs
+++ b/kernel/crate_metadata_serde/src/lib.rs
@@ -146,4 +146,9 @@ impl SectionType {
     pub fn is_data_or_bss(&self) -> bool {
         matches!(self, Self::Data | Self::Bss)
     }
+
+    /// Returns `true` if `TlsData` or `TlsBss`, otherwise `false`.
+    pub fn is_tls(&self) -> bool {
+        matches!(self, Self::TlsData | Self::TlsBss)
+    }
 }

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -796,6 +796,9 @@ fn add_new_section(
         )))
     }
     else if main_section_info.tls_data_info.map_or(false, |(shndx, _)| sec_ndx == shndx) {
+        // Skip zero-sized TLS sections, which are just markers, not real sections.
+        if sec_size == 0 { return Ok(()); }
+
         // TLS sections encode their TLS offset in the virtual address field,
         // which is necessary to properly calculate relocation entries that depend upon them.
         let tls_offset = sec_vaddr;
@@ -824,6 +827,9 @@ fn add_new_section(
         Some(tls_section_ref)
     }
     else if main_section_info.tls_bss_info.map_or(false, |(shndx, _)| sec_ndx == shndx) {
+        // Skip zero-sized TLS sections, which are just markers, not real sections.
+        if sec_size == 0 { return Ok(()); }
+
         // TLS sections encode their TLS offset in the virtual address field,
         // which is necessary to properly calculate relocation entries that depend upon them.
         let tls_offset = sec_vaddr;


### PR DESCRIPTION
* Skip zero-sized TLS sections, which aarch64 uses as "marker"
  sections that define the real address in memory of .tdata sections.
  However, we already calculate this, so we don't need it.

* This implementation is not yet complete on aarch64, since we
  still need to confirm proper TLS data image generation
  and handle dynamically-loaded TLS sections too.