### PR TITLE
Make spin_loop() the default in loop

### DIFF
--- a/applications/cat/src/lib.rs
+++ b/applications/cat/src/lib.rs
@@ -9,7 +9,7 @@ extern crate path;
 extern crate fs_node;
 extern crate core2;
 
-use core::str;
+use core::{str, hint::spin_loop};
 use alloc::{
     string::{String, ToString},
     vec::Vec,
@@ -103,6 +103,7 @@ fn echo_from_stdin() -> Result<(), &'static str> {
         if cnt == 0 { break; }
         stdout.write_all(&buf[0..cnt])
             .or(Err("faileld to perform write_all"))?;
+        spin_loop();
     }
     Ok(())
 }

--- a/applications/hull/src/builtin.rs
+++ b/applications/hull/src/builtin.rs
@@ -1,5 +1,7 @@
 //! Builtin shell commands.
 
+use core::hint::spin_loop;
+
 use crate::{Error, Result, Shell};
 use alloc::{borrow::ToOwned, vec::Vec};
 use app_io::println;
@@ -28,6 +30,7 @@ impl Shell {
                     // TODO: Print
                     return Ok(());
                 }
+                spin_loop();
             }
         } else {
             for arg in args {

--- a/applications/hull/src/lib.rs
+++ b/applications/hull/src/lib.rs
@@ -22,7 +22,7 @@ pub use error::{Error, Result};
 use crate::job::{JobPart, State};
 use alloc::{borrow::ToOwned, format, string::String, sync::Arc, vec, vec::Vec};
 use app_io::println;
-use core::fmt::Write;
+use core::{fmt::Write, hint::spin_loop};
 use hashbrown::HashMap;
 use job::Job;
 use noline::{builder::EditorBuilder, sync::embedded::IO as Io};
@@ -92,6 +92,7 @@ impl Shell {
             } else {
                 write!(io, "failed to read line").expect("failed to write output");
             }
+            spin_loop();
         }
     }
 
@@ -194,6 +195,7 @@ impl Shell {
                     _ => Err(Error::Command(exit_value)),
                 };
             }
+            spin_loop();
         }
     }
 

--- a/applications/ping/src/lib.rs
+++ b/applications/ping/src/lib.rs
@@ -20,6 +20,7 @@ extern crate getopts;
 
 
 use getopts::{Matches, Options};
+use core::hint::spin_loop;
 use core::str::FromStr;
 use hashbrown::HashMap;
 use alloc::vec::Vec;        
@@ -323,8 +324,7 @@ fn ping(address: IpAddress, count: usize, interval: u64, timeout: u64, verbose: 
                 break
             }
         }
-    
-
+        spin_loop();
     }
     
     // Computes ping min/avg/max

--- a/applications/ping_2/src/lib.rs
+++ b/applications/ping_2/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 
 use alloc::{string::String, vec, vec::Vec};
 use app_io::println;
-use core::str::FromStr;
+use core::{str::FromStr, hint::spin_loop};
 use getopts::{Matches, Options};
 use net::{
     icmp::{Endpoint, PacketBuffer, PacketMetadata, Socket},
@@ -132,6 +132,7 @@ fn _main(matches: Matches) -> Result<(), &'static str> {
         if received == count {
             return Ok(());
         }
+        spin_loop();
     }
 }
 

--- a/applications/raw_mode/src/lib.rs
+++ b/applications/raw_mode/src/lib.rs
@@ -4,6 +4,8 @@
 
 extern crate alloc;
 
+use core::hint::spin_loop;
+
 use alloc::{string::String, vec::Vec};
 
 pub fn main(_args: Vec<String>) -> isize {
@@ -30,6 +32,7 @@ fn run() -> Result<(), &'static str> {
         stdout
             .write_all(&buf)
             .or(Err("failed to invoke write_all"))?;
+        spin_loop();
     }
 
     Ok(())

--- a/applications/seconds_counter/src/lib.rs
+++ b/applications/seconds_counter/src/lib.rs
@@ -2,6 +2,8 @@
 
 extern crate alloc;
 
+use core::hint::spin_loop;
+
 use alloc::{string::String, vec::Vec};
 
 pub fn main(_: Vec<String>) {
@@ -14,5 +16,6 @@ pub fn main(_: Vec<String>) {
             app_io::println!("{}", counter);
             previous = now;
         }
+        spin_loop();
     }
 }

--- a/applications/shell/src/lib.rs
+++ b/applications/shell/src/lib.rs
@@ -37,6 +37,7 @@ use dfqueue::{DFQueue, DFQueueConsumer, DFQueueProducer};
 use alloc::sync::Arc;
 use spin::Mutex;
 use environment::Environment;
+use core::hint::spin_loop;
 use core::mem;
 use alloc::collections::BTreeMap;
 use stdio::{Stdio, KeyEventQueue, KeyEventQueueReader, KeyEventQueueWriter,
@@ -112,6 +113,7 @@ pub fn main(_args: Vec<String>) -> isize {
 
     loop {
         warn!("BUG: blocked shell task was scheduled in unexpectedly");
+        spin_loop();
     }
 
     // TODO: when `join` puts this task to sleep instead of spinning, we can re-enable it.
@@ -426,6 +428,7 @@ impl Shell {
                         if !task_ref.is_running() {
                             break;
                         }
+                        spin_loop();
                     }
                 }
                 self.terminal.lock().print_to_terminal("^C\n".to_string());
@@ -465,6 +468,7 @@ impl Shell {
                         if !task_ref.is_running() {
                             break;
                         }
+                        spin_loop();
                     }
                 }
             }
