### PR TITLE
Small scheduling improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,6 +1520,7 @@ dependencies = [
  "gdt",
  "gic",
  "irq_safety",
+ "kernel_config",
  "locked_idt",
  "log",
  "memory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,7 @@ dependencies = [
  "scheduler_round_robin",
  "sleep",
  "task",
+ "time",
  "x86_64",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3151,7 +3151,6 @@ dependencies = [
  "scheduler_round_robin",
  "sleep",
  "task",
- "time",
  "x86_64",
 ]
 

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -173,7 +173,7 @@ pub fn init(
         info!("Initialized per-core heaps");
     }
 
-    #[cfg(feature = "uefi")] {
+    #[cfg(all(target_arch = "x86_64", feature = "uefi"))] {
         log::error!("uefi boot cannot proceed as it is not fully implemented");
         loop {}
     }

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -10,6 +10,7 @@ log = "0.4.8"
 
 memory = { path = "../memory" }
 cpu = { path = "../cpu" }
+spin = "0.9.4"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
@@ -27,5 +28,4 @@ gdt = { path = "../gdt" }
 pic = { path = "../pic" }
 tss = { path = "../tss" }
 x86_64 = "0.14.8"
-spin = "0.9.4"
 locked_idt = { path = "../../libs/locked_idt" }

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -13,6 +13,7 @@ cpu = { path = "../cpu" }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
+kernel_config = { path = "../kernel_config" }
 gic = { path = "../gic" }
 tock-registers = "0.7.0"
 cortex-a = "7.5.0"

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -92,12 +92,12 @@ extern "C" fn default_irq_handler(exc: &ExceptionContext) -> EoiBehaviour {
 }
 
 #[inline(always)]
-fn read_timer_period_femtoseconds() -> u64 {
-    let counter_freq_hz = CNTFRQ_EL0.get();
-    let fs_in_one_sec = 1_000_000_000_000_000;
-    let period_femtoseconds = fs_in_one_sec / counter_freq_hz;
-    TICK_PERIOD_FEMTOSECS.call_once(|| period_femtoseconds);
-    period_femtoseconds
+fn read_timer_period_femtoseconds() -> u64 { 
+    *TICK_PERIOD_FEMTOSECS.call_once(|| {
+        let counter_freq_hz = CNTFRQ_EL0.get();
+        let fs_in_one_sec = 1_000_000_000_000_000;
+        fs_in_one_sec / counter_freq_hz
+    })
 }
 
 /// Please call this (only once) before using this crate.

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -172,8 +172,7 @@ pub fn init_timer(timer_tick_handler: HandlerFunc) -> Result<(), &'static str> {
 pub fn schedule_next_timer_tick() {
     enable_timer(false);
     let timeslice_femtosecs = (CONFIG_TIMESLICE_PERIOD_MICROSECONDS as u64) * 1_000_000_000;
-    let tick_period_femtosecs = TICK_PERIOD_FEMTOSECS.get()
-        .expect("please call interrupts::init before enabling the timer!");
+    let tick_period_femtosecs = read_timer_period_femtoseconds();
     let ticks = timeslice_femtosecs / tick_period_femtosecs;
     CNTP_TVAL_EL0.set(ticks);
     enable_timer(true);

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -23,7 +23,7 @@ global_asm!(include_str!("table.s"));
 // The global Generic Interrupt Controller singleton
 static GIC: MutexIrqSafe<Option<ArmGic>> = MutexIrqSafe::new(None);
 
-// The global Generic Interrupt Controller singleton
+// The number of femtoseconds between each internal timer tick
 static TICK_PERIOD_FEMTOSECS: Once<u64> = Once::new();
 
 /// The IRQ number reserved for CPU-local timer interrupts,

--- a/kernel/scheduler/Cargo.toml
+++ b/kernel/scheduler/Cargo.toml
@@ -21,3 +21,6 @@ scheduler_realtime = { path = "../scheduler_realtime" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = "0.14.8"
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+time = { path = "../time" }

--- a/kernel/scheduler/Cargo.toml
+++ b/kernel/scheduler/Cargo.toml
@@ -21,6 +21,3 @@ scheduler_realtime = { path = "../scheduler_realtime" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = "0.14.8"
-
-[target.'cfg(target_arch = "aarch64")'.dependencies]
-time = { path = "../time" }

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -63,8 +63,8 @@ pub fn init() -> Result<(), &'static str> {
 /// The handler for each CPU's local timer interrupt, used for preemptive task switching.
 #[cfg(target_arch = "aarch64")]
 extern "C" fn aarch64_timer_handler(_exc: &interrupts::ExceptionContext) -> interrupts::EoiBehaviour {
+    interrupts::schedule_next_timer_tick(time::Duration::from_micros(100));
     cpu_local_timer_tick_handler();
-
     interrupts::EoiBehaviour::HandlerHasSignaledEoi
 }
 

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -78,7 +78,6 @@ extern "x86-interrupt" fn lapic_timer_handler(_stack_frame: x86_64::structures::
 fn cpu_local_timer_tick_handler() {
     // tick count, only used for debugging
     if false {
-        // optimized out on release builds
         use core::sync::atomic::{AtomicUsize, Ordering};
         static CPU_LOCAL_TIMER_TICKS: AtomicUsize = AtomicUsize::new(0);
         let _ticks = CPU_LOCAL_TIMER_TICKS.fetch_add(1, Ordering::Relaxed);

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -77,7 +77,8 @@ extern "x86-interrupt" fn lapic_timer_handler(_stack_frame: x86_64::structures::
 // Cross platform scheduling code
 fn cpu_local_timer_tick_handler() {
     // tick count, only used for debugging
-    #[cfg(any())] { // cfg(any()) is always false
+    if false {
+        // optimized out on release builds
         use core::sync::atomic::{AtomicUsize, Ordering};
         static CPU_LOCAL_TIMER_TICKS: AtomicUsize = AtomicUsize::new(0);
         let _ticks = CPU_LOCAL_TIMER_TICKS.fetch_add(1, Ordering::Relaxed);

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -63,7 +63,7 @@ pub fn init() -> Result<(), &'static str> {
 /// The handler for each CPU's local timer interrupt, used for preemptive task switching.
 #[cfg(target_arch = "aarch64")]
 extern "C" fn aarch64_timer_handler(_exc: &interrupts::ExceptionContext) -> interrupts::EoiBehaviour {
-    interrupts::schedule_next_timer_tick(time::Duration::from_micros(100));
+    interrupts::schedule_next_timer_tick();
     cpu_local_timer_tick_handler();
     interrupts::EoiBehaviour::HandlerHasSignaledEoi
 }


### PR DESCRIPTION
- Added preemption rate control for aarch64
- Changed the style of a debug-gate (cfg() → constant boolean)
- Removed the uefi gate in captain for aarch64