### PR TITLE
Replace busy-waiting with halting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "locked_idt",
  "memory",
  "mod_mgmt",
+ "pause 0.1.0",
  "spin 0.9.4",
  "tss",
  "x86_64",
@@ -1060,6 +1061,7 @@ dependencies = [
  "locked_idt",
  "log",
  "memory",
+ "pause 0.1.0",
  "pmu_x86",
  "runqueue",
  "signal_handler",
@@ -2190,7 +2192,7 @@ dependencies = [
  "madt",
  "memory",
  "mod_mgmt",
- "pause",
+ "pause 0.1.0",
  "pit_clock_basic",
  "spin 0.9.4",
  "stack",
@@ -2433,6 +2435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "object"
 version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,6 +2536,7 @@ dependencies = [
  "memory",
  "mod_mgmt",
  "panic_wrapper",
+ "pause 0.1.0",
  "unwind",
 ]
 
@@ -2573,6 +2582,15 @@ dependencies = [
 [[package]]
 name = "pause"
 version = "0.1.0"
+
+[[package]]
+name = "pause"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778411a10652cb1cef2b9bf3157992277cb82268f6b4c62f0e94190aafe161e5"
+dependencies = [
+ "termion",
+]
 
 [[package]]
 name = "pci"
@@ -2918,6 +2936,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,6 +3073,7 @@ dependencies = [
  "hpet",
  "libtest",
  "log",
+ "pause 0.1.0",
  "runqueue",
  "spawn",
  "task",
@@ -3368,6 +3405,7 @@ dependencies = [
  "log",
  "memory",
  "mod_mgmt",
+ "pause 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pit_clock",
  "spawn",
  "task",
@@ -3486,7 +3524,7 @@ dependencies = [
  "mod_mgmt",
  "no_drop",
  "path",
- "pause",
+ "pause 0.1.0",
  "preemption",
  "runqueue",
  "scheduler",
@@ -3717,6 +3755,18 @@ dependencies = [
  "preemption",
  "spin 0.9.4",
  "stack",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
 ]
 
 [[package]]
@@ -4101,7 +4151,7 @@ dependencies = [
  "irq_safety",
  "log",
  "memory",
- "pause",
+ "pause 0.1.0",
  "x86_64",
 ]
 

--- a/applications/rq_eval/Cargo.toml
+++ b/applications/rq_eval/Cargo.toml
@@ -31,3 +31,6 @@ path = "../../kernel/app_io"
 
 [dependencies.libtest]
 path = "../../kernel/libtest"
+
+[dependencies.pause]
+path = "../../kernel/pause"

--- a/applications/rq_eval/src/lib.rs
+++ b/applications/rq_eval/src/lib.rs
@@ -33,7 +33,6 @@ use hpet::get_hpet;
 use task::{Task, TaskRef};
 use libtest::{hpet_timing_overhead, hpet_2_us};
 
-
 const CONFIG: &'static str = "WITHOUT state spill";
 
 const _FEMTOSECONDS_PER_SECOND: u64 = 1000*1000*1000*1000*1000; // 10^15
@@ -151,7 +150,7 @@ fn run_single(iterations: usize) -> Result<(), &'static str> {
     task.name = String::from("rq_eval_single_task_unrunnable");
     let taskref = TaskRef::create(
         task,
-        |_, _| loop { }, // dummy failure function
+        |_, _| loop { pause::spin_loop_hint() }, // dummy failure function
     );
     
     let hpet = get_hpet().ok_or("couldn't get HPET timer")?;

--- a/kernel/exceptions_early/Cargo.toml
+++ b/kernel/exceptions_early/Cargo.toml
@@ -25,6 +25,9 @@ path = "../tss"
 [dependencies.gdt]
 path = "../gdt"
 
+[dependencies.pause]
+path = "../pause"
+
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/exceptions_early/src/lib.rs
+++ b/kernel/exceptions_early/src/lib.rs
@@ -5,6 +5,8 @@
 #![no_std]
 #![feature(abi_x86_interrupt)]
 
+use pause::spin_loop_hint;
+
 use spin::Mutex;
 use x86_64::{
     structures::{
@@ -106,7 +108,7 @@ pub fn init(double_fault_stack_top_unusable: Option<memory::VirtualAddress>) {
 /// exception 0x00
 extern "x86-interrupt" fn divide_error_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): DIVIDE ERROR\n{:#X?}", stack_frame);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x01
@@ -118,7 +120,7 @@ extern "x86-interrupt" fn debug_handler(stack_frame: InterruptStackFrame) {
 /// exception 0x02
 extern "x86-interrupt" fn nmi_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): NON-MASKABLE INTERRUPT\n{:#X?}", stack_frame);
-    loop { }
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x03
@@ -130,19 +132,19 @@ extern "x86-interrupt" fn breakpoint_handler(stack_frame: InterruptStackFrame) {
 /// exception 0x04
 extern "x86-interrupt" fn overflow_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): OVERFLOW\n{:#X?}", stack_frame);
-    loop { }
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x05
 extern "x86-interrupt" fn bound_range_exceeded_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): BOUND RANGE EXCEEDED\n{:#X?}", stack_frame);
-    loop { }
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x06
 extern "x86-interrupt" fn invalid_opcode_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): INVALID OPCODE\n{:#X?}", stack_frame);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x07
@@ -151,7 +153,7 @@ extern "x86-interrupt" fn invalid_opcode_handler(stack_frame: InterruptStackFram
 /// see [here](http://wiki.osdev.org/I_Cant_Get_Interrupts_Working#I_keep_getting_an_IRQ7_for_no_apparent_reason).
 extern "x86-interrupt" fn device_not_available_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): DEVICE NOT AVAILABLE\n{:#X?}", stack_frame);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x08
@@ -160,31 +162,31 @@ extern "x86-interrupt" fn device_not_available_handler(stack_frame: InterruptSta
 pub extern "x86-interrupt" fn double_fault_handler(stack_frame: InterruptStackFrame, error_code: u64) -> ! {
     println!("\nEXCEPTION (early): DOUBLE FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
     println!("\nNote: this may be caused by stack overflow. Is the size of the initial_bsp_stack is too small?");
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x0A
 extern "x86-interrupt" fn invalid_tss_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): INVALID TSS\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x0B
 extern "x86-interrupt" fn segment_not_present_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): SEGMENT NOT PRESENT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x0C
 extern "x86-interrupt" fn stack_segment_fault_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): STACK SEGMENT FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x0D
 extern "x86-interrupt" fn general_protection_fault_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): GENERAL PROTECTION FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x0E
@@ -211,47 +213,47 @@ extern "x86-interrupt" fn early_page_fault_handler(stack_frame: InterruptStackFr
             true, // look at all sections (.data/.bss/.rodata), not just .text
         )),
     );
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x10
 extern "x86-interrupt" fn x87_floating_point_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): x87 FLOATING POINT\n{:#X?}", stack_frame);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x11
 extern "x86-interrupt" fn alignment_check_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): ALIGNMENT CHECK\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x12
 extern "x86-interrupt" fn machine_check_handler(stack_frame: InterruptStackFrame) -> ! {
     println!("\nEXCEPTION (early): MACHINE CHECK\n{:#X?}", stack_frame);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x13
 extern "x86-interrupt" fn simd_floating_point_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): SIMD FLOATING POINT\n{:#X?}", stack_frame);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x14
 extern "x86-interrupt" fn virtualization_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): VIRTUALIZATION\n{:#X?}", stack_frame);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x1D
 extern "x86-interrupt" fn vmm_communication_exception_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): VMM COMMUNICATION EXCEPTION\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x1E
 extern "x86-interrupt" fn security_exception_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): SECURITY EXCEPTION\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop {}
+    loop { spin_loop_hint() }
 }

--- a/kernel/exceptions_full/Cargo.toml
+++ b/kernel/exceptions_full/Cargo.toml
@@ -52,5 +52,8 @@ path = "../debug_info"
 [dependencies.signal_handler]
 path = "../signal_handler"
 
+[dependencies.pause]
+path = "../pause"
+
 [lib]
 crate-type = ["rlib"]

--- a/kernel/exceptions_full/src/lib.rs
+++ b/kernel/exceptions_full/src/lib.rs
@@ -5,6 +5,8 @@
 #![no_std]
 #![feature(abi_x86_interrupt)]
 
+use pause::spin_loop_hint;
+
 use log::{warn, debug, trace};
 use memory::{VirtualAddress, Page};
 use signal_handler::{Signal, SignalContext, ErrorCode};
@@ -233,7 +235,7 @@ fn kill_and_halt(
     // But in general, this task should have already been marked as killed and thus no longer schedulable,
     // so it should not reach this point. 
     // Only exceptions during the early OS initialization process will get here, meaning that the OS will basically stop.
-    loop { }
+    loop { spin_loop_hint() }
 }
 
 
@@ -361,7 +363,7 @@ extern "x86-interrupt" fn double_fault_handler(stack_frame: InterruptStackFrame,
     }
     
     kill_and_halt(0x8, &stack_frame, Some(error_code.into()), false);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x0A
@@ -424,7 +426,7 @@ extern "x86-interrupt" fn alignment_check_handler(stack_frame: InterruptStackFra
 extern "x86-interrupt" fn machine_check_handler(stack_frame: InterruptStackFrame) -> ! {
     println_both!("\nEXCEPTION: MACHINE CHECK\n{:#X?}", stack_frame);
     kill_and_halt(0x12, &stack_frame, None, true);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 /// exception 0x13

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -14,6 +14,7 @@ use irq_safety::{RwLockIrqSafe, MutexIrqSafe};
 use memory::get_kernel_mmi_ref;
 use log::{info, error};
 use spin::Once;
+use pause::spin_loop_hint;
 
 use time::{Monotonic, ClockSource, Instant, Period, register_clock_source};
 
@@ -79,13 +80,13 @@ type HandlerFunc = extern "C" fn(&ExceptionContext) -> EoiBehaviour;
 // called for all exceptions other than interrupts
 fn default_exception_handler(exc: &ExceptionContext, origin: &'static str) {
     log::error!("Unhandled Exception ({})\r\n{:?}\r\n[looping forever now]", origin, exc);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 // called for all unhandled interrupt requests
 extern "C" fn default_irq_handler(exc: &ExceptionContext) -> EoiBehaviour {
     log::error!("Unhandled IRQ:\r\n{:?}\r\n[looping forever now]", exc);
-    loop {}
+    loop { spin_loop_hint() }
 }
 
 fn read_timer_period_femtoseconds() -> u64 {

--- a/kernel/panic_entry/Cargo.toml
+++ b/kernel/panic_entry/Cargo.toml
@@ -16,6 +16,9 @@ path = "../memory"
 [dependencies.mod_mgmt]
 path = "../mod_mgmt"
 
+[dependencies.pause]
+path = "../pause"
+
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 early_printer = { path = "../early_printer" }
 panic_wrapper = { path = "../panic_wrapper" }

--- a/kernel/simd_personality/Cargo.toml
+++ b/kernel/simd_personality/Cargo.toml
@@ -31,6 +31,9 @@ path = "../mod_mgmt"
 [dependencies.fs_node]
 path = "../fs_node"
 
+[dependencies.pause]
+pause = "../pause"
+
 # [target.'cfg(target_feature = "sse2")'.dependencies.compiler_builtins]
 # git = "https://github.com/rust-lang-nursery/compiler-builtins"
 # features = [ "no-lang-items" ]

--- a/kernel/simd_personality/src/lib.rs
+++ b/kernel/simd_personality/src/lib.rs
@@ -51,6 +51,7 @@
 #![no_std]
 
 // NOTE: the `cfg_if` macro makes the entire file dependent upon the `simd_personality` config.
+
 #[macro_use] extern crate cfg_if;
 cfg_if! { if #[cfg(simd_personality)] {
 
@@ -81,6 +82,7 @@ use alloc::{
 };
 use mod_mgmt::{CrateNamespace, CrateType, NamespaceDir, get_initial_kernel_namespace, get_namespaces_directory};
 use task::SimdExt;
+use pause::spin_loop_hint;
 
 
 /// Initializes a new SIMD personality based on the provided `simd_ext` level of given SIMD extensions, e.g., SSE, AVX.
@@ -198,7 +200,7 @@ fn internal_setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str
 	// TODO FIXME: check for this somehow in the thread spawn code, perhaps by giving the new thread ownership of the MappedPages,
 	//             just like we do for application Tasks
 
-	loop { }
+	loop { spin_loop_hint() }
 	
 	// _task1.join()?;
 	// _task2.join()?;

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -29,6 +29,7 @@ use alloc::{
 use log::{error, info, debug};
 use cpu::CpuId;
 use debugit::debugit;
+use pause::spin_loop_hint;
 use spin::Mutex;
 use irq_safety::enable_interrupts;
 use memory::{get_kernel_mmi_ref, MmiRef};
@@ -904,7 +905,7 @@ fn task_cleanup_final<F, A, R>(preemption_guard: PreemptionGuard, current_task: 
 
     scheduler::schedule();
     error!("BUG: task_cleanup_final(): task was rescheduled after being dead!");
-    loop { }
+    loop { spin_loop_hint() }
 }
 
 /// The final piece of the task cleanup logic for restartable tasks.
@@ -986,7 +987,7 @@ where
 
     scheduler::schedule();
     error!("BUG: task_cleanup_final(): task was rescheduled after being dead!");
-    loop { }
+    loop { spin_loop_hint() }
 }
 
 /// Helper function to remove a task from its runqueue and drop it.


### PR DESCRIPTION
If Theseus enters any of the tight loops (`loop {}`), then it's going to waste 100% of CPU without doing any meaningful work. This PR should replace this busy-waiting with halting so that the CPU doesn't do anything until it receives the next interrupt. 