@@ -1325,6 +1329,7 @@ impl Shell {
                 } else { // currently the key event queue is taken by an application
                     break;
                 }
+                spin_loop();
             }
             if need_refresh {
                 // update if there are inputs
@@ -1332,6 +1337,7 @@ impl Shell {
             } else {
                 scheduler::schedule(); // yield the CPU if nothing to do
             }
+            spin_loop();
         }
     }
 }

--- a/applications/test_ixgbe/src/lib.rs
+++ b/applications/test_ixgbe/src/lib.rs
@@ -110,6 +110,7 @@ fn rmain(matches: &Matches, _opts: &Options) -> Result<(), &'static str> {
                         println!("Received packet on vnic {}", nic.id());
                     }
                 }
+                core::hint::spin_loop();
             }
         }
     } else {
@@ -125,6 +126,7 @@ fn rmain(matches: &Matches, _opts: &Options) -> Result<(), &'static str> {
                         println!("Received packet on queue {}", qid);
                     }
                 }
+                core::hint::spin_loop();
             }
         }
     }

--- a/applications/test_mutex_sleep/src/lib.rs
+++ b/applications/test_mutex_sleep/src/lib.rs
@@ -150,6 +150,7 @@ fn lockstep_task((lock, remainder): (Arc<MutexSleep<usize>>, usize)) -> Result<(
                 warn!("Task {} going back to sleep, value {}, remainder {}!", curr_task, *locked, remainder);
             }
             scheduler::schedule();
+            core::hint::spin_loop();
         }
     }
     warn!("{} finished loop.", curr_task);

--- a/applications/test_realtime/src/lib.rs
+++ b/applications/test_realtime/src/lib.rs
@@ -57,5 +57,6 @@ fn _task_delay_tester(_arg: usize) {
         info!("I run periodically (iter {}).", iter);
         iter += 1;
         sleep::sleep_until(end_time).unwrap();
+        core::hint::spin_loop();
     }
 }

--- a/applications/test_serial_echo/src/lib.rs
+++ b/applications/test_serial_echo/src/lib.rs
@@ -49,6 +49,7 @@ pub fn main(args: Vec<String>) -> isize {
                     serial_port_io.write(s.as_bytes()).expect("serial port write failed");
                 }
             }
+            core::hint::spin_loop();
         }
     }
     else {
@@ -61,6 +62,7 @@ pub fn main(args: Vec<String>) -> isize {
                     serial_port.lock().write_str(s).expect("serial port write failed");
                 }
             }
+            core::hint::spin_loop();
         }
     }
     

--- a/applications/test_task_cancel/src/lib.rs
+++ b/applications/test_task_cancel/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate alloc;
 
 use alloc::{string::String, sync::Arc, vec::Vec};
-use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
+use core::{sync::atomic::{AtomicBool, Ordering::Relaxed}, hint::spin_loop};
 use spin::Mutex;
 
 pub fn main(_: Vec<String>) -> isize {
@@ -37,6 +37,7 @@ fn guard_hog(lock: Arc<Mutex<()>>) {
         // that only covers the instructions associated with the panic, which we would
         // never reach.
         lsda_generator();
+        spin_loop();
     }
 }
 

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -7,7 +7,7 @@
 extern crate alloc;
 
 use alloc::collections::BTreeMap;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::{sync::atomic::{AtomicBool, Ordering}, hint::spin_loop};
 use log::{error, info};
 use cpu::CpuId;
 use irq_safety::{enable_interrupts, MutexIrqSafe};
@@ -68,7 +68,7 @@ pub fn kstart_ap(
 
     #[cfg(target_arch = "aarch64")] {
         log::info!("cpu {} is ready!", cpu_id);
-        loop {}
+        loop { spin_loop(); }
     }
 
     // initialize interrupts (including TSS/GDT) for this AP
@@ -130,5 +130,6 @@ pub fn kstart_ap(
     scheduler::schedule();
     loop { 
         error!("BUG: ap_start::kstart_ap(): CPU {} bootstrap task was rescheduled after being dead!", cpu_id);
+        spin_loop();
     }
 }

--- a/kernel/async_channel/src/lib.rs
+++ b/kernel/async_channel/src/lib.rs
@@ -23,7 +23,7 @@ use alloc::sync::Arc;
 use mpmc::Queue as MpmcQueue;
 use wait_queue::WaitQueue;
 use crossbeam_utils::atomic::AtomicCell;
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::{sync::atomic::{AtomicUsize, Ordering}, hint::spin_loop};
 
 /// Create a new channel that allows senders and receivers to 
 /// asynchronously exchange messages via an internal intermediary buffer.
@@ -434,6 +434,7 @@ impl <T: Send> Receiver<T> {
                 Err(Error::WouldBlock) => return Ok(read),
                 Err(e) => return Err(e),
             };
+            spin_loop();
         }
     }
 

--- a/kernel/ata/src/lib.rs
+++ b/kernel/ata/src/lib.rs
@@ -10,7 +10,7 @@
 extern crate alloc;
 #[macro_use] extern crate log;
 
-use core::fmt;
+use core::{fmt, hint::spin_loop};
 use bitflags::bitflags;
 use spin::Mutex;
 use alloc::{
@@ -479,6 +479,7 @@ impl AtaBus {
 			if status.intersects(AtaStatus::DATA_REQUEST_READY) {
 				return Ok(()); // ready to go!
 			}
+			spin_loop();
 		}
 	}
 
