### PR TITLE
Enable graphical framebuffer usage for early text output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,7 @@ dependencies = [
  "font",
  "log",
  "memory",
+ "page_attribute_table",
  "spin 0.9.4",
  "vga_buffer",
  "volatile 0.2.7",
@@ -2500,7 +2501,6 @@ name = "page_attribute_table"
 version = "0.1.0"
 dependencies = [
  "log",
- "memory",
  "modular-bitfield",
  "msr",
  "raw-cpuid",

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -660,8 +660,8 @@ impl LocalApic {
     /// After this lapic has been enabled, initialize its LVT timer.
     fn init_lvt_timer(&mut self) {
         let apic_period = if cfg!(apic_timer_fixed) {
-            info!("apic_timer_fixed config: overriding LocalAPIC LVT timer period to {}", 0x10000);
-            0x10000 // for bochs, which doesn't do apic periods right
+            info!("apic_timer_fixed config: overriding LocalAPIC LVT timer period to {}", 1000000);
+            1000000 // for bochs, which doesn't do apic periods right
         } else {
             self.calibrate_lapic_timer(CONFIG_TIMESLICE_PERIOD_MICROSECONDS)
         };

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -150,7 +150,8 @@ pub fn init(
     let ap_count = 0;
 
     let cpu_count = ap_count + 1;
-    info!("Finished handling and booting up all {} AP cores; {} total CPUs are running.", ap_count, cpu_count);
+    info!("Finished booting all {} AP cores; {} total CPUs are running.", ap_count, cpu_count);
+    info!("Proceeding with system initialization, please wait...");
 
     // arch-gate: no framebuffer support on aarch64 at the moment
     #[cfg(all(mirror_log_to_vga, target_arch = "x86_64"))] {

--- a/kernel/early_printer/Cargo.toml
+++ b/kernel/early_printer/Cargo.toml
@@ -13,6 +13,7 @@ volatile = "0.2.7"
 boot_info = { path = "../boot_info" }
 font = { path = "../font" }
 memory = { path = "../memory" }
+page_attribute_table = { path = "../page_attribute_table" }
 vga_buffer = { path = "../vga_buffer" }
 
 [features]

--- a/kernel/early_printer/src/lib.rs
+++ b/kernel/early_printer/src/lib.rs
@@ -309,11 +309,11 @@ impl EarlyFramebufferPrinter {
 
         if let Some(staging_fb) = self.staging_fb.as_deref_mut() {
             // Scroll up the staging buffer.
-            staging_fb.copy_within(src_range.clone(), 0);
+            staging_fb.copy_within(src_range, 0);
         }
         else {
             // If we don't have a staging fb, we must scroll within the main fb itself.
-            self.fb.copy_within(src_range.clone(), 0);
+            self.fb.copy_within(src_range, 0);
         }
         let start_of_last_line = self.height - CHARACTER_HEIGHT;
         self.curr_pixel = PixelCoord { x: 0, y: start_of_last_line };

--- a/kernel/kernel_config/src/display.rs
+++ b/kernel/kernel_config/src/display.rs
@@ -1,4 +1,8 @@
 /// The maximum resolution `(width, height)` of the graphical framebuffer, in pixels.
 /// This is a **requested limit** and does not control what the actual
 /// resolution of the graphical framebuffer will be.
-pub const FRAMEBUFFER_MAX_RESOLUTION: (u16, u16) = (1024, 768);
+///
+/// We recommend matching this to the value set in
+/// `kernel/nano_core/src/asm/bios/multiboot_header.asm`,
+/// but it's not strictly necessary to do so.
+pub const FRAMEBUFFER_MAX_RESOLUTION: (u16, u16) = (1280, 1024);

--- a/kernel/nano_core/src/asm/ap_boot.asm
+++ b/kernel/nano_core/src/asm/ap_boot.asm
@@ -27,10 +27,10 @@ ap_start_protected_mode:
 %ifdef BIOS
     ; each character is reversed in the dword cuz of little endianness
 	; prints PGTBL
-	mov dword [0xb8018], 0x4f2E4f2E ; ".."
-    mov dword [0xb801c], 0x4f504f2E ; ".P"
-	mov dword [0xb8020], 0x4f544f47 ; "GT"
-	mov dword [0xb8024], 0x4f4C4f42 ; "BL"
+	; mov dword [0xb8018], 0x4f2E4f2E ; ".."
+    ; mov dword [0xb801c], 0x4f504f2E ; ".P"
+	; mov dword [0xb8020], 0x4f544f47 ; "GT"
+	; mov dword [0xb8024], 0x4f4C4f42 ; "BL"
 %endif ; BIOS
 
 	; Load the 64-bit GDT
@@ -47,9 +47,9 @@ ap_start_protected_mode:
 
 %ifdef BIOS
 	; prints GDT
-	mov dword [0xb8028], 0x4f2E4f2E ; ".."
-    mov dword [0xb802c], 0x4f474f2E ; ".G"
-	mov dword [0xb8030], 0x4f544f44 ; "DT"
+	; mov dword [0xb8028], 0x4f2E4f2E ; ".."
+    ; mov dword [0xb802c], 0x4f474f2E ; ".G"
+	; mov dword [0xb8030], 0x4f544f44 ; "DT"
 	mov eax, 0x4f004f00
 	or eax, GDT_AP.code + 0x30 ; convert GDT_AP.code value to ASCII char
 	mov dword [0xb8034], eax ; prints GDT_AP.code value
@@ -125,9 +125,9 @@ long_mode_start_ap:
 	
 %ifdef BIOS
 	; each character is reversed in the dword cuz of little endianness
-	mov dword [0xb8038], 0x4f2E4f2E ; ".."
-    mov dword [0xb803c], 0x4f4f4f4c ; "LO"
-	mov dword [0xb8040], 0x4f474f4e ; "NG"
+	; mov dword [0xb8038], 0x4f2E4f2E ; ".."
+    ; mov dword [0xb803c], 0x4f4f4f4c ; "LO"
+	; mov dword [0xb8040], 0x4f474f4e ; "NG"
 %endif ; BIOS
 
 	; Long jump to the higher half. Because `jmp` does not take
@@ -173,10 +173,10 @@ start_high_ap:
 	
 %ifdef BIOS
 	; each character is reversed in the dword cuz of little endianness
-	mov dword [0xb8048], 0x4f2E4f2E ; ".."
-    mov dword [0xb804c], 0x4f494f48 ; "HI"
-	mov dword [0xb8050], 0x4f484f47 ; "GH"
-	mov dword [0xb8054], 0x4f524f45 ; "ER"
+	; mov dword [0xb8048], 0x4f2E4f2E ; ".."
+    ; mov dword [0xb804c], 0x4f494f48 ; "HI"
+	; mov dword [0xb8050], 0x4f484f47 ; "GH"
+	; mov dword [0xb8054], 0x4f524f45 ; "ER"
 %endif ; BIOS
 
 	; move to the new stack that was alloc'd for this AP

--- a/kernel/nano_core/src/asm/bios/multiboot_header.asm
+++ b/kernel/nano_core/src/asm/bios/multiboot_header.asm
@@ -21,18 +21,19 @@ multiboot_header_start:
 ; NOTE: this works properly now. Uncomment the below sections when we are ready to enable
 ;       early boot-time usage of the graphical framebuffer by default.
 ;
-; %ifndef VGA_TEXT_MODE
-; align 8
-; 	dw 5     ; type (5 means framebuffer tag)
-; 	dw 0     ; flags. Bit 0 = `1` means this tag is optional, Bit 0 = `0` means it's mandatory.
-; 	dd 20    ; size of this tag (20)
-; 	; The resolution specified below is limited by the hardware.
-; 	; We have successfully tested resolutions up to 2560 x 1600.
-;   ; See more VGA/*XGA resolutions here: <https://en.wikipedia.org/wiki/Graphics_display_resolution#Extended_Graphics_Array>
-; 	dd 1920  ; width in pixels
-; 	dd 1080  ; height in pixels
-; 	dd 32    ; depth: pixel size in bits. Theseus only supports 32-bit pixels.
-; %endif
+%ifndef VGA_TEXT_MODE
+align 8
+	dw 5     ; type (5 means framebuffer tag)
+	dw 0     ; flags. Bit 0 = `1` means this tag is optional, Bit 0 = `0` means it's mandatory.
+	dd 20    ; size of this tag (20)
+	; The resolution specified below is limited by the hardware.
+	; We have successfully tested resolutions up to 2560 x 1600.
+	; We recommend matching the resolution set in `kernel_config/src/display.rs`.
+	; See more VGA/*XGA resolutions here: <https://en.wikipedia.org/wiki/Graphics_display_resolution#Extended_Graphics_Array>
+	dd 1280  ; width in pixels
+	dd 1024  ; height in pixels
+	dd 32    ; depth: pixel size in bits. Theseus only supports 32-bit pixels.
+%endif
 
 
 ; This marks the end of the tag region.

--- a/kernel/nano_core/src/asm/defines.asm
+++ b/kernel/nano_core/src/asm/defines.asm
@@ -17,6 +17,7 @@ AP_NMI_FLAGS        equ TRAMPOLINE + 64
 AP_MAX_FB_WIDTH     equ TRAMPOLINE + 72
 AP_MAX_FB_HEIGHT    equ TRAMPOLINE + 80
 AP_GDT              equ TRAMPOLINE + 88
+AP_IS_LAST_AP       equ TRAMPOLINE + 96
 
 ; Kernel is linked to run at -2Gb
 KERNEL_OFFSET equ 0xFFFFFFFF80000000

--- a/kernel/page_attribute_table/Cargo.toml
+++ b/kernel/page_attribute_table/Cargo.toml
@@ -14,9 +14,6 @@ modular-bitfield = "0.11.2"
 [dependencies.msr]
 path = "../../libs/msr"
 
-[dependencies.memory]
-path = "../memory"
-
 [dependencies.raw-cpuid]
 version = "10.6.0"
 

--- a/tools/grub_cfg_generation/src/main.rs
+++ b/tools/grub_cfg_generation/src/main.rs
@@ -67,6 +67,10 @@ fn create_grub_cfg_string(input_directory: String) -> Result<String, String> {
     content.push_str("set default=0\n\n");
     content.push_str("menuentry \"Theseus OS\" {\n");
     content.push_str("\tmultiboot2 /boot/kernel.bin \n");
+    // Below is a priority-ordered list of resolutions.
+    // Based on our testing, 4x3 aspect ratios are the most widely supported.
+    content.push_str("\tset gfxpayload=1280x1024x32,1280x720x32,1024x768x32,640x480x32,auto \n");
+    
 
     for path in fs::read_dir(input_directory).map_err(|e| e.to_string())? {
         let path = path.map_err(|e| e.to_string())?;


### PR DESCRIPTION
* Theseus now enables and uses a graphical framebuffer by default
  during early bootstrap/init for basic text output. This allows more info
  to be displayed than on the text-mode VGA screen.

* The `early_printer` now uses performance optimizations when possible:
  1. Writes are first made to an intermediary staging in order to accelerate scrolling by avoiding the need to read from the actual framebuffer.
  2. The framebuffer is mapped as write-combining using the page attribute table (PAT) if available.

* Don't switch graphical modes until the last AP is being brought up, in order to display the log output on real hardware for as long as possible.
  * Now that we use graphical framebuffer output by default, avoid printing to the text mode VGA buffer while booting up APs.

* Make the grub.cfg file specify more widely-used resolutions as GRUB-assigned default resolutions.