### PR TITLE
-D clippy::all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,7 +602,7 @@ clippy:
 		cargo clippy \
 		$(BUILD_STD_CARGOFLAGS) $(FEATURES) \
 		--target $(TARGET) \
-		-- -D warnings
+		-- -D clippy::all
 
 
 ## The output directory for source-level documentation.


### PR DESCRIPTION
doesn't really make any semantic difference but I think the value lies in clearly communicating to the code user that all lints have been addressed