@@ -509,6 +510,7 @@ impl AtaBus {
 			if !status.intersects(AtaStatus::DATA_REQUEST_READY) {
 				return Ok(()); // ready to go!
 			}
+			spin_loop();
 		}
 	}
 

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -19,6 +19,8 @@
 
 extern crate alloc;
 
+use core::hint::spin_loop;
+
 use log::{error, info};
 use memory::{EarlyIdentityMappedPages, MmiRef, PhysicalAddress};
 use irq_safety::enable_interrupts;
@@ -230,5 +232,6 @@ pub fn init(
     scheduler::schedule();
     loop { 
         error!("BUG: captain::init(): captain's bootstrap task was rescheduled after being dead!");
+        spin_loop();
     }
 }

--- a/kernel/console/src/lib.rs
+++ b/kernel/console/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 use alloc::{format, sync::Arc};
 use async_channel::Receiver;
-use core::sync::atomic::{AtomicU16, Ordering};
+use core::{sync::atomic::{AtomicU16, Ordering}, hint::spin_loop};
 use core2::io::Write;
 use irq_safety::MutexIrqSafe;
 use log::{error, info, warn};
@@ -88,6 +88,7 @@ fn console_connection_detector(
                 serial_port_address
             );
         }
+        spin_loop();
     }
 }
 
@@ -167,6 +168,7 @@ fn tty_to_port_loop((port, master): (Arc<MutexIrqSafe<SerialPort>>, tty::Master)
         if let Err(e) = port.lock().write(&data[..len]) {
             error!("couldn't write to port: {e}");
         }
+        spin_loop();
     }
 }
 
@@ -183,5 +185,6 @@ fn port_to_tty_loop((receiver, master): (Receiver<DataChunk>, tty::Master)) {
         if let Err(e) = master.write(&data[..len as usize]) {
             error!("couldn't write to master: {e}");
         }
+        spin_loop();
     }
 }

--- a/kernel/deferred_interrupt_tasks/src/lib.rs
+++ b/kernel/deferred_interrupt_tasks/src/lib.rs
@@ -55,6 +55,8 @@ extern crate scheduler;
 #[macro_use] extern crate debugit;
 extern crate interrupts;
 
+use core::hint::spin_loop;
+
 use alloc::string::String;
 use task::{get_my_current_task, JoinableTaskRef};
 
@@ -177,5 +179,6 @@ fn deferred_task_entry_point<DIA, Arg, Success, Failure>(
         }
 
         scheduler::schedule();
+        spin_loop();
     }
 }

--- a/kernel/dreadnought/src/lib.rs
+++ b/kernel/dreadnought/src/lib.rs
@@ -23,7 +23,7 @@ extern crate alloc;
 
 use core::{
     future::Future,
-    task::{Context, Poll},
+    task::{Context, Poll}, hint::spin_loop,
 };
 
 pub use futures::{future, pin_mut, select_biased, FutureExt};
@@ -49,5 +49,6 @@ where
             Poll::Ready(output) => return output,
             Poll::Pending => blocker.block(),
         }
+        spin_loop();
     }
 }

--- a/kernel/exceptions_early/src/lib.rs
+++ b/kernel/exceptions_early/src/lib.rs
@@ -106,7 +106,7 @@ pub fn init(double_fault_stack_top_unusable: Option<memory::VirtualAddress>) {
 /// exception 0x00
 extern "x86-interrupt" fn divide_error_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): DIVIDE ERROR\n{:#X?}", stack_frame);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x01
@@ -118,7 +118,7 @@ extern "x86-interrupt" fn debug_handler(stack_frame: InterruptStackFrame) {
 /// exception 0x02
 extern "x86-interrupt" fn nmi_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): NON-MASKABLE INTERRUPT\n{:#X?}", stack_frame);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x03
@@ -130,19 +130,19 @@ extern "x86-interrupt" fn breakpoint_handler(stack_frame: InterruptStackFrame) {
 /// exception 0x04
 extern "x86-interrupt" fn overflow_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): OVERFLOW\n{:#X?}", stack_frame);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x05
 extern "x86-interrupt" fn bound_range_exceeded_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): BOUND RANGE EXCEEDED\n{:#X?}", stack_frame);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x06
 extern "x86-interrupt" fn invalid_opcode_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): INVALID OPCODE\n{:#X?}", stack_frame);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x07
@@ -151,7 +151,7 @@ extern "x86-interrupt" fn invalid_opcode_handler(stack_frame: InterruptStackFram
 /// see [here](http://wiki.osdev.org/I_Cant_Get_Interrupts_Working#I_keep_getting_an_IRQ7_for_no_apparent_reason).
 extern "x86-interrupt" fn device_not_available_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): DEVICE NOT AVAILABLE\n{:#X?}", stack_frame);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x08
@@ -160,31 +160,31 @@ extern "x86-interrupt" fn device_not_available_handler(stack_frame: InterruptSta
 pub extern "x86-interrupt" fn double_fault_handler(stack_frame: InterruptStackFrame, error_code: u64) -> ! {
     println!("\nEXCEPTION (early): DOUBLE FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
     println!("\nNote: this may be caused by stack overflow. Is the size of the initial_bsp_stack is too small?");
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x0A
 extern "x86-interrupt" fn invalid_tss_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): INVALID TSS\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x0B
 extern "x86-interrupt" fn segment_not_present_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): SEGMENT NOT PRESENT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x0C
 extern "x86-interrupt" fn stack_segment_fault_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): STACK SEGMENT FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x0D
 extern "x86-interrupt" fn general_protection_fault_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): GENERAL PROTECTION FAULT\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x0E
@@ -211,47 +211,47 @@ extern "x86-interrupt" fn early_page_fault_handler(stack_frame: InterruptStackFr
             true, // look at all sections (.data/.bss/.rodata), not just .text
         )),
     );
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x10
 extern "x86-interrupt" fn x87_floating_point_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): x87 FLOATING POINT\n{:#X?}", stack_frame);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x11
 extern "x86-interrupt" fn alignment_check_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): ALIGNMENT CHECK\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x12
 extern "x86-interrupt" fn machine_check_handler(stack_frame: InterruptStackFrame) -> ! {
     println!("\nEXCEPTION (early): MACHINE CHECK\n{:#X?}", stack_frame);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x13
 extern "x86-interrupt" fn simd_floating_point_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): SIMD FLOATING POINT\n{:#X?}", stack_frame);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x14
 extern "x86-interrupt" fn virtualization_handler(stack_frame: InterruptStackFrame) {
     println!("\nEXCEPTION (early): VIRTUALIZATION\n{:#X?}", stack_frame);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x1D
 extern "x86-interrupt" fn vmm_communication_exception_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): VMM COMMUNICATION EXCEPTION\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }
 
 /// exception 0x1E
 extern "x86-interrupt" fn security_exception_handler(stack_frame: InterruptStackFrame, error_code: u64) {
     println!("\nEXCEPTION (early): SECURITY EXCEPTION\n{:#X?}\nError code: {:#b}", stack_frame, error_code);
-    loop { spin_loop() }
+    loop { spin_loop(); }
 }

