### PR TITLE
Add a pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+echo '+make clippy'
+make clippy

--- a/Makefile
+++ b/Makefile
@@ -683,8 +683,13 @@ clean-doc:
 	@cargo clean --doc
 	@rm -rf $(RUSTDOC_OUT) $(BOOK_OUT)
 
+### Sets this repo's git hooks directory
 hooks:
 	@git config --local core.hooksPath .githooks/
+
+### Unsets this repo's git hooks directory
+unhook:
+	@git config --local --unset core.hooksPath
 
 ### The primary documentation for this makefile itself.
 help: 

--- a/Makefile
+++ b/Makefile
@@ -682,7 +682,9 @@ view-book: book
 clean-doc:
 	@cargo clean --doc
 	@rm -rf $(RUSTDOC_OUT) $(BOOK_OUT)
-	
+
+hooks:
+	@git config --local core.hooksPath .githooks/
 
 ### The primary documentation for this makefile itself.
 help: 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ For VS Code, recommended plugins are:
  * **rust-analyzer**, by matklad
  * **Better TOML**, by bungcip
  * **x86 and x86_64 Assembly**, by 13xforever
- 
+
+If you want to contribute, please run `make hooks` once. This way, `clippy` runs automatically on `git push` so you can't forget.
 
 ## Acknowledgements
 We would like to express our thanks to the [OS Dev wiki](https://wiki.osdev.org/) and its community and to Philipp Oppermann's [blog_os](https://os.phil-opp.com/) for serving as excellent starting points for Theseus. The early days of Theseus's development progress are indebted to these resources. 


### PR DESCRIPTION
- add a pre-push hook running clippy (can be expanded to run docs (view-docs?))
- add a make target for contributors to use our hooks (this should not be done automatically due to safety) and one to un-use them (if build fails but changes are ok this is useful)
- add a sentence to README about this

This currently won't do much besides ensuring that the build succeeds.
After #900 it will help.
What I dislike a bit about this is that the usual vscode git ui doesn't really tell you "hey, push fails because of a hook" but just tells you to "maybe pull in changes" or sth like that. Will take a look if there is some way to improve this later.