### PR TITLE
Use `early_printer` by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "device_manager",
  "dfqueue",
  "e1000",
+ "early_printer",
  "exceptions_full",
  "first_application",
  "interrupts",
@@ -386,7 +387,6 @@ dependencies = [
  "task_fs",
  "tlb_shootdown",
  "tsc",
- "vga_buffer",
  "window_manager",
 ]
 
@@ -965,6 +965,7 @@ dependencies = [
  "log",
  "memory",
  "spin 0.9.4",
+ "vga_buffer",
  "volatile 0.2.7",
 ]
 
@@ -1037,13 +1038,13 @@ dependencies = [
 name = "exceptions_early"
 version = "0.1.0"
 dependencies = [
+ "early_printer",
  "gdt",
  "locked_idt",
  "memory",
  "mod_mgmt",
  "spin 0.9.4",
  "tss",
- "vga_buffer",
  "x86_64",
 ]
 
@@ -1054,6 +1055,7 @@ dependencies = [
  "app_io",
  "cpu",
  "debug_info",
+ "early_printer",
  "fault_log",
  "locked_idt",
  "log",
@@ -1066,7 +1068,6 @@ dependencies = [
  "tlb_shootdown",
  "tss",
  "unwind",
- "vga_buffer",
  "x86_64",
 ]
 
@@ -1124,11 +1125,11 @@ version = "0.1.0"
 dependencies = [
  "app_io",
  "cpu",
+ "early_printer",
  "irq_safety",
  "log",
  "memory",
  "task",
- "vga_buffer",
 ]
 
 [[package]]
@@ -1529,6 +1530,7 @@ dependencies = [
  "apic",
  "cortex-a",
  "cpu",
+ "early_printer",
  "exceptions_early",
  "gdt",
  "gic",
@@ -1542,7 +1544,6 @@ dependencies = [
  "time",
  "tock-registers",
  "tss",
- "vga_buffer",
  "x86_64",
 ]
 
@@ -2263,7 +2264,6 @@ dependencies = [
  "stack",
  "state_store",
  "uefi-bootloader-api",
- "vga_buffer",
 ]
 
 [[package]]
@@ -2523,12 +2523,12 @@ dependencies = [
 name = "panic_entry"
 version = "0.1.0"
 dependencies = [
+ "early_printer",
  "log",
  "memory",
  "mod_mgmt",
  "panic_wrapper",
  "unwind",
- "vga_buffer",
 ]
 
 [[package]]
@@ -4287,9 +4287,6 @@ dependencies = [
 name = "vga_buffer"
 version = "0.1.0"
 dependencies = [
- "kernel_config",
- "logger_x86_64",
- "spin 0.9.4",
  "volatile 0.2.7",
 ]
 

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -10,6 +10,7 @@ log = "0.4.8"
 
 irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
 dfqueue = { path = "../../libs/dfqueue", version = "0.1.0" }
+early_printer = { path = "../early_printer" }
 kernel_config = { path = "../kernel_config" }
 interrupts = { path = "../interrupts" }
 scheduler = { path = "../scheduler" }
@@ -37,7 +38,6 @@ device_manager = { path = "../device_manager" }
 e1000 = { path = "../e1000" }
 console = { path = "../console" }
 app_io = { path = "../app_io" }
-vga_buffer = { path = "../vga_buffer" }
 network_manager = { path = "../network_manager" }
 ota_update_client = { path = "../ota_update_client" }
 
@@ -45,10 +45,6 @@ ota_update_client = { path = "../ota_update_client" }
 ## but it cannot be because of https://github.com/rust-lang/cargo/issues/5499.
 ## Therefore, it has to be unconditionally included.
 simd_personality = { path = "../simd_personality" }
-
-[features]
-# TODO: Remove when UEFI is fully implemented
-uefi = []
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -35,7 +35,7 @@ use {
 mod mirror_log_callbacks {
     /// The callback for use in the logger crate to mirror log functions to the early VGA screen.
     pub(crate) fn mirror_to_early_vga(args: core::fmt::Arguments) {
-        vga_buffer::println_raw!("{}", args);
+        early_printer::println!("{}", args);
     }
 
     /// The callback for use in the logger crate to mirror log functions to the

--- a/kernel/early_printer/Cargo.toml
+++ b/kernel/early_printer/Cargo.toml
@@ -13,6 +13,7 @@ volatile = "0.2.7"
 boot_info = { path = "../boot_info" }
 font = { path = "../font" }
 memory = { path = "../memory" }
+vga_buffer = { path = "../vga_buffer" }
 
 [features]
 bios = []

--- a/kernel/exceptions_early/Cargo.toml
+++ b/kernel/exceptions_early/Cargo.toml
@@ -13,8 +13,8 @@ locked_idt = { path = "../../libs/locked_idt" }
 [dependencies.memory]
 path = "../memory"
 
-[dependencies.vga_buffer]
-path = "../vga_buffer"
+[dependencies.early_printer]
+path = "../early_printer"
 
 [dependencies.mod_mgmt]
 path = "../mod_mgmt"

--- a/kernel/exceptions_early/src/lib.rs
+++ b/kernel/exceptions_early/src/lib.rs
@@ -18,7 +18,7 @@ use x86_64::{
 };
 use locked_idt::LockedIdt;
 use gdt::{Gdt, create_gdt};
-use vga_buffer::println_raw;
+use early_printer::println;
 
 /// An initial Interrupt Descriptor Table (IDT) with only very simple CPU exceptions handlers.
 /// This is no longer used after interrupts are set up properly, it's just a failsafe.
@@ -41,12 +41,12 @@ static EARLY_TSS: Mutex<TaskStateSegment> = Mutex::new(TaskStateSegment::new());
 /// will be created and set up such that the processor will jump to 
 /// that stack upon a double fault.
 pub fn init(double_fault_stack_top_unusable: Option<memory::VirtualAddress>) {
-    println_raw!("exceptions_early(): double_fault_stack_top_unusable: {:X?}", double_fault_stack_top_unusable);
+    println!("exceptions_early(): double_fault_stack_top_unusable: {:X?}", double_fault_stack_top_unusable);
     if let Some(df_stack_top) = double_fault_stack_top_unusable {
         // Create and load an initial TSS and GDT so we can handle early exceptions such as double faults. 
         let mut tss = TaskStateSegment::new();
         tss.interrupt_stack_table[tss::DOUBLE_FAULT_IST_INDEX] = x86_64::VirtAddr::new(df_stack_top.value() as u64);
-        println_raw!("exceptions_early(): Created TSS: {:?}", tss);
+        println!("exceptions_early(): Created TSS: {:?}", tss);
         *EARLY_TSS.lock() = tss;
         
         let (gdt, kernel_cs, kernel_ds, _user_cs_32, _user_ds_32, _user_cs_64, _user_ds_64, tss_segment) = create_gdt(&EARLY_TSS.lock());
@@ -105,43 +105,43 @@ pub fn init(double_fault_stack_top_unusable: Option<memory::VirtualAddress>) {
 
 /// exception 0x00
 extern "x86-interrupt" fn divide_error_handler(stack_frame: InterruptStackFrame) {
-    println_raw!("\nEXCEPTION (early): DIVIDE ERROR\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): DIVIDE ERROR\n{:#X?}", stack_frame);
     loop {}
 }
 
 /// exception 0x01
 extern "x86-interrupt" fn debug_handler(stack_frame: InterruptStackFrame) {
-    println_raw!("\nEXCEPTION (early): DEBUG EXCEPTION\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): DEBUG EXCEPTION\n{:#X?}", stack_frame);
     // don't halt here, this isn't a fatal/permanent failure, just a brief pause.
 }
 
 /// exception 0x02
 extern "x86-interrupt" fn nmi_handler(stack_frame: InterruptStackFrame) {
-    println_raw!("\nEXCEPTION (early): NON-MASKABLE INTERRUPT\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): NON-MASKABLE INTERRUPT\n{:#X?}", stack_frame);
     loop { }
 }
 
 /// exception 0x03
 extern "x86-interrupt" fn breakpoint_handler(stack_frame: InterruptStackFrame) {
-    println_raw!("\nEXCEPTION (early): BREAKPOINT\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): BREAKPOINT\n{:#X?}", stack_frame);
     // don't halt here, this isn't a fatal/permanent failure, just a brief pause.
 }
 
 /// exception 0x04
 extern "x86-interrupt" fn overflow_handler(stack_frame: InterruptStackFrame) {
-    println_raw!("\nEXCEPTION (early): OVERFLOW\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): OVERFLOW\n{:#X?}", stack_frame);
     loop { }
 }
 
 /// exception 0x05
 extern "x86-interrupt" fn bound_range_exceeded_handler(stack_frame: InterruptStackFrame) {
-    println_raw!("\nEXCEPTION (early): BOUND RANGE EXCEEDED\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): BOUND RANGE EXCEEDED\n{:#X?}", stack_frame);
     loop { }
 }
 
 /// exception 0x06
 extern "x86-interrupt" fn invalid_opcode_handler(stack_frame: InterruptStackFrame) {
-    println_raw!("\nEXCEPTION (early): INVALID OPCODE\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): INVALID OPCODE\n{:#X?}", stack_frame);
     loop {}
 }
 
@@ -150,7 +150,7 @@ extern "x86-interrupt" fn invalid_opcode_handler(stack_frame: InterruptStackFram
 /// For more information about "spurious interrupts", 
 /// see [here](http://wiki.osdev.org/I_Cant_Get_Interrupts_Working#I_keep_getting_an_IRQ7_for_no_apparent_reason).
 extern "x86-interrupt" fn device_not_available_handler(stack_frame: InterruptStackFrame) {
-    println_raw!("\nEXCEPTION (early): DEVICE NOT AVAILABLE\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): DEVICE NOT AVAILABLE\n{:#X?}", stack_frame);
     loop {}
 }
 
@@ -158,53 +158,53 @@ extern "x86-interrupt" fn device_not_available_handler(stack_frame: InterruptSta
 /// 
 /// Note: this is `pub` so we can access it within `interrupts::init()`.
 pub extern "x86-interrupt" fn double_fault_handler(stack_frame: InterruptStackFrame, error_code: u64) -> ! {
-    println_raw!("\nEXCEPTION (early): DOUBLE FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    println_raw!("\nNote: this may be caused by stack overflow. Is the size of the initial_bsp_stack is too small?");
+    println!("\nEXCEPTION (early): DOUBLE FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
+    println!("\nNote: this may be caused by stack overflow. Is the size of the initial_bsp_stack is too small?");
     loop {}
 }
 
 /// exception 0x0A
 extern "x86-interrupt" fn invalid_tss_handler(stack_frame: InterruptStackFrame, error_code: u64) {
-    println_raw!("\nEXCEPTION (early): INVALID TSS\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
+    println!("\nEXCEPTION (early): INVALID TSS\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
     loop {}
 }
 
 /// exception 0x0B
 extern "x86-interrupt" fn segment_not_present_handler(stack_frame: InterruptStackFrame, error_code: u64) {
-    println_raw!("\nEXCEPTION (early): SEGMENT NOT PRESENT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
+    println!("\nEXCEPTION (early): SEGMENT NOT PRESENT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
     loop {}
 }
 
 /// exception 0x0C
 extern "x86-interrupt" fn stack_segment_fault_handler(stack_frame: InterruptStackFrame, error_code: u64) {
-    println_raw!("\nEXCEPTION (early): STACK SEGMENT FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
+    println!("\nEXCEPTION (early): STACK SEGMENT FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
     loop {}
 }
 
 /// exception 0x0D
 extern "x86-interrupt" fn general_protection_fault_handler(stack_frame: InterruptStackFrame, error_code: u64) {
-    println_raw!("\nEXCEPTION (early): GENERAL PROTECTION FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
+    println!("\nEXCEPTION (early): GENERAL PROTECTION FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
     loop {}
 }
 
 /// exception 0x0E
 extern "x86-interrupt" fn early_page_fault_handler(stack_frame: InterruptStackFrame, error_code: PageFaultErrorCode) {
     let accessed_address = x86_64::registers::control::Cr2::read_raw();
-    println_raw!("\nEXCEPTION (early): PAGE FAULT (early handler) while accessing {:#x}\n\
+    println!("\nEXCEPTION (early): PAGE FAULT (early handler) while accessing {:#x}\n\
         error code: {:?}\n{:#X?}",
         accessed_address,
         error_code,
         stack_frame
     );
 
-    println_raw!("Exception IP {:#X} is at {:?}", 
+    println!("Exception IP {:#X} is at {:?}", 
         stack_frame.instruction_pointer, 
         mod_mgmt::get_initial_kernel_namespace().and_then(|ns| ns.get_section_containing_address(
             memory::VirtualAddress::new_canonical(stack_frame.instruction_pointer.as_u64() as usize),
             false // only look at .text sections, not all other types
         )),
     );
-    println_raw!("Faulted access address {:#X} is at {:?}",
+    println!("Faulted access address {:#X} is at {:?}",
         accessed_address,
         mod_mgmt::get_initial_kernel_namespace().and_then(|ns| ns.get_section_containing_address(
             memory::VirtualAddress::new_canonical(accessed_address as usize),
@@ -216,42 +216,42 @@ extern "x86-interrupt" fn early_page_fault_handler(stack_frame: InterruptStackFr
 
 /// exception 0x10
 extern "x86-interrupt" fn x87_floating_point_handler(stack_frame: InterruptStackFrame) {
-    println_raw!("\nEXCEPTION (early): x87 FLOATING POINT\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): x87 FLOATING POINT\n{:#X?}", stack_frame);
     loop {}
 }
 
 /// exception 0x11
 extern "x86-interrupt" fn alignment_check_handler(stack_frame: InterruptStackFrame, error_code: u64) {
-    println_raw!("\nEXCEPTION (early): ALIGNMENT CHECK\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
+    println!("\nEXCEPTION (early): ALIGNMENT CHECK\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
     loop {}
 }
 
 /// exception 0x12
 extern "x86-interrupt" fn machine_check_handler(stack_frame: InterruptStackFrame) -> ! {
-    println_raw!("\nEXCEPTION (early): MACHINE CHECK\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): MACHINE CHECK\n{:#X?}", stack_frame);
     loop {}
 }
 
 /// exception 0x13
 extern "x86-interrupt" fn simd_floating_point_handler(stack_frame: InterruptStackFrame) {
-    println_raw!("\nEXCEPTION (early): SIMD FLOATING POINT\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): SIMD FLOATING POINT\n{:#X?}", stack_frame);
     loop {}
 }
 
 /// exception 0x14
 extern "x86-interrupt" fn virtualization_handler(stack_frame: InterruptStackFrame) {
-    println_raw!("\nEXCEPTION (early): VIRTUALIZATION\n{:#X?}", stack_frame);
+    println!("\nEXCEPTION (early): VIRTUALIZATION\n{:#X?}", stack_frame);
     loop {}
 }
 
 /// exception 0x1D
 extern "x86-interrupt" fn vmm_communication_exception_handler(stack_frame: InterruptStackFrame, error_code: u64) {
-    println_raw!("\nEXCEPTION (early): VMM COMMUNICATION EXCEPTION\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
+    println!("\nEXCEPTION (early): VMM COMMUNICATION EXCEPTION\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
     loop {}
 }
 
 /// exception 0x1E
 extern "x86-interrupt" fn security_exception_handler(stack_frame: InterruptStackFrame, error_code: u64) {
-    println_raw!("\nEXCEPTION (early): SECURITY EXCEPTION\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
+    println!("\nEXCEPTION (early): SECURITY EXCEPTION\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
     loop {}
 }

--- a/kernel/exceptions_full/Cargo.toml
+++ b/kernel/exceptions_full/Cargo.toml
@@ -10,8 +10,8 @@ x86_64 = "0.14.8"
 log = "0.4.8"
 locked_idt = { path = "../../libs/locked_idt" }
 
-[dependencies.vga_buffer]
-path = "../vga_buffer"
+[dependencies.early_printer]
+path = "../early_printer"
 
 [dependencies.app_io]
 path = "../app_io"

--- a/kernel/exceptions_full/src/lib.rs
+++ b/kernel/exceptions_full/src/lib.rs
@@ -64,15 +64,15 @@ pub fn init(idt_ref: &'static LockedIdt) {
 }
 
 
-/// calls print!() and then print_raw!()
+/// Prints to both the `early_printer` and the current terminal via `app_io`.
 macro_rules! println_both {
     ($fmt:expr) => {
-        vga_buffer::print_raw!(concat!($fmt, "\n"));
-        app_io::print!(concat!($fmt, "\n"));
+        early_printer::println!($fmt);
+        app_io::println!($fmt);
     };
     ($fmt:expr, $($arg:tt)*) => {
-        vga_buffer::print_raw!(concat!($fmt, "\n"), $($arg)*);
-        app_io::print!(concat!($fmt, "\n"), $($arg)*);
+        early_printer::println!($fmt, $($arg)*);
+        app_io::println!($fmt, $($arg)*);
     };
 }
 

--- a/kernel/fault_log/Cargo.toml
+++ b/kernel/fault_log/Cargo.toml
@@ -3,7 +3,7 @@ name = "fault_log"
 version = "0.1.0"
 description = "Logs all exceptions occuring in Theseus"
 authors = ["Namitha Liyanage <namithaliyanage@gmail.com>"]
-
+edition = "2021"
 
 [dependencies.irq_safety]
 git = "https://github.com/theseus-os/irq_safety"
@@ -11,8 +11,8 @@ git = "https://github.com/theseus-os/irq_safety"
 [dependencies.memory]
 path = "../memory"
 
-[dependencies.vga_buffer]
-path = "../vga_buffer"
+[dependencies.early_printer]
+path = "../early_printer"
 
 [dependencies.app_io]
 path = "../app_io"

--- a/kernel/fault_log/src/lib.rs
+++ b/kernel/fault_log/src/lib.rs
@@ -6,19 +6,13 @@
 #![no_std]
 #![feature(drain_filter)]
 
-#[macro_use] extern crate vga_buffer; // for println_raw!()
-#[macro_use] extern crate app_io; // for regular println!()
-#[macro_use] extern crate log;
 extern crate alloc;
-extern crate memory;
-extern crate task;
-extern crate cpu;
-extern crate irq_safety;
 
 use alloc::{
     string::{String,ToString},
     vec::Vec,
 };
+use log::debug;
 use cpu::CpuId;
 use memory::VirtualAddress;
 use irq_safety::MutexIrqSafe;
@@ -218,15 +212,15 @@ pub fn remove_unhandled_exceptions() -> Vec<FaultEntry> {
     FAULT_LIST.lock().drain_filter(|fe| fe.action_taken == RecoveryAction::None).collect::<Vec<_>>()
 }
 
-/// calls println!() and then println_raw!()
+/// Prints to both the `early_printer` and the current terminal via `app_io`.
 macro_rules! println_both {
     ($fmt:expr) => {
-        print_raw!(concat!($fmt, "\n"));
-        print!(concat!($fmt, "\n"));
+        early_printer::println!($fmt);
+        app_io::println!($fmt);
     };
     ($fmt:expr, $($arg:tt)*) => {
-        print_raw!(concat!($fmt, "\n"), $($arg)*);
-        print!(concat!($fmt, "\n"), $($arg)*);
+        early_printer::println!($fmt, $($arg)*);
+        app_io::println!($fmt, $($arg)*);
     };
 }
 

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -22,7 +22,7 @@ time = { path = "../time" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 exceptions_early = { path = "../exceptions_early" }
-vga_buffer = { path = "../vga_buffer" }
+early_printer = { path = "../early_printer" }
 apic = { path = "../apic" }
 gdt = { path = "../gdt" }
 pic = { path = "../pic" }

--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -30,7 +30,6 @@ early_printer = { path = "../early_printer" }
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 exceptions_early = { path = "../exceptions_early" }
 serial_port_basic = { path = "../serial_port_basic" }
-vga_buffer = { path = "../vga_buffer" }
 logger_x86_64 = { path = "../logger_x86_64" }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
@@ -46,9 +45,9 @@ cfg-if = "1.0.0"
 [features]
 default = [ "bios" ]
 ## Build for a system that boots via legacy BIOS (multiboot2).
-bios = ["boot_info/multiboot2", "vga_buffer/bios", "dep:multiboot2"]
+bios = ["boot_info/multiboot2", "early_printer/bios", "dep:multiboot2"]
 ## Build for a system that boots via UEFI.
-uefi = ["boot_info/uefi", "captain/uefi", "dep:uefi-bootloader-api"]
+uefi = ["boot_info/uefi", "dep:uefi-bootloader-api"]
 
 [lib]
 # staticlib is required to build a self-contained, fully-linked .a file 

--- a/kernel/nano_core/src/bios.rs
+++ b/kernel/nano_core/src/bios.rs
@@ -1,20 +1,25 @@
-use crate::{early_setup, nano_core, shutdown, try_exit};
+//! The main entry point into Rust code from a legacy BIOS (multiboot2) bootloader.
+
+use crate::{nano_core, shutdown, try_exit};
 use boot_info::BootInformation;
 use memory::VirtualAddress;
 
 #[no_mangle]
-pub extern "C" fn rust_entry(boot_info_vaddr: usize, double_fault_stack: usize) {
-    try_exit!(early_setup(double_fault_stack));
+pub extern "C" fn rust_entry(boot_info_vaddr: usize, double_fault_stack_top: usize) {
     if VirtualAddress::new(boot_info_vaddr).is_none() {
-        shutdown(format_args!("multiboot2 info address invalid"));
+        shutdown(format_args!("BUG: multiboot2 info virtual address is invalid"));
     }
     let boot_info = match unsafe { multiboot2::load(boot_info_vaddr) } {
         Ok(i) => i,
-        Err(e) => shutdown(format_args!("failed to load multiboot 2 info: {e:?}")),
+        Err(e) => shutdown(format_args!("BUG: failed to load multiboot 2 info: {e:?}")),
     };
     let kernel_stack_start = try_exit!(
-        VirtualAddress::new(double_fault_stack - try_exit!(boot_info.stack_size()))
-            .ok_or("invalid kernel stack start")
+        VirtualAddress::new(double_fault_stack_top - try_exit!(boot_info.stack_size()))
+            .ok_or("BUG: kernel_stack_start virtual address is invalid")
     );
-    try_exit!(nano_core(boot_info, kernel_stack_start));
+    let double_fault_stack_top = try_exit!(
+        VirtualAddress::new(double_fault_stack_top)
+            .ok_or("BUG: double_fault_stack_top virtual address is invalid")
+    );
+    try_exit!(nano_core(boot_info, double_fault_stack_top, kernel_stack_start));
 }

--- a/kernel/panic_entry/Cargo.toml
+++ b/kernel/panic_entry/Cargo.toml
@@ -17,7 +17,7 @@ path = "../memory"
 path = "../mod_mgmt"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-vga_buffer = { path = "../vga_buffer" }
+early_printer = { path = "../early_printer" }
 panic_wrapper = { path = "../panic_wrapper" }
 unwind = { path = "../unwind" }
 

--- a/kernel/panic_entry/src/lib.rs
+++ b/kernel/panic_entry/src/lib.rs
@@ -20,7 +20,7 @@ extern crate mod_mgmt;
 #[cfg(not(loadable))] extern crate unwind;
 
 #[cfg(target_arch = "x86_64")]
-#[macro_use] extern crate vga_buffer;
+#[macro_use] extern crate early_printer;
 
 #[cfg(target_arch = "x86_64")]
 #[cfg(not(loadable))] extern crate panic_wrapper;
@@ -74,7 +74,7 @@ fn panic_entry_point(info: &PanicInfo) -> ! {
         error!("Halting due to early panic: {}", info);
         // basic early panic printing with no dependencies
         #[cfg(target_arch = "x86_64")]
-        println_raw!("\nHalting due to early panic: {}", info);
+        println!("\nHalting due to early panic: {}", info);
     }
 
     // If we failed to handle the panic, there's not really much we can do about it,

--- a/kernel/vga_buffer/Cargo.toml
+++ b/kernel/vga_buffer/Cargo.toml
@@ -1,23 +1,9 @@
 [package]
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "vga_buffer"
-description = "Support for the simple 80x25 text-only VGA display mode"
+description = "Support for printing to an 80x25 text-mode VGA display"
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
-spin = "0.9.4"
-
-[dependencies.volatile]
-version = "0.2.7"
-
-[dependencies.logger_x86_64]
-path = "../logger_x86_64"
-
-[dependencies.kernel_config]
-path = "../kernel_config"
-
-[features]
-bios = []
-
-[lib]
-crate-type = ["rlib"]
+volatile = "0.2.7"


### PR DESCRIPTION
* `early_printer` now acts as the public interface for any early printing, including being a wrapper around the old text-mode VGA buffer crate.
  * Thus, all crates now use it as the main printing interface.
  * Removed `vga_buffer:print*raw!()` macros. 

* We don't yet request a graphical framebuffer on bios (multiboot2) by default, but it is tested and works fully. 

* Simplify `nano_core` init process by removing `early_init()`.