--- a/kernel/exceptions_full/src/lib.rs
+++ b/kernel/exceptions_full/src/lib.rs
@@ -227,7 +227,7 @@ fn kill_and_halt(
     // But in general, this task should have already been marked as killed and thus no longer schedulable,
     // so it should not reach this point. 
     // Only exceptions during the early OS initialization process will get here, meaning that the OS will basically stop.
-    loop { core::hint::spin_loop() }
+    loop { core::hint::spin_loop(); }
 }
 
 
@@ -355,7 +355,7 @@ extern "x86-interrupt" fn double_fault_handler(stack_frame: InterruptStackFrame,
     }
     
     kill_and_halt(0x8, &stack_frame, Some(error_code.into()), false);
-    loop { core::hint::spin_loop() }
+    loop { core::hint::spin_loop(); }
 }
 
 /// exception 0x0A
@@ -416,7 +416,7 @@ extern "x86-interrupt" fn alignment_check_handler(stack_frame: InterruptStackFra
 extern "x86-interrupt" fn machine_check_handler(stack_frame: InterruptStackFrame) -> ! {
     println_both!("\nEXCEPTION: MACHINE CHECK\n{:#X?}", stack_frame);
     kill_and_halt(0x12, &stack_frame, None, true);
-    loop { core::hint::spin_loop() }
+    loop { core::hint::spin_loop(); }
 }
 
 /// exception 0x13

--- a/kernel/fault_crate_swap/src/lib.rs
+++ b/kernel/fault_crate_swap/src/lib.rs
@@ -13,7 +13,7 @@ extern crate crate_swap;
 extern crate task;
 extern crate fault_log;
 
-use core::ptr;
+use core::{ptr, hint::spin_loop};
 use core::ops::Range;
 
 use alloc::{
@@ -268,6 +268,7 @@ pub fn constant_offset_fix(
         if x > top {
             break;
         }
+        spin_loop();
     }
     Ok(())
 }

--- a/kernel/framebuffer_compositor/src/lib.rs
+++ b/kernel/framebuffer_compositor/src/lib.rs
@@ -30,6 +30,7 @@ extern crate shapes;
 use alloc::collections::BTreeMap;
 use alloc::vec::{Vec};
 use core::hash::{Hash, Hasher, BuildHasher};
+use core::hint::spin_loop;
 use hashbrown::hash_map::{DefaultHashBuilder};
 use compositor::{Compositor, FramebufferUpdates, CompositableRegion};
 use framebuffer::{Framebuffer, Pixel};
@@ -228,6 +229,7 @@ impl Compositor for FrameCompositor {
                         )?;
                     }
                     row_start += CACHE_BLOCK_HEIGHT;
+                    spin_loop();
                 }
             }
         } else {
@@ -257,6 +259,7 @@ impl Compositor for FrameCompositor {
                             cache_range,
                         )?;
                         row_range.start += CACHE_BLOCK_HEIGHT;
+                        spin_loop();
                     } 
                 }
             }

--- a/kernel/framebuffer_drawer/src/lib.rs
+++ b/kernel/framebuffer_drawer/src/lib.rs
@@ -7,6 +7,8 @@
 extern crate framebuffer;
 extern crate shapes;
 
+use core::hint::spin_loop;
+
 use framebuffer::{Framebuffer, Pixel};
 use shapes::Coord;
 
@@ -48,6 +50,7 @@ pub fn draw_line<P: Pixel>(
                 break;
             }
             x += step;
+            spin_loop();
         }
     } else {
         let mut x;
@@ -67,6 +70,7 @@ pub fn draw_line<P: Pixel>(
                 break;
             }
             y += step;
+            spin_loop();
         }
     }
 }
