### PR TITLE
Enable `early_printer` to be used on aarch64

### DIFF
--- a/kernel/early_printer/Cargo.toml
+++ b/kernel/early_printer/Cargo.toml
@@ -13,6 +13,8 @@ volatile = "0.2.7"
 boot_info = { path = "../boot_info" }
 font = { path = "../font" }
 memory = { path = "../memory" }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
 page_attribute_table = { path = "../page_attribute_table" }
 vga_buffer = { path = "../vga_buffer" }
 

--- a/kernel/vga_buffer/src/lib.rs
+++ b/kernel/vga_buffer/src/lib.rs
@@ -11,6 +11,7 @@ use volatile::Volatile;
 
 /// The VBE/VESA standard defines the text mode VGA buffer to start at this address.
 /// We must rely on the early bootstrap code to identity map this address.
+#[cfg(target_arch = "x86_64")] // ensures build failure on non-x86 platforms
 const VGA_BUFFER_VIRTUAL_ADDR: usize = 0xb8000;
 
 /// height of the VGA text window


### PR DESCRIPTION
* Ensure that `early_printer` can only fall back to using vga text mode on x86_64.