### PR TITLE
Add preserves_flags

### DIFF
--- a/kernel/pause/src/lib.rs
+++ b/kernel/pause/src/lib.rs
@@ -15,5 +15,5 @@
 pub fn spin_loop_hint() {
     // core::hint::spin_loop();
     #[cfg(target_arch = "x86_64")]
-    unsafe { core::arch::asm!("pause", options(nomem, nostack)); }
+    unsafe { core::arch::asm!("pause", options(nomem, nostack, preserves_flags)); }
 }


### PR DESCRIPTION
> preserves_flags: The asm! block does not modify the flags register (defined in the rules below). This allows the compiler to avoid recomputing the condition flags after the asm! block.

(https://doc.rust-lang.org/nightly/reference/inline-assembly.html)

the flags registers aren't modified here, so it's safe to use this option. (https://www.felixcloutier.com/x86/pause) <-- In this link, it doesn't mention anything about flags and it says `This instruction does not change the architectural state of the processor`