### PR TITLE
aarch64: update `uefi-bootloader` to fix `jump_to_kernel`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4174,7 +4174,7 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 [[package]]
 name = "uefi-bootloader-api"
 version = "0.1.0"
-source = "git+https://github.com/theseus-os/uefi-bootloader#c4e8aabb3430df2b1e16d87cbe567034c6742d02"
+source = "git+https://github.com/theseus-os/uefi-bootloader#661ea6245885307a3988713eeebcb7de723b7583"
 
 [[package]]
 name = "unicode-ident"

--- a/tools/uefi_builder/aarch64/Cargo.lock
+++ b/tools/uefi_builder/aarch64/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "uefi-bootloader"
 version = "0.1.0"
-source = "git+https://github.com/theseus-os/uefi-bootloader#c4e8aabb3430df2b1e16d87cbe567034c6742d02"
+source = "git+https://github.com/theseus-os/uefi-bootloader#661ea6245885307a3988713eeebcb7de723b7583"
 dependencies = [
  "bit_field",
  "cfg-if",
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "uefi-bootloader-api"
 version = "0.1.0"
-source = "git+https://github.com/theseus-os/uefi-bootloader#c4e8aabb3430df2b1e16d87cbe567034c6742d02"
+source = "git+https://github.com/theseus-os/uefi-bootloader#661ea6245885307a3988713eeebcb7de723b7583"
 
 [[package]]
 name = "uefi-macros"

--- a/tools/uefi_builder/x86_64/Cargo.lock
+++ b/tools/uefi_builder/x86_64/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "uefi-bootloader"
 version = "0.1.0"
-source = "git+https://github.com/theseus-os/uefi-bootloader#c4e8aabb3430df2b1e16d87cbe567034c6742d02"
+source = "git+https://github.com/theseus-os/uefi-bootloader#661ea6245885307a3988713eeebcb7de723b7583"
 dependencies = [
  "bit_field",
  "cfg-if",
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "uefi-bootloader-api"
 version = "0.1.0"
-source = "git+https://github.com/theseus-os/uefi-bootloader#c4e8aabb3430df2b1e16d87cbe567034c6742d02"
+source = "git+https://github.com/theseus-os/uefi-bootloader#661ea6245885307a3988713eeebcb7de723b7583"
 
 [[package]]
 name = "uefi-macros"


### PR DESCRIPTION
* Note: no changes to Theseus's actual code.

* The bootloader stack was inaccessible because it wasn't mapped into the new page table that gets switched to right before jumping to Theseus.

* Therefore, we must put context items directly into registers before activating the MMU that will use the new page table, to avoid accessing the context items that are on the old stack (which is no longer accessible).