### PR TITLE
 Jump to captain and enable scheduling on aarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,6 +1525,7 @@ dependencies = [
  "memory",
  "pic",
  "spin 0.9.4",
+ "time",
  "tock-registers",
  "tss",
  "vga_buffer",

--- a/kernel/app_io/src/lib.rs
+++ b/kernel/app_io/src/lib.rs
@@ -12,7 +12,8 @@
 #![no_std]
 
 extern crate alloc;
-extern crate logger_x86_64 as logger;
+#[cfg(target_arch = "x86_64")]
+extern crate logger_x86_64;
 
 use alloc::{format, sync::Arc};
 use core2::io::{self, Error, ErrorKind, Read, Write};
@@ -215,9 +216,10 @@ pub fn print_to_stdout_args(fmt_args: core::fmt::Arguments) {
                 .write_all(format!("{fmt_args}").as_bytes())
                 .is_err()
             {
-                let _ = logger::write_str("\x1b[31m [E] failed to write to stdout \x1b[0m\n");
+                #[cfg(target_arch = "x86_64")]
+                let _ = logger_x86_64::write_str("\x1b[31m [E] failed to write to stdout \x1b[0m\n");
             }
     } else {
-        // let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
+        // let _ = logger_x86_64::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
     };
 }

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -8,102 +8,43 @@ edition = "2021"
 [dependencies]
 log = "0.4.8"
 
-[dependencies.irq_safety]
-git = "https://github.com/theseus-os/irq_safety"
+irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
+dfqueue = { path = "../../libs/dfqueue", version = "0.1.0" }
+kernel_config = { path = "../kernel_config" }
+interrupts = { path = "../interrupts" }
+scheduler = { path = "../scheduler" }
+mod_mgmt = { path = "../mod_mgmt" }
+no_drop = { path = "../no_drop" }
+task_fs = { path = "../task_fs" }
+memory = { path = "../memory" }
+spawn = { path = "../spawn" }
+stack = { path = "../stack" }
+task = { path = "../task" }
+cpu = { path = "../cpu" }
 
-[dependencies.dfqueue]
-path = "../../libs/dfqueue"
-version = "0.1.0"
-
-[dependencies.kernel_config]
-path = "../kernel_config"
-
-[dependencies.logger_x86_64]
-path = "../logger_x86_64"
-
-[dependencies.window_manager]
-path = "../window_manager"
-
-[dependencies.first_application]
-path = "../first_application"
-
-[dependencies.memory]
-path = "../memory"
-
-[dependencies.no_drop]
-path = "../no_drop"
-
-[dependencies.stack]
-path = "../stack"
-
-[dependencies.mod_mgmt]
-path = "../mod_mgmt"
-
-[dependencies.exceptions_full]
-path = "../exceptions_full"
-
-[dependencies.tlb_shootdown]
-path = "../tlb_shootdown"
-
-[dependencies.cpu]
-path = "../cpu"
-
-[dependencies.spawn]
-path = "../spawn"
-
-[dependencies.tsc]
-path = "../tsc"
-
-[dependencies.interrupts]
-path = "../interrupts"
-
-[dependencies.acpi]
-path = "../acpi"
-
-[dependencies.multicore_bringup]
-path = "../multicore_bringup"
-
-[dependencies.page_attribute_table]
-path = "../page_attribute_table"
-
-[dependencies.device_manager]
-path = "../device_manager"
-
-[dependencies.e1000]
-path = "../e1000"
-
-[dependencies.task]
-path = "../task"
-
-[dependencies.scheduler]
-path = "../scheduler"
-
-[dependencies.console]
-path = "../console"
-
-[dependencies.app_io]
-path = "../app_io"
-
-[dependencies.vga_buffer]
-path = "../vga_buffer"
-
-[dependencies.network_manager]
-path = "../network_manager"
-
-[dependencies.ota_update_client]
-path = "../ota_update_client"
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+logger_x86_64 = { path = "../logger_x86_64" }
+window_manager = { path = "../window_manager" }
+first_application = { path = "../first_application" }
+exceptions_full = { path = "../exceptions_full" }
+tlb_shootdown = { path = "../tlb_shootdown" }
+multiple_heaps = { path = "../multiple_heaps" }
+tsc = { path = "../tsc" }
+acpi = { path = "../acpi" }
+multicore_bringup = { path = "../multicore_bringup" }
+page_attribute_table = { path = "../page_attribute_table" }
+device_manager = { path = "../device_manager" }
+e1000 = { path = "../e1000" }
+console = { path = "../console" }
+app_io = { path = "../app_io" }
+vga_buffer = { path = "../vga_buffer" }
+network_manager = { path = "../network_manager" }
+ota_update_client = { path = "../ota_update_client" }
 
 ## This should be dependent upon 'cfg(simd_personality)',
 ## but it cannot be because of https://github.com/rust-lang/cargo/issues/5499.
 ## Therefore, it has to be unconditionally included.
