### PR TITLE
Early graphical framebuffer output works; not yet default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,6 +1166,7 @@ name = "framebuffer"
 version = "0.1.0"
 dependencies = [
  "color",
+ "early_printer",
  "log",
  "memory",
  "multicore_bringup",

--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,7 @@ endif
 	@echo -e "\t TARGET: \"$(TARGET)\""
 	@echo -e "\t KERNEL_PREFIX: \"$(KERNEL_PREFIX)\""
 	@echo -e "\t APP_PREFIX: \"$(APP_PREFIX)\""
+	@echo -e "\t CFLAGS: \"$(CFLAGS)\""
 	@echo -e "\t THESEUS_CONFIG (before build.rs script): \"$(THESEUS_CONFIG)\""
 	THESEUS_CFLAGS='$(CFLAGS)' THESEUS_NANO_CORE_BUILD_DIR='$(NANO_CORE_BUILD_DIR)' RUST_TARGET_PATH='$(CFG_DIR)' RUSTFLAGS='$(RUSTFLAGS)' cargo build $(CARGOFLAGS) $(FEATURES) $(BUILD_STD_CARGOFLAGS) --target $(TARGET)
 

--- a/kernel/acpi/acpi_table/src/lib.rs
+++ b/kernel/acpi/acpi_table/src/lib.rs
@@ -76,7 +76,7 @@ impl AcpiTables {
         if !self.frames.contains(&first_frame) {
             // Drop the current MappedPages and deallocate its frames so we can reallocate over them below. 
             let _orig_mp = core::mem::replace(&mut self.mapped_pages, MappedPages::empty());
-            trace!("[0] Dropping original {:?}", _orig_mp);
+            // trace!("[0] Dropping original {:?}", _orig_mp);
             drop(_orig_mp);
 
             let new_frames = self.frames.to_extended(first_frame);

--- a/kernel/app_io/src/lib.rs
+++ b/kernel/app_io/src/lib.rs
@@ -218,6 +218,6 @@ pub fn print_to_stdout_args(fmt_args: core::fmt::Arguments) {
                 let _ = logger::write_str("\x1b[31m [E] failed to write to stdout \x1b[0m\n");
             }
     } else {
-        // let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
+        let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
     };
 }

--- a/kernel/app_io/src/lib.rs
+++ b/kernel/app_io/src/lib.rs
@@ -218,6 +218,6 @@ pub fn print_to_stdout_args(fmt_args: core::fmt::Arguments) {
                 let _ = logger::write_str("\x1b[31m [E] failed to write to stdout \x1b[0m\n");
             }
     } else {
-        let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
+        // let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
     };
 }

--- a/kernel/boot_info/src/lib.rs
+++ b/kernel/boot_info/src/lib.rs
@@ -152,7 +152,7 @@ impl FramebufferInfo {
 }
 
 /// The format of the framebuffer, in graphical pixels or text-mode characters.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum FramebufferFormat {
     /// The format of a pixel is `[Pad] <Red> <Green> <Blue>`,
     /// in which `<Blue>` occupies the least significant bits.