@@ -113,6 +117,7 @@ pub fn draw_rectangle<P: Pixel>(
             framebuffer.draw_pixel(top + (0, end_y_offset), pixel);
         }
         top.x += 1;
+        spin_loop();
     }
 
     let mut left = Coord::new(start_x, start_y); 
@@ -128,6 +133,7 @@ pub fn draw_rectangle<P: Pixel>(
             framebuffer.draw_pixel(left + (end_x_offset, 0), pixel);
         }
         left.y += 1;
+        spin_loop();
     }
 }
 
@@ -167,12 +173,14 @@ pub fn fill_rectangle<P: Pixel>(
             if coordinate.x == end_x {
                 break;
             }
+            spin_loop();
         }
         coordinate.y += 1;
         if coordinate.y == end_y {
             break;
         }
         coordinate.x = start_x;
+        spin_loop();
     }
 }
 

--- a/kernel/framebuffer_printer/src/lib.rs
+++ b/kernel/framebuffer_printer/src/lib.rs
@@ -8,6 +8,8 @@ extern crate font;
 extern crate framebuffer;
 extern crate shapes;
 
+use core::hint::spin_loop;
+
 use alloc::vec;
 use font::{CHARACTER_HEIGHT, CHARACTER_WIDTH};
 use framebuffer::{Framebuffer, Pixel};
@@ -193,6 +195,7 @@ pub fn print_ascii_character<P: Pixel>(
             }
             j = off_set_x;
         }
+        spin_loop();
     }
 }
 
@@ -225,6 +228,7 @@ pub fn fill_blank<P: Pixel>(
             framebuffer.composite_buffer(&fill, start);
         }
         coordinate.y += 1;
+        spin_loop();
     }
 }
 

--- a/kernel/http_client/src/lib.rs
+++ b/kernel/http_client/src/lib.rs
@@ -16,10 +16,8 @@ use core::str;
 use alloc::vec::Vec;
 use alloc::string::String;
 use hpet::get_hpet;
-use smoltcp::{
-    socket::{SocketSet, TcpSocket, SocketHandle},
-};
-use network_manager::{NetworkInterfaceRef};
+use smoltcp::socket::{SocketSet, TcpSocket, SocketHandle};
+use network_manager::NetworkInterfaceRef;
 use smoltcp_helper::{millis_since, poll_iface};
 
 /// The states that implement the finite state machine for 
@@ -310,6 +308,8 @@ pub fn send_request(
                 state
             }
         }
+        // spinloop skipped because this loop returns value
+        // TODO: verify if this loop is really necessary and if so, find a way to minimize time spent in the loop
     }
 
 

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -79,13 +79,13 @@ type HandlerFunc = extern "C" fn(&ExceptionContext) -> EoiBehaviour;
 // called for all exceptions other than interrupts
 fn default_exception_handler(exc: &ExceptionContext, origin: &'static str) {
     log::error!("Unhandled Exception ({})\r\n{:?}\r\n[looping forever now]", origin, exc);
-    loop { core::hint::spin_loop() }
+    loop { core::hint::spin_loop(); }
 }
 
 // called for all unhandled interrupt requests
 extern "C" fn default_irq_handler(exc: &ExceptionContext) -> EoiBehaviour {
     log::error!("Unhandled IRQ:\r\n{:?}\r\n[looping forever now]", exc);
-    loop { core::hint::spin_loop() }
+    loop { core::hint::spin_loop(); }
 }
 
 fn read_timer_period_femtoseconds() -> u64 {

--- a/kernel/mutex_preemption/src/mutex_preempt.rs
+++ b/kernel/mutex_preemption/src/mutex_preempt.rs
@@ -1,4 +1,4 @@
-use core::{fmt, ops::{Deref, DerefMut}};
+use core::{fmt, ops::{Deref, DerefMut}, hint::spin_loop};
 use preemption::{PreemptionGuard, hold_preemption};
 use spin::{Mutex, MutexGuard};
 use lockable::{Lockable, LockableSized};
@@ -62,6 +62,7 @@ impl<T: ?Sized> MutexPreempt<T> {
             if let Some(guard) = self.try_lock() {
                 return guard;
             }
+            spin_loop();
         }
     }
 

--- a/kernel/mutex_preemption/src/rwlock_preempt.rs
+++ b/kernel/mutex_preemption/src/rwlock_preempt.rs
@@ -1,7 +1,7 @@
 // TODO: add documentation to each unsafe block, laying out all the conditions under which it's safe or unsafe to use it.
 #![allow(clippy::missing_safety_doc)]
 
-use core::{fmt, ops::{Deref, DerefMut}};
+use core::{fmt, ops::{Deref, DerefMut}, hint::spin_loop};
 use preemption::{PreemptionGuard, hold_preemption};
 use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use lockable::{Lockable, LockableSized};
