### PR TITLE
Debug state for PS/2 real hardware testing with logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ full: iso
 iso: $(iso)
 
 ### This target builds an .iso OS image from all of the compiled crates.
+$(iso) : export override THESEUS_CONFIG += mirror_log_to_vga
 $(iso): clean-old-build build extra_files copy_kernel $(iso)-$(boot_spec)
 
 ## This target is invoked by the '$(iso)' target when boot_spec = 'bios'.

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -1464,6 +1464,7 @@ impl Shell {
 
 /// Start a new shell. Shell::start() is an infinite loop, so normally we do not return from this function.
 fn shell_loop(mut _dummy: ()) -> Result<(), &'static str> {
-    Shell::new()?.start()?;
+    // Shell::new()?.start()?;
+    loop {}
     Ok(())
 }

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -116,29 +116,29 @@ pub fn init(
     exceptions_full::init(idt);
     
     // boot up the other cores (APs)
-    let ap_count = multicore_bringup::handle_ap_cores(
-        &kernel_mmi_ref,
-        ap_start_realmode_begin,
-        ap_start_realmode_end,
-        ap_gdt,
-        Some(kernel_config::display::FRAMEBUFFER_MAX_RESOLUTION),
-    )?;
-    let cpu_count = ap_count + 1;
-    info!("Finished handling and booting up all {} AP cores; {} total CPUs are running.", ap_count, cpu_count);
+    // let ap_count = multicore_bringup::handle_ap_cores(
+    //     &kernel_mmi_ref,
+    //     ap_start_realmode_begin,
+    //     ap_start_realmode_end,
+    //     ap_gdt,
+    //     Some(kernel_config::display::FRAMEBUFFER_MAX_RESOLUTION),
+    // )?; //
+    let cpu_count = 1; //ap_count + 1
+    // info!("Finished handling and booting up all {} AP cores; {} total CPUs are running.", ap_count, cpu_count); //
 
     #[cfg(mirror_log_to_vga)] {
         // Currently, handling the AP cores also siwtches the graphics mode
         // (from text mode VGA to a graphical framebuffer).
         // Thus, we can now use enable the function that mirrors logger output to the terminal.
-        logger_x86_64::set_log_mirror_function(mirror_log_callbacks::mirror_to_terminal);
+        // logger_x86_64::set_log_mirror_function(mirror_log_callbacks::mirror_to_terminal); //
     }
 
     // Now that other CPUs are fully booted, init TLB shootdowns,
     // which rely on Local APICs to broadcast an IPI to all running CPUs.
-    tlb_shootdown::init();
+    // tlb_shootdown::init(); //
     
     // Initialize the per-core heaps.
-    multiple_heaps::switch_to_multiple_heaps()?;
+    // multiple_heaps::switch_to_multiple_heaps()?; //
     info!("Initialized per-core heaps");
 
     #[cfg(feature = "uefi")] {
@@ -150,9 +150,9 @@ pub fn init(
     // The PAT supports write-combining caching of graphics video memory for better performance
     // and must be initialized explicitly on every CPU, 
     // but it is not a fatal error if it doesn't exist.
-    if page_attribute_table::init().is_err() {
-        error!("This CPU does not support the Page Attribute Table");
-    }
+    // if page_attribute_table::init().is_err() { //
+    //     error!("This CPU does not support the Page Attribute Table");
+    // }
     let (key_producer, mouse_producer) = window_manager::init()?;
 
     // initialize the rest of our drivers

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -75,7 +75,7 @@ pub fn early_init(
 /// * The legacy PS2 controller and any connected devices: [`keyboard`] and [`mouse`],
 /// * All other devices discovered on the [`pci`] bus.
 pub fn init(key_producer: Queue<Event>, mouse_producer: Queue<Event>) -> Result<(), &'static str>  {
-
+    
     let serial_ports = logger::take_early_log_writers();
     let logger_writers = IntoIterator::into_iter(serial_ports)
         .flatten()
@@ -99,7 +99,7 @@ pub fn init(key_producer: Queue<Event>, mouse_producer: Queue<Event>) -> Result<
         }
     };
     init_serial_port(SerialPortAddress::COM1);