--- a/kernel/boot_info/src/uefi.rs
+++ b/kernel/boot_info/src/uefi.rs
@@ -210,10 +210,7 @@ impl crate::BootInformation for &'static uefi_bootloader_api::BootInformation {
             */
         };
         Some(crate::FramebufferInfo {
-            // TODO FIXME: not sure about this, it seems to be a virtual address, not physical
-            address: Address::Physical(
-                PhysicalAddress::new_canonical(uefi_fb.start)
-            ),
+            address: Address::Physical(PhysicalAddress::new_canonical(uefi_fb.start)),
             total_size_in_bytes: uefi_fb_info.size as u64,
             width: uefi_fb_info.width as u32,
             height: uefi_fb_info.height as u32,

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -173,11 +173,6 @@ pub fn init(
         info!("Initialized per-core heaps");
     }
 
-    #[cfg(feature = "uefi")] {
-        log::error!("uefi boot cannot proceed as it is not fully implemented");
-        loop {}
-    }
-
     // Initialize the window manager, and also the PAT, if available.
     // The PAT supports write-combining caching of graphics video memory for better performance
     // and must be initialized explicitly on every CPU, 

--- a/kernel/framebuffer/Cargo.toml
+++ b/kernel/framebuffer/Cargo.toml
@@ -9,20 +9,11 @@ edition = "2021"
 log = "0.4.8"
 zerocopy = "0.5.0"
 
+color = { path = "../color" }
+early_printer = { path = "../early_printer" }
+memory = { path = "../memory" }
+multicore_bringup = { path = "../multicore_bringup" }
+shapes = { path = "../shapes" }
+
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 page_attribute_table = { path = "../page_attribute_table" }
-
-[dependencies.memory]
-path = "../memory"
-
-[dependencies.multicore_bringup]
-path = "../multicore_bringup"
-
-[dependencies.shapes]
-path = "../shapes"
-
-[dependencies.color]
-path = "../color"
-
-[lib]
-crate-type = ["rlib"]

--- a/kernel/multicore_bringup/src/lib.rs
+++ b/kernel/multicore_bringup/src/lib.rs
@@ -330,7 +330,7 @@ pub fn handle_ap_cores(
     }
 
     // Retrieve the graphic mode information written during the AP bootup sequence in `ap_realmode.asm`.
-    {
+    if ap_count != 0 {
         let graphic_info = trampoline_mapped_pages
             .as_type::<GraphicInfo>(GRAPHIC_INFO_OFFSET_FROM_TRAMPOLINE)?;
         info!("Obtained graphic info from real mode: {:?}", graphic_info);

--- a/kernel/nano_core/src/asm/bios/multiboot_header.asm
+++ b/kernel/nano_core/src/asm/bios/multiboot_header.asm
@@ -18,7 +18,7 @@ multiboot_header_start:
 ; By default, we ask the bootloader to switch modes to a graphical framebuffer for us,
 ; though this can be disabled by defining `VGA_TEXT_MODE`.
 ;
-; NOTE: TODO: uncomment the below sections when we are ready to enable
+; NOTE: this works properly now. Uncomment the below sections when we are ready to enable
 ;       early boot-time usage of the graphical framebuffer by default.
 ;
 ; %ifndef VGA_TEXT_MODE
@@ -26,9 +26,11 @@ multiboot_header_start:
 ; 	dw 5     ; type (5 means framebuffer tag)
 ; 	dw 0     ; flags. Bit 0 = `1` means this tag is optional, Bit 0 = `0` means it's mandatory.
 ; 	dd 20    ; size of this tag (20)
-; 	dd 1280  ; width (in pixels)
-; 	dd 1024  ; height (in pixels)
-; 	dd 32    ; depth (pixel size in bits)
+; 	; The resolution specified below is limited by the hardware.
+; 	; We have successfully tested resolutions up to 2560 x 1600.
+; 	dd 1920  ; width in pixels
+; 	dd 1080  ; height in pixels
+; 	dd 32    ; depth: pixel size in bits. Theseus only supports 32-bit pixels.
 ; %endif
 
 

--- a/kernel/nano_core/src/asm/bios/multiboot_header.asm
+++ b/kernel/nano_core/src/asm/bios/multiboot_header.asm
@@ -28,6 +28,7 @@ multiboot_header_start:
 ; 	dd 20    ; size of this tag (20)
 ; 	; The resolution specified below is limited by the hardware.
 ; 	; We have successfully tested resolutions up to 2560 x 1600.
+;   ; See more VGA/*XGA resolutions here: <https://en.wikipedia.org/wiki/Graphics_display_resolution#Extended_Graphics_Array>
 ; 	dd 1920  ; width in pixels
 ; 	dd 1080  ; height in pixels
 ; 	dd 32    ; depth: pixel size in bits. Theseus only supports 32-bit pixels.

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -4,7 +4,8 @@
 //! 1. Bootstraps the OS after the bootloader is finished, and initializes simple things like logging.
 //! 2. Establishes a simple virtual memory subsystem so that other modules can be loaded.
 //! 3. Loads the core library module, the `captain` module, and then calls [`captain::init()`] as a final step.
-//! 4. That's it! Once `nano_core` gives complete control to the `captain`, it takes no other actions.
+//!
+//! That's it! Once `nano_core` gives complete control to the `captain`, it takes no other actions.
 //!
 //! In general, you shouldn't ever need to change `nano_core`. 
 //! That's because `nano_core` doesn't contain any specific program logic, 
@@ -139,10 +140,11 @@ where
         identity_mapped_pages
     ) = memory_initialization::init_memory_management(boot_info, kernel_stack_start)?;
 
-    // If the bootloader did not map the framebuffer for us, then we must map it ourselves,
-    // which we can do now after after initializing the memory mgmt subsystem.
-    if let Some(ref fb_info) = framebuffer_info && !fb_info.is_mapped() {
+    // Now that we initialized the memory subsystem, we can map an early framebuffer
+    // for basic graphical text output.
+    if let Some(ref fb_info) = framebuffer_info {
         early_printer::init(fb_info)?;
+        early_printer::println!("Hello from early printer! This is currently not fully utilized.");
     }
 
     #[cfg(target_arch = "aarch64")] {


### PR DESCRIPTION
* `early_printer` supports basic ASCII text output to a graphical
  framebuffer during early bootstrap / init. It is still not enabled by
  default, as we need to migrate from using `vga_buffer` to
  using `early_printer` in order to actually have log messages
  printed to the graphical screen rather than the text mode VGA.

* Implement framebuffer info for `multiboot2` (bios) systems,
  such that `boot_info` can always provide framebuffer info
  regardless of what bootloader standard was used.

* Allow the `framebuffer` crate to re-take ownership of the
  early framebuffer's underlying memory mapping such that it
  can be reused by our more fully-featured graphics stack.

* The `early_printer` can also use a framebuffer that was
  pre-mapped for us by the bootloader, but this has not yet
  been tested since our `theseus-os/uefi-bootloader` crate
  doesn't yet offer that functionality. Thus, this part is untested.

* Allow the UEFI boot/init sequence to fully proceed,
  as we no longer make assumptions about the availability
  or default usage of VGA text mode.