@@ -95,6 +95,7 @@ impl<T: ?Sized> RwLockPreempt<T> {
     pub fn read(&self) -> RwLockPreemptReadGuard<T> {
         loop {
             if let Some(guard) = self.try_read() { return guard }
+            spin_loop();
         }
     }
 
@@ -187,6 +188,7 @@ impl<T: ?Sized> RwLockPreempt<T> {
     pub fn write(&self) -> RwLockPreemptWriteGuard<T> {
         loop {
             if let Some(guard) = self.try_write() { return guard }
+            spin_loop();
         }
     }
 

--- a/kernel/ota_update_client/src/lib.rs
+++ b/kernel/ota_update_client/src/lib.rs
@@ -19,7 +19,7 @@ extern crate itertools;
 #[macro_use] extern crate smoltcp_helper;
 
 
-use core::str;
+use core::{str, hint::spin_loop};
 use alloc::{
     vec::Vec,
     collections::BTreeSet,
@@ -439,6 +439,7 @@ fn download_files<S: AsRef<str>>(
             // to the remote endpoint, which requires another call to poll_iface (which will happen at the top of the loop).
             // Then, the socket will be in the Closed state, and that conditional above will break out of the loop. 
         }
+        spin_loop();
     }
 
     if downloaded_files.len() != absolute_paths.len() {

--- a/kernel/panic_entry/src/lib.rs
+++ b/kernel/panic_entry/src/lib.rs
@@ -79,7 +79,7 @@ fn panic_entry_point(info: &PanicInfo) -> ! {
     // other than just let the thread spin endlessly (which doesn't hurt correctness but is inefficient). 
     // But in general, this task should be killed by the panic_wrapper, so it shouldn't reach this point.
     // Only panics early on in the initialization process will get here, meaning that the OS will basically stop.
-    loop { core::hint::spin_loop() }
+    loop { core::hint::spin_loop(); }
 }
 
 
@@ -94,7 +94,7 @@ fn panic_entry_point(info: &PanicInfo) -> ! {
 #[doc(hidden)]
 extern "C" fn rust_eh_personality() -> ! {
     error!("BUG: Theseus does not use rust_eh_personality. Why has it been invoked?");
-    loop { core::hint::spin_loop() }
+    loop { core::hint::spin_loop(); }
 }
 
 /// This function is automatically jumped to after each unwinding cleanup routine finishes executing,
@@ -107,7 +107,7 @@ extern "C" fn rust_eh_personality() -> ! {
 #[cfg_attr(target_arch = "aarch64", allow(unused_variables))]
 extern "C" fn _Unwind_Resume(arg: usize) -> ! {
     #[cfg(target_arch = "aarch64")]
-    loop { core::hint::spin_loop() }
+    loop { core::hint::spin_loop(); }
 
     #[cfg(all(target_arch = "x86_64", not(loadable)))] {
         unwind::unwind_resume(arg)
@@ -130,7 +130,7 @@ extern "C" fn _Unwind_Resume(arg: usize) -> ! {
             Ok(()) => error!("BUG: _Unwind_Resume: unexpectedly returned Ok(()) from unwind::unwind_resume()"),
             Err(e) => error!("_Unwind_Resume: failed to dynamically invoke unwind::unwind_resume! Error: {}", e),
         }
-        loop { core::hint::spin_loop() }
+        loop { core::hint::spin_loop(); }
     }
 }
 

--- a/kernel/path/src/lib.rs
+++ b/kernel/path/src/lib.rs
@@ -10,7 +10,7 @@ extern crate root;
 use core::{
     fmt,
     fmt::Write,
-    ops::{Deref, DerefMut},
+    ops::{Deref, DerefMut}, hint::spin_loop,
 };
 use alloc::{
     string::{String, ToString},
@@ -176,6 +176,7 @@ impl Path {
                     break;
                 }
             }
+            spin_loop();
         }
         // Create the new path from its components 
         let mut new_path = String::new();

--- a/kernel/rendezvous/src/lib.rs
+++ b/kernel/rendezvous/src/lib.rs
@@ -27,7 +27,7 @@ extern crate wait_queue;
 extern crate task;
 extern crate scheduler;
 
-use core::fmt;
+use core::{fmt, hint::spin_loop};
 use alloc::sync::Arc;
 use irq_safety::MutexIrqSafe;
 use spin::Mutex;
@@ -285,6 +285,7 @@ impl <T: Send> Sender<T> {
                 }
             }
             scheduler::schedule();
+            spin_loop();
         }
 
         // Here, we are at the rendezvous point
@@ -338,6 +339,7 @@ impl <T: Send> Sender<T> {
                 }
             };
             let old_state = core::mem::replace(&mut wait_entry, new_state);
+            spin_loop();
         }
         */
     }
@@ -436,6 +438,7 @@ impl <T: Send> Receiver<T> {
                 }
             }
             scheduler::schedule();
+            spin_loop();
         }
 
 

--- a/kernel/simd_personality/src/lib.rs
+++ b/kernel/simd_personality/src/lib.rs
@@ -198,7 +198,7 @@ fn internal_setup_simd_personality(simd_ext: SimdExt) -> Result<(), &'static str
 	// TODO FIXME: check for this somehow in the thread spawn code, perhaps by giving the new thread ownership of the MappedPages,
 	//             just like we do for application Tasks
 
-	loop { core::hint::spin_loop() }
+	loop { core::hint::spin_loop(); }
 	
 	// _task1.join()?;
 	// _task2.join()?;

--- a/kernel/simd_test/src/lib.rs
+++ b/kernel/simd_test/src/lib.rs
@@ -3,7 +3,6 @@
 
 // The entire crate is only built if both `simd_personality` and `sse2` are enabled.
 
