### PR TITLE
aarch64: fix stack allocation math in context switch

### DIFF
--- a/kernel/context_switch_regular/src/aarch64.rs
+++ b/kernel/context_switch_regular/src/aarch64.rs
@@ -79,7 +79,7 @@ macro_rules! save_registers_regular {
         // Save all general purpose registers into the previous task.
         r#"
             // Make room on the stack for the registers.
-            sub sp,  sp,  #8 * 2 + 6
+            sub sp,  sp,  #8 * 2 * 6
 
             // Push registers on the stack, two at a time.
             stp x19, x20, [sp, #8 * 2 * 0]


### PR DESCRIPTION
In `save_registers_regular`:
```rust
#[macro_export]
macro_rules! save_registers_regular {
    () => (
        // Save all general purpose registers into the previous task.
        r#"
            // Make room on the stack for the registers.
            sub sp,  sp,  #8 * 2 + 6

            // Push registers on the stack, two at a time.
            stp x19, x20, [sp, #8 * 2 * 0]
            stp x21, x22, [sp, #8 * 2 * 1]
            stp x23, x24, [sp, #8 * 2 * 2]
            stp x25, x26, [sp, #8 * 2 * 3]
            stp x27, x28, [sp, #8 * 2 * 4]
            stp x29, x30, [sp, #8 * 2 * 5]
        "#
    );
}
```
`#8 * 2 + 6` is wrong, it should be `#8 * 2 * 6`: 8 bytes, 2 registers per store, 6 stores