### PR TITLE
Added aarch64 scheduling code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,6 +1525,7 @@ dependencies = [
  "memory",
  "pic",
  "spin 0.9.4",
+ "time",
  "tock-registers",
  "tss",
  "vga_buffer",

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -16,6 +16,7 @@ irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
 gic = { path = "../gic" }
 tock-registers = "0.7.0"
 cortex-a = "7.5.0"
+time = { path = "../time" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 exceptions_early = { path = "../exceptions_early" }

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -249,8 +249,11 @@ pub fn eoi(irq_num: InterruptNumber) {
     gic.end_of_interrupt(irq_num);
 }
 
+// A ClockSource for the time crate, implemented using
+// the System Counter of the Generic Arm Timer. The
+// period of this timer is computed in `init` above.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct PhysicalSystemCounter;
+struct PhysicalSystemCounter;
 
 impl ClockSource for PhysicalSystemCounter {
     type ClockType = Monotonic;

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -96,12 +96,9 @@ pub fn init() -> Result<(), &'static str> {
         static __exception_vector_start: extern "C" fn();
     }
 
-    let counter_freq_hz = CNTFRQ_EL0.get() as f64;
-    let fs_in_one_sec = 1_000_000_000_000_000.0;
-
-    // https://doc.rust-lang.org/reference/expressions/operator-expr.html
-    // "Casting from a float to an integer will round the float towards zero"
-    let period_femtoseconds = (fs_in_one_sec / counter_freq_hz) as u64;
+    let counter_freq_hz = CNTFRQ_EL0.get();
+    let fs_in_one_sec = 1_000_000_000_000_000;
+    let period_femtoseconds = fs_in_one_sec / counter_freq_hz;
 
     register_clock_source::<PhysicalSystemCounter>(Period::new(period_femtoseconds));
 

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -66,6 +66,7 @@ pub struct ExceptionContext {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
 pub enum EoiBehaviour {
     CallerMustSignalEoi,
     HandlerHasSignaledEoi,
@@ -122,7 +123,7 @@ pub fn init() -> Result<(), &'static str> {
         let mut mmi = kernel_mmi_ref.lock();
         let page_table = &mut mmi.deref_mut().page_table;
 
-        log::info!("Configuring the GIC");
+        info!("Configuring the GIC");
         let mut inner = ArmGic::init(
             page_table,
             GicVersion::InitV3 {
@@ -134,7 +135,7 @@ pub fn init() -> Result<(), &'static str> {
         inner.set_minimum_priority(0);
         *gic = Some(inner);
 
-        log::info!("Done Configuring the GIC");
+        info!("Done Configuring the GIC");
 
         Ok(())
     }
@@ -180,9 +181,9 @@ pub fn enable_timer_interrupts(enable: bool, timer_tick_handler: HandlerFunc) ->
 
     /* DEBUGGING CODE
 
-    log::info!("timer enabled: {:?}",  CNTP_CTL_EL0.read(CNTP_CTL_EL0::ENABLE));
-    log::info!("timer IMASK: {:?}",   CNTP_CTL_EL0.read(CNTP_CTL_EL0::IMASK));
-    log::info!("timer status: {:?}", CNTP_CTL_EL0.read(CNTP_CTL_EL0::ISTATUS));
+    info!("timer enabled: {:?}",  CNTP_CTL_EL0.read(CNTP_CTL_EL0::ENABLE));
+    info!("timer IMASK: {:?}",   CNTP_CTL_EL0.read(CNTP_CTL_EL0::IMASK));
+    info!("timer status: {:?}", CNTP_CTL_EL0.read(CNTP_CTL_EL0::ISTATUS));
 
     */
 

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -72,9 +72,6 @@ pub enum EoiBehaviour {
     HandlerHasSignaledEoi,
 }
 
-/// Return value:
-/// - true if you sent an End Of Interrupt signal in the handler
-/// - false if you want the caller to do it for you after you return
 type HandlerFunc = extern "C" fn(&ExceptionContext) -> EoiBehaviour;
 
 // called for all exceptions other than interrupts

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -13,6 +13,8 @@ use irq_safety::{RwLockIrqSafe, MutexIrqSafe};
 use memory::get_kernel_mmi_ref;
 use log::{info, error};
 
+use time::{Monotonic, ClockSource, Instant, Period, register_clock_source};
+
 // This assembly file contains trampolines to `extern "C"` functions defined below.
 global_asm!(include_str!("table.s"));
 
@@ -96,6 +98,15 @@ pub fn init() -> Result<(), &'static str> {
         static __exception_vector_start: extern "C" fn();
     }
 
+    let counter_freq_hz = CNTFRQ_EL0.get() as f64;
+    let fs_in_one_sec = 1_000_000_000_000_000.0;
+
+    // https://doc.rust-lang.org/reference/expressions/operator-expr.html
+    // "Casting from a float to an integer will round the float towards zero"
+    let period_femtoseconds = (fs_in_one_sec / counter_freq_hz) as u64;
+
+    register_clock_source::<PhysicalSystemCounter>(Period::new(period_femtoseconds));
+
     let mut gic = GIC.lock();
     if gic.is_some() {
         Err("The GIC has already been initialized!")
@@ -158,10 +169,6 @@ pub fn enable_timer_interrupts(enable: bool, timer_tick_handler: HandlerFunc) ->
         gic.set_interrupt_state(CPU_LOCAL_TIMER_IRQ, enable);
     }
 
-    // read the frequency (useless atm)
-    // let counter_freq_hz = CNTFRQ_EL0.get();
-    // log::info!("frq: {:?}", counter_freq_hz);
-
     // unmask the interrupt & enable the timer
     CNTP_CTL_EL0.write(
           CNTP_CTL_EL0::IMASK.val(0)
@@ -173,7 +180,6 @@ pub fn enable_timer_interrupts(enable: bool, timer_tick_handler: HandlerFunc) ->
 
     /* DEBUGGING CODE
 
-    log::info!("timer counter: {:?}", CNTPCT_EL0.get());
     log::info!("timer enabled: {:?}",  CNTP_CTL_EL0.read(CNTP_CTL_EL0::ENABLE));
     log::info!("timer IMASK: {:?}",   CNTP_CTL_EL0.read(CNTP_CTL_EL0::IMASK));
     log::info!("timer status: {:?}", CNTP_CTL_EL0.read(CNTP_CTL_EL0::ISTATUS));
@@ -241,6 +247,17 @@ pub fn eoi(irq_num: InterruptNumber) {
     let mut gic = GIC.lock();
     let gic = gic.as_mut().expect("GIC is uninitialized");
     gic.end_of_interrupt(irq_num);
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PhysicalSystemCounter;
+
+impl ClockSource for PhysicalSystemCounter {
+    type ClockType = Monotonic;
+
+    fn now() -> Instant {
+        Instant::new(CNTPCT_EL0.get())
+    }
 }
 
 #[rustfmt::skip]

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -24,7 +24,7 @@ cfg_if::cfg_if! {
     }
 }
 
-use interrupts::{self, CPU_LOCAL_TIMER_IRQ, eoi, register_interrupt};
+use interrupts::{self, CPU_LOCAL_TIMER_IRQ, eoi};
 use task::{self, TaskRef};
 
 /// A re-export of [`task::schedule()`] for convenience and legacy compatibility.
@@ -44,7 +44,7 @@ pub fn init() -> Result<(), &'static str> {
     task::set_scheduler_policy(scheduler::select_next_task);
 
     #[cfg(target_arch = "x86_64")] {
-        register_interrupt(
+        interrupts::register_interrupt(
             CPU_LOCAL_TIMER_IRQ,
             lapic_timer_handler,
         ).map_err(|_handler| {

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -58,11 +58,6 @@ pub fn init() -> Result<(), &'static str> {
         interrupts::enable_timer(true);
         Ok(())
     }
-
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))] {
-        log::error!("TODO: scheduler::init() only supports registering a preemptive task switching timer interrupt on x86_64");
-        Err("TODO: scheduler::init() only supports registering a preemptive task switching timer interrupt on x86_64")
-    }
 }
 
 /// The handler for each CPU's local timer interrupt, used for preemptive task switching.

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -54,7 +54,9 @@ pub fn init() -> Result<(), &'static str> {
     }
 
     #[cfg(target_arch = "aarch64")] {
-        interrupts::enable_timer_interrupts(true, aarch64_timer_handler)
+        interrupts::init_timer(aarch64_timer_handler)?;
+        interrupts::enable_timer(true);
+        Ok(())
     }
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))] {

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -79,9 +79,9 @@ fn cpu_local_timer_tick_handler() {
     // tick count, only used for debugging
     #[cfg(any())] { // cfg(any()) is always false
         use core::sync::atomic::{AtomicUsize, Ordering};
-        static LAPIC_TIMER_TICKS: AtomicUsize = AtomicUsize::new(0);
-        let _ticks = LAPIC_TIMER_TICKS.fetch_add(1, Ordering::Relaxed);
-        log::info!("(CPU {}) LAPIC TIMER HANDLER! TICKS = {}", cpu::current_cpu(), _ticks);
+        static CPU_LOCAL_TIMER_TICKS: AtomicUsize = AtomicUsize::new(0);
+        let _ticks = CPU_LOCAL_TIMER_TICKS.fetch_add(1, Ordering::Relaxed);
+        log::info!("(CPU {}) CPU-LOCAL TIMER HANDLER! TICKS = {}", cpu::current_cpu(), _ticks);
     }
 
     // Inform the `sleep` crate that it should update its inner tick count


### PR DESCRIPTION
Two unrelated changes to `interrupts` & `scheduler`
- implements preemptive scheduling via timer interrupts on aarch64
- a `time::ClockSource` was implemented for aarch64 in `interrupts` using the physical system timer