-use core::hint::spin_loop;
 #[macro_use] extern crate cfg_if;
 cfg_if! { if #[cfg(all(simd_personality, target_feature = "sse2"))] {
 

--- a/kernel/simd_test/src/lib.rs
+++ b/kernel/simd_test/src/lib.rs
@@ -2,6 +2,8 @@
 #![feature(portable_simd)]
 
 // The entire crate is only built if both `simd_personality` and `sse2` are enabled.
+
+use core::hint::spin_loop;
 #[macro_use] extern crate cfg_if;
 cfg_if! { if #[cfg(all(simd_personality, target_feature = "sse2"))] {
 
@@ -27,6 +29,7 @@ pub fn test1(_: ()) {
             debug!("SIMD TEST1 (should be 1.111, 11.11, 111.1, 1111): {:?}", x);
         }
         loop_ctr += 1;
+        spin_loop();
     }
 }
 
@@ -46,6 +49,7 @@ pub fn test2(_: ()) {
             trace!("SIMD TEST2 (should be 2.222, 22.22, 222.2, 2222): {:?}", x);
         }
         loop_ctr += 1;
+        spin_loop();
     }
 }
 

--- a/kernel/smoltcp_helper/src/lib.rs
+++ b/kernel/smoltcp_helper/src/lib.rs
@@ -11,7 +11,7 @@ extern crate spin;
 extern crate hpet;
 
 use alloc::string::ToString;
-use core::convert::TryInto;
+use core::{convert::TryInto, hint::spin_loop};
 use spin::Once;
 use hpet::get_hpet;
 use smoltcp::{
@@ -106,6 +106,7 @@ pub fn connect(
             error!("smoltcp_helper: failed to connect to socket, timed out after {} ms", timeout_millis);
             return Err("smoltcp_helper: failed to connect to socket, timed out.");
         }
+        spin_loop();
     }
 
     debug!("smoltcp_helper: connected!  (took {} ms)", millis_since(start)?);

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -901,7 +901,7 @@ fn task_cleanup_final<F, A, R>(preemption_guard: PreemptionGuard, current_task: 
 
     scheduler::schedule();
     error!("BUG: task_cleanup_final(): task was rescheduled after being dead!");
-    loop { core::hint::spin_loop() }
+    loop { core::hint::spin_loop(); }
 }
 
 /// The final piece of the task cleanup logic for restartable tasks.
@@ -977,7 +977,7 @@ where
 
     scheduler::schedule();
     error!("BUG: task_cleanup_final(): task was rescheduled after being dead!");
-    loop { core::hint::spin_loop() }
+    loop { core::hint::spin_loop(); }
 }
 
 /// Helper function to remove a task from its runqueue and drop it.
@@ -1010,7 +1010,7 @@ pub fn create_idle_task() -> Result<JoinableTaskRef, &'static str> {
         .spawn_restartable(None)
 }
 
-/// A basic idle task that does nothing but loop endlessly.
+/// An idle task that pauses CPU until an interrupt is received.
 ///
 /// Note: the current spawn API does not support spawning a task with the return type `!`,
 /// so we use `()` here instead. 
@@ -1018,7 +1018,6 @@ pub fn create_idle_task() -> Result<JoinableTaskRef, &'static str> {
 fn idle_task_entry(_cpu_id: CpuId) {
     info!("Entered idle task loop on core {}: {:?}", cpu::current_cpu(), task::get_my_current_task());
     loop {
-        // TODO: put this core into a low-power state
         core::hint::spin_loop();
     }
 }

--- a/kernel/tty/src/discipline.rs
+++ b/kernel/tty/src/discipline.rs
@@ -272,5 +272,7 @@ const fn werase(buf: &[u8]) -> usize {
         } else if buf[len - offset] == b' ' {
             return offset - 1;
         }
+        // spin_loop() is skipped here because it's harder to implement in const environment
+        // TODO: verify whether the loop is necessary and if so, minimize the time spent in the loop
     }
 }

--- a/kernel/wait_queue/src/lib.rs
+++ b/kernel/wait_queue/src/lib.rs
@@ -8,6 +8,8 @@ extern crate task;
 extern crate scheduler;
 
 
+use core::hint::spin_loop;
+
 use alloc::collections::VecDeque;
 use irq_safety::MutexIrqSafe;
 use task::{TaskRef, RunState};
@@ -140,6 +142,7 @@ impl WaitQueue {
 
             // Here, we have been woken up, so loop back around and check the condition again
             // trace!("WaitQueue::wait_until():  woke up!");
+            spin_loop();
         }
     }
 
@@ -172,6 +175,7 @@ impl WaitQueue {
 
             // Here, we have been woken up, so loop back around and check the condition again
             // trace!("WaitQueue::wait_until():  woke up!");
+            spin_loop();
         }
     }
 
@@ -234,6 +238,7 @@ impl WaitQueue {
                 // trace!("WaitQueue::notify():  did nothing");
                 return false;
             }
+            spin_loop();
         }
     }
 }

--- a/kernel/waker_generic/src/lib.rs
+++ b/kernel/waker_generic/src/lib.rs
@@ -9,6 +9,8 @@
 
 extern crate alloc;
 
+use core::hint::spin_loop;
+
 use alloc::sync::Arc;
 use spin::Mutex; 
 
@@ -87,6 +89,7 @@ impl Blocker {
                 };
                 drop(result);
             }
+            spin_loop();
         }
     }
 }

--- a/kernel/window_manager/src/lib.rs
+++ b/kernel/window_manager/src/lib.rs
@@ -28,6 +28,8 @@ extern crate window_inner;
 extern crate shapes;
 extern crate color;
 
+use core::hint::spin_loop;
+
 use alloc::collections::VecDeque;
 use alloc::string::ToString;
 use alloc::sync::{Arc, Weak};
@@ -709,6 +711,7 @@ fn window_manager_loop(
                 }
             }
         }