-    init_serial_port(SerialPortAddress::COM2);
+    init_serial_port(SerialPortAddress::COM2); //
 
     let ps2_controller = ps2::init()?;
     keyboard::init(ps2_controller.keyboard_ref(), key_producer)?;

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -36,15 +36,15 @@ struct KeyboardInterruptParams {
 pub fn init(keyboard: PS2Keyboard<'static>, keyboard_queue_producer: Queue<Event>) -> Result<(), &'static str> {
     // Detect which kind of keyboard is connected.
     // TODO: actually do something with the keyboard type.
-    match keyboard.keyboard_detect() {
-        Ok(KeyboardType::AncientATKeyboard) => debug!("The PS/2 keyboard type is: Ancient AT Keyboard with translator enabled in the PS/2 Controller"),
-        Ok(KeyboardType::MF2Keyboard) => debug!("The PS/2 keyboard type is: MF2Keyboard"),
-        Ok(KeyboardType::MF2KeyboardWithPSControllerTranslator) => debug!("The PS/2 keyboard type is: MF2 Keyboard with translator enabled in PS/2 Controller"),
-        Err(e) => {
-            error!("Failed to detect the PS/2 keyboard type: {e}");
-            return Err("Failed to detect the PS/2 keyboard type");
-        }
-    }
+    // match keyboard.keyboard_detect() {
+    //     Ok(KeyboardType::AncientATKeyboard) => debug!("The PS/2 keyboard type is: Ancient AT Keyboard with translator enabled in the PS/2 Controller"),
+    //     Ok(KeyboardType::MF2Keyboard) => debug!("The PS/2 keyboard type is: MF2Keyboard"),
+    //     Ok(KeyboardType::MF2KeyboardWithPSControllerTranslator) => debug!("The PS/2 keyboard type is: MF2 Keyboard with translator enabled in PS/2 Controller"),
+    //     Err(e) => {
+    //         error!("Failed to detect the PS/2 keyboard type: {e}");
+    //         return Err("Failed to detect the PS/2 keyboard type");
+    //     }
+    // }
 
     // TODO: figure out what we should do, for now using set 1
     keyboard.keyboard_scancode_set(ScancodeSet::Set1)?;
@@ -63,6 +63,7 @@ pub fn init(keyboard: PS2Keyboard<'static>, keyboard_queue_producer: Queue<Event
 
 /// The interrupt handler for a PS/2-connected keyboard, registered at IRQ 0x21.
 extern "x86-interrupt" fn ps2_keyboard_handler(_stack_frame: InterruptStackFrame) {
+    debug!("ps2_keyboard_handler");
     // Some of the scancodes are "extended", which means they generate two different interrupts,
     // the first handling the E0 byte, the second handling their second byte.
     static EXTENDED_SCANCODE: AtomicBool = AtomicBool::new(false);

--- a/kernel/logger_x86_64/src/lib.rs
+++ b/kernel/logger_x86_64/src/lib.rs
@@ -120,11 +120,11 @@ impl Log for DummyLogger {
         let file_loc = record.file().unwrap_or("??");
         let line_loc = record.line().unwrap_or(0);
         let _result = self.write_fmt(
-            format_args!("{}{}{}:{}: {}{}",
+            format_args!("{}{}: {}{}",
                 color.as_terminal_string(),
                 level_str,
-                file_loc,
-                line_loc,
+                // file_loc,
+                // line_loc,
                 record.args(),
                 LogColor::Reset.as_terminal_string(),
             )
@@ -136,10 +136,10 @@ impl Log for DummyLogger {
         if let Some(func) = mirror_log::get_log_mirror_function() {
             // Currently printing to the VGA terminal doesn't support ANSI color escape sequences,
             // so we exclude the first and the last elements that set those colors.
-            func(format_args!("{}{}:{}: {}",
+            func(format_args!("{}: {}",
                 level_str,
-                file_loc,
-                line_loc,
+                // file_loc,
+                // line_loc,
                 record.args(),
             ));
         }

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -34,22 +34,23 @@ pub fn init(mut mouse: PS2Mouse<'static>, mouse_queue_producer: Queue<Event>) ->
     // Set Mouse ID to 4.
     if let Err(e) = mouse.set_mouse_id(MouseId::Four) {
         error!("Failed to set the mouse id to four: {e}");
+        loop {}
         return Err("Failed to set the mouse id to four");
     }
     // Read it back to check that it worked.
-    match mouse.mouse_id() {
-        Ok(id) =>  {
-            debug!("The PS/2 mouse ID is: {id:?}");
-            if !matches!(id, MouseId::Four) {
-                error!("Failed to set the mouse id to four");
-                return Err("Failed to set the mouse id to four");
-            }
-        }
-        Err(e) => {
-            error!("Failed to read the PS/2 mouse ID: {e}");
-            return Err("Failed to read the PS/2 mouse ID");
-        }
-    }
+    // match mouse.mouse_id() {
+    //     Ok(id) =>  {
+    //         debug!("The PS/2 mouse ID is: {id:?}");
+    //         if !matches!(id, MouseId::Four) {
+    //             error!("Failed to set the mouse id to four");
+    //             return Err("Failed to set the mouse id to four");
+    //         }
+    //     }
+    //     Err(e) => {
+    //         error!("Failed to read the PS/2 mouse ID: {e}");
+    //         return Err("Failed to read the PS/2 mouse ID");
+    //     }
+    // }
 
     // Register the interrupt handler
     interrupts::register_interrupt(PS2_MOUSE_IRQ, ps2_mouse_handler).map_err(|e| {

--- a/kernel/window_manager/src/lib.rs
+++ b/kernel/window_manager/src/lib.rs
@@ -602,33 +602,33 @@ impl WindowManager {
 
 /// Initialize the window manager. It returns (keyboard_producer, mouse_producer) for the I/O devices.
 pub fn init() -> Result<(Queue<Event>, Queue<Event>), &'static str> {
-    let final_fb: Framebuffer<AlphaPixel> = framebuffer::init()?;
-    let (width, height) = final_fb.get_size();
+    // let final_fb: Framebuffer<AlphaPixel> = framebuffer::init()?;
+    // let (width, height) = final_fb.get_size();
 
-    let mut bottom_fb = Framebuffer::new(width, height, None)?;
-    let mut top_fb = Framebuffer::new(width, height, None)?;
-    let (screen_width, screen_height) = bottom_fb.get_size();
-    bottom_fb.fill(color::LIGHT_GRAY.into());
-    top_fb.fill(color::TRANSPARENT.into()); 
+    // let mut bottom_fb = Framebuffer::new(width, height, None)?;
+    // let mut top_fb = Framebuffer::new(width, height, None)?;
+    // let (screen_width, screen_height) = bottom_fb.get_size();
+    // bottom_fb.fill(color::LIGHT_GRAY.into());
+    // top_fb.fill(color::TRANSPARENT.into()); 
 
-    // Initial position for the mouse
-    let mouse = Coord {
-        x: screen_width as isize / 2,
-        y: screen_height as isize / 2,
-    }; 
+    // // Initial position for the mouse
+    // let mouse = Coord {
+    //     x: screen_width as isize / 2,
+    //     y: screen_height as isize / 2,
+    // }; 
 
-    // Initialize static window manager
-    let window_manager = WindowManager {
-        hide_list: VecDeque::new(),
-        show_list: VecDeque::new(),
-        active: Weak::new(),
-        mouse,
-        repositioned_border: None,
-        bottom_fb,
-        top_fb,
-        final_fb,
-    };
-    WINDOW_MANAGER.call_once(|| Mutex::new(window_manager));
+    // // Initialize static window manager
+    // let window_manager = WindowManager {
+    //     hide_list: VecDeque::new(),
+    //     show_list: VecDeque::new(),
+    //     active: Weak::new(),
+    //     mouse,
+    //     repositioned_border: None,
+    //     bottom_fb,
+    //     top_fb,
+    //     final_fb,
+    // };
+    // WINDOW_MANAGER.call_once(|| Mutex::new(window_manager)); //everything above including this line
 
     // keyinput queue initialization
     let key_consumer: Queue<Event> = Queue::with_capacity(100);
@@ -638,9 +638,9 @@ pub fn init() -> Result<(Queue<Event>, Queue<Event>), &'static str> {
     let mouse_consumer: Queue<Event> = Queue::with_capacity(100);
     let mouse_producer = mouse_consumer.clone();
 
-    spawn::new_task_builder(window_manager_loop, (key_consumer, mouse_consumer))
-        .name("window_manager_loop".to_string())
-        .spawn()?;
+    // spawn::new_task_builder(window_manager_loop, (key_consumer, mouse_consumer))
+    //     .name("window_manager_loop".to_string())
+    //     .spawn()?;
 
     Ok((key_producer, mouse_producer))
 }


### PR DESCRIPTION
- just prints out debug info to vga
- should loop on error so you can see logs

Please try this as is and type some stuff, then update `keyboard.keyboard_scancode_set(ScancodeSet::Set1)?;` to use Set2 and maybe Set 3 as well. Some of these might print bogus scancode errors, I'm interested in seeing "ps2_keyboard_handler" logs.

Then also try putting an infinite loop in device_manager after the ps2 setup (I mean after all the ps2 setup is done, not just the controller), so I can see the debug logs of the setup.

(Of course this is just for testing, the real PR will come later)