-[dependencies.simd_personality]
-path = "../simd_personality"
-
-[dependencies.task_fs]
-path = "../task_fs"
-
-[dependencies.multiple_heaps]
-path = "../multiple_heaps"
+simd_personality = { path = "../simd_personality" }
 
 [features]
 # TODO: Remove when UEFI is fully implemented

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -161,7 +161,7 @@ pub fn init(
         info!("Initialized per-core heaps");
     }
 
-    #[cfg(feature = "uefi")] {
+    #[cfg(all(feature = "uefi", target_arch = "x86_64"))] {
         log::error!("uefi boot cannot proceed as it is not fully implemented");
         loop {}
     }

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -19,14 +19,17 @@
 
 extern crate alloc;
 
-use core::ops::DerefMut;
 use log::{error, info};
 use memory::{EarlyIdentityMappedPages, MmiRef, PhysicalAddress, VirtualAddress};
-use kernel_config::memory::KERNEL_STACK_SIZE_IN_PAGES;
 use irq_safety::enable_interrupts;
 use stack::Stack;
 use no_drop::NoDrop;
 
+#[cfg(target_arch = "x86_64")]
+use {
+    core::ops::DerefMut,
+    kernel_config::memory::KERNEL_STACK_SIZE_IN_PAGES,
+};
 
 #[cfg(all(mirror_log_to_vga, target_arch = "x86_64"))]
 mod mirror_log_callbacks {
@@ -69,6 +72,7 @@ impl DropAfterInit {
 /// * `ap_gdt`: the virtual address of the GDT created for the AP's realmode boot code.
 /// * `rsdp_address`: the physical address of the RSDP (an ACPI table pointer),
 ///    if available and provided by the bootloader.
+#[cfg_attr(target_arch = "aarch64", allow(unreachable_code, unused_variables))]
 pub fn init(
     kernel_mmi_ref: MmiRef,
     bsp_initial_stack: NoDrop<Stack>,

--- a/kernel/catch_unwind/Cargo.toml
+++ b/kernel/catch_unwind/Cargo.toml
@@ -4,14 +4,13 @@ name = "catch_unwind"
 description = "Support for catching unwinding after a panic, like `std::panic::catch_unwind`"
 version = "0.1.0"
 
-[dependencies.log]
-version = "0.4.8"
+[dependencies]
+log = "0.4.8"
 
-[dependencies.unwind]
-path = "../unwind"
+task = { path = "../task" }
 
-[dependencies.task]
-path = "../task"
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+unwind = { path = "../unwind" }
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/catch_unwind/src/lib.rs
+++ b/kernel/catch_unwind/src/lib.rs
@@ -7,8 +7,9 @@ extern crate alloc;
 extern crate task;
 
 use core::mem::ManuallyDrop;
-use alloc::boxed::Box;
 use task::KillReason;
+#[cfg(target_arch = "x86_64")]
+use alloc::boxed::Box;
 
 /// Invokes the given closure `f`, catching a panic as it is unwinding the stack.
 /// 
@@ -52,7 +53,8 @@ pub fn catch_unwind_with_arg<F, A, R>(f: F, arg: A) -> Result<R, KillReason>
 /// # Arguments
 /// * a pointer to the 
 /// * a pointer to the arbitrary object passed around during the unwinding process,
-///   which in Theseus is a pointer to the `UnwindingContext`. 
+///   which in Theseus is a pointer to the `UnwindingContext`.
+#[cfg_attr(target_arch = "aarch64", allow(unused_variables))]
 fn panic_callback<F, A, R>(data_ptr: *mut u8, exception_object: *mut u8) where F: FnOnce(A) -> R {
     #[cfg(not(target_arch = "x86_64"))]
     loop {};
@@ -110,6 +112,7 @@ fn try_intrinsic_trampoline<F, A, R>(try_intrinsic_arg: *mut u8) where F: FnOnce
 ///    represent the possibility of a non-panic failure, e.g., a machine exception.
 /// 
 /// [`std::panic::resume_unwind()`]: https://doc.rust-lang.org/std/panic/fn.resume_unwind.html
+#[cfg_attr(target_arch = "aarch64", allow(unused_variables))]
 pub fn resume_unwind(caught_panic_reason: KillReason) -> ! {
     // We can skip up to 2 frames here: `unwind::start_unwinding` and `resume_unwind` (this function)
     #[cfg(target_arch = "x86_64")]

--- a/kernel/cpu/src/aarch64.rs
+++ b/kernel/cpu/src/aarch64.rs
@@ -4,6 +4,8 @@ use cortex_a::registers::MPIDR_EL1;
 use tock_registers::interfaces::Readable;
 
 use core::fmt;
+use super::CpuId;
+use derive_more::{Display, Binary, Octal, LowerHex, UpperHex};
 
 /// Returns the number of CPUs (SMP cores) that exist and
 /// are currently initialized on this system.

--- a/kernel/fault_log/Cargo.toml
+++ b/kernel/fault_log/Cargo.toml
@@ -4,26 +4,13 @@ version = "0.1.0"
 description = "Logs all exceptions occuring in Theseus"
 authors = ["Namitha Liyanage <namithaliyanage@gmail.com>"]
 
+[dependencies]
+irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
+memory = { path = "../memory" }
+app_io = { path = "../app_io" }
+task = { path = "../task" }
+cpu = { path = "../cpu" }
+log = { default-features = false, version = "0.4.8" }
 
-[dependencies.irq_safety]
-git = "https://github.com/theseus-os/irq_safety"
-
-[dependencies.memory]
-path = "../memory"
-
-[dependencies.vga_buffer]
-path = "../vga_buffer"
-
-[dependencies.app_io]
-path = "../app_io"
-
-[dependencies.task]
-path = "../task"
-
-[dependencies.cpu]
-path = "../cpu"
-
-[dependencies.log]
-default-features = false
-version = "0.4.8"
-
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+vga_buffer = { path = "../vga_buffer" }

--- a/kernel/fault_log/src/lib.rs
+++ b/kernel/fault_log/src/lib.rs
@@ -6,7 +6,10 @@
 #![no_std]
 #![feature(drain_filter)]
 
-#[macro_use] extern crate vga_buffer; // for println_raw!()
+#[cfg(target_arch = "x86_64")]
+#[macro_use]
+extern crate vga_buffer; // for println_raw!()
+
 #[macro_use] extern crate app_io; // for regular println!()
 #[macro_use] extern crate log;
 extern crate alloc;
@@ -221,11 +224,15 @@ pub fn remove_unhandled_exceptions() -> Vec<FaultEntry> {
 /// calls println!() and then println_raw!()
 macro_rules! println_both {
     ($fmt:expr) => {
+        #[cfg(target_arch = "x86_64")]
         print_raw!(concat!($fmt, "\n"));
+
         print!(concat!($fmt, "\n"));
     };
     ($fmt:expr, $($arg:tt)*) => {
+        #[cfg(target_arch = "x86_64")]
         print_raw!(concat!($fmt, "\n"), $($arg)*);
+
         print!(concat!($fmt, "\n"), $($arg)*);
     };
 }

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -16,6 +16,7 @@ irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
 gic = { path = "../gic" }
 tock-registers = "0.7.0"
 cortex-a = "7.5.0"
+time = { path = "../time" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 exceptions_early = { path = "../exceptions_early" }

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -250,8 +250,11 @@ pub fn eoi(irq_num: InterruptNumber) {
     gic.end_of_interrupt(irq_num);
 }
 
+// A ClockSource for the time crate, implemented using
+// the System Counter of the Generic Arm Timer. The
+// period of this timer is computed in `init` above.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct PhysicalSystemCounter;
+struct PhysicalSystemCounter;
 
 impl ClockSource for PhysicalSystemCounter {
     type ClockType = Monotonic;

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -11,7 +11,7 @@ use tock_registers::registers::InMemoryRegister;
 use gic::{qemu_virt_addrs, ArmGic, InterruptNumber, Version as GicVersion};
 use irq_safety::{RwLockIrqSafe, MutexIrqSafe};
 use memory::get_kernel_mmi_ref;
-use log::{info, error};
+use log::error;
 
 // This assembly file contains trampolines to `extern "C"` functions defined below.
 global_asm!(include_str!("table.s"));
@@ -64,6 +64,7 @@ pub struct ExceptionContext {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
 pub enum EoiBehaviour {
     CallerMustSignalEoi,
     HandlerHasSignaledEoi,

--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -24,10 +24,10 @@ mod_mgmt = { path = "../mod_mgmt" }
 panic_entry = { path = "../panic_entry" }
 memory_initialization = { path = "../memory_initialization" }
 boot_info = { path = "../boot_info" }
+captain = { path = "../captain" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 exceptions_early = { path = "../exceptions_early" }
-captain = { path = "../captain" }
 serial_port_basic = { path = "../serial_port_basic" }
 vga_buffer = { path = "../vga_buffer" }
 logger_x86_64 = { path = "../logger_x86_64" }

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -23,11 +23,14 @@ extern crate panic_entry;
 
 use core::ops::DerefMut;
 use memory::VirtualAddress;
-use kernel_config::memory::KERNEL_OFFSET;
 use mod_mgmt::parse_nano_core::NanoCoreItems;
 
 #[cfg(target_arch = "x86_64")]
-use vga_buffer::println_raw;
+use {
+    vga_buffer::println_raw,
+    kernel_config::memory::KERNEL_OFFSET,
+};
+
 #[cfg(target_arch = "aarch64")]
 use log::info as println_raw;
 

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -24,7 +24,7 @@ cfg_if::cfg_if! {
     }
 }
 
-use interrupts::{self, CPU_LOCAL_TIMER_IRQ, eoi, register_interrupt};
+use interrupts::{self, CPU_LOCAL_TIMER_IRQ, eoi};
 use task::{self, TaskRef};
 
 /// A re-export of [`task::schedule()`] for convenience and legacy compatibility.
@@ -44,7 +44,7 @@ pub fn init() -> Result<(), &'static str> {
     task::set_scheduler_policy(scheduler::select_next_task);
 
     #[cfg(target_arch = "x86_64")] {
-        register_interrupt(
+        interrupts::register_interrupt(
             CPU_LOCAL_TIMER_IRQ,
             lapic_timer_handler,
         ).map_err(|_handler| {

--- a/kernel/tls_initializer/src/lib.rs
+++ b/kernel/tls_initializer/src/lib.rs
@@ -16,13 +16,16 @@
 extern crate alloc;
 
 use alloc::{sync::Arc, vec::Vec, boxed::Box};
-use core::{mem::size_of, cmp::max, ops::Deref};
+use core::{cmp::max, ops::Deref};
 use crate_metadata::{LoadedSection, SectionType, StrongSectionRef};
 use memory_structs::VirtualAddress;
 use rangemap::RangeMap;
 
 #[cfg(target_arch = "x86_64")]
-use x86_64::{registers::model_specific::FsBase, VirtAddr};
+use {
+    core::mem::size_of,
+    x86_64::{registers::model_specific::FsBase, VirtAddr},
+};
 
 #[cfg(target_arch = "aarch64")]
 use {
@@ -127,6 +130,7 @@ impl TlsInitializer {
     ///   would overlap with an existing section. 
     ///   An error occurring here would indicate a link-time bug 
     ///   or a bug in the symbol parsing code that invokes this function.
+    #[cfg_attr(target_arch = "aarch64", allow(unused_variables))]
     pub fn add_existing_static_tls_section(
         &mut self,
         mut tls_section: LoadedSection,


### PR DESCRIPTION
This contains four changes:
- `nano_core` depends on `captain` and jumps to it just like on x86_64
- `captain::init` calls are almost entirely arch-gated
- preemptive scheduling is enabled on aarch64
- a `time::ClockSource` was implemented for aarch64 in `interrupts` using the physical system timer