+        spin_loop();
     }
 }
 

--- a/libs/stdio/src/lib.rs
+++ b/libs/stdio/src/lib.rs
@@ -16,7 +16,7 @@ use alloc::vec::Vec;
 use spin::{Mutex, MutexGuard};
 use core2::io::{Read, Write};
 use keycodes_ascii::KeyEvent;
-use core::ops::Deref;
+use core::{ops::Deref, hint::spin_loop};
 
 /// A ring buffer with an EOF mark.
 pub struct RingBufferEof<T> {
@@ -178,6 +178,7 @@ impl StdioReader {
             let mut locked = self.lock();
             new_cnt = locked.read(&mut tmp_buf[..])?;
             if new_cnt == 0 && locked.is_eof() { return Ok(total_cnt); }
+            spin_loop();
         }
     }
 }
@@ -232,6 +233,7 @@ impl<'a> Read for StdioReadGuard<'a> {
 
             // Break if we have read something or we encounter EOF.
             if cnt > 0 || end { break; }
+            spin_loop();
         }
         return Ok(cnt);
     }

--- a/libtheseus/src/lib.rs
+++ b/libtheseus/src/lib.rs
@@ -42,21 +42,21 @@ pub fn libtheseus_hello(_args: Vec<String>) -> isize {
 #[panic_handler] // same as:  #[lang = "panic_impl"]
 fn panic_entry_point(_info: &core::panic::PanicInfo) -> ! {
     // println!("panic: {:?}", info);
-    loop { }
+    loop { core::hint::spin_loop(); }
 }
 
 /// This is the callback entry point that gets invoked when the heap allocator runs out of memory.
 #[alloc_error_handler]
 fn oom(_layout: core::alloc::Layout) -> ! {
     panic!("\n(oom) Out of Heap Memory! requested allocation: {:?}", _layout);
-    // loop { }
+    // loop { core::hint::spin_loop(); }
 }
 
 #[lang = "eh_personality"]
 #[no_mangle]
 extern "C" fn rust_eh_personality() -> ! {
     // println!("BUG: Theseus does not use rust_eh_personality. Why has it been invoked?");
-    loop { }
+    loop { core::hint::spin_loop(); }
 }
 
 #[global_allocator]

--- a/old_crates/immediate_input_echo/src/lib.rs
+++ b/old_crates/immediate_input_echo/src/lib.rs
@@ -41,6 +41,7 @@ fn run() -> Result<(), &'static str> {
         let byte_num = stdin_locked.read(&mut buf).or(Err("failed to invoke read"))?;
         if byte_num == 0 { break; }
         stdout_locked.write_all(&buf).or(Err("failed to invoke write_all"))?;
+        core::hint::spin_loop();
     }
     stdout_locked.write_all(&['\n' as u8]).or(Err("failed to invoke write_all"))?;
     Ok(())

--- a/old_crates/input_echo/src/lib.rs
+++ b/old_crates/input_echo/src/lib.rs
@@ -40,6 +40,7 @@ fn run() -> Result<(), &'static str> {
         stdout_locked.write_all(buf.as_bytes())
             .or(Err("faileld to perform write_all"))?;
         buf.clear();
+        core::hint::spin_loop();
     }
     Ok(())
 }

--- a/old_crates/keyboard_echo/src/lib.rs
+++ b/old_crates/keyboard_echo/src/lib.rs
@@ -47,6 +47,7 @@ fn run() -> Result<(), &'static str> {
             if key_event.keycode == Keycode::Q { break; }
         }
         scheduler::schedule();
+        core::hint::spin_loop();
     }
 
     Ok(())

--- a/old_crates/less/src/lib.rs
+++ b/old_crates/less/src/lib.rs
@@ -197,6 +197,7 @@ fn event_handler_loop(content: &String, map: &BTreeMap<usize, LineSlice>,
             },
             _ => {}
         }
+        core::hint::spin_loop();
     }
 }
 

--- a/ports/theseus_std/src/path.rs
+++ b/ports/theseus_std/src/path.rs
@@ -275,6 +275,7 @@ where
             (None, Some(_)) => return None,
         }
         iter = iter_next;
+        core::hint::spin_loop();
     }
 }
 

--- a/tlibc/src/stdio/printf.rs
+++ b/tlibc/src/stdio/printf.rs
@@ -534,6 +534,7 @@ impl Iterator for PrintfIter {
                     _ => break,
                 }
                 self.format = self.format.add(1);
+                core::hint::spin_loop();
             }
 
             // Width and precision:
@@ -574,6 +575,7 @@ impl Iterator for PrintfIter {
                 };
 
                 self.format = self.format.add(1);
+                core::hint::spin_loop();
             }
             let fmt = *self.format;
             let fmtkind = match fmt {

--- a/tlibc/src/string.rs
+++ b/tlibc/src/string.rs
@@ -164,6 +164,7 @@ pub unsafe extern "C" fn strcpy(dst: *mut c_char, src: *const c_char) -> *mut c_
         }
 
         i += 1;
+        core::hint::spin_loop();
     }
 
     dst
@@ -395,6 +396,7 @@ unsafe fn inner_strstr(
             }
 
             i += 1;
+            core::hint::spin_loop();
         }
 
         haystack = haystack.offset(1);


### PR DESCRIPTION
`loop{}` is basically the most expensive operation in existence. I think it would be a good idea to default to having `spin_loop()` in a `loop {}` to avoid eating 95% of CPU when you actually need just 1% of CPU