### PR TITLE
Make secondary cores usable on aarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "apic",
  "cortex-a",
  "derive_more",
+ "irq_safety",
  "tock-registers",
 ]
 

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -50,7 +50,6 @@ pub fn kstart_ap(
     nmi_lint: u8,
     nmi_flags: u16,
 ) -> ! {
-    // As a cheap precaution
     irq_safety::disable_interrupts();
 
     info!("Booting AP: proc: {}, CPU: {}, stack: {:#X} to {:#X}, nmi_lint: {}, nmi_flags: {:#X}",

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -50,13 +50,12 @@ pub fn kstart_ap(
     nmi_lint: u8,
     nmi_flags: u16,
 ) -> ! {
+    // As a cheap precaution
+    irq_safety::disable_interrupts();
+
     info!("Booting AP: proc: {}, CPU: {}, stack: {:#X} to {:#X}, nmi_lint: {}, nmi_flags: {:#X}",
         processor_id, cpu_id, _stack_start, _stack_end, nmi_lint, nmi_flags
     );
-
-    // As a cheap precaution
-    #[cfg(target_arch = "aarch64")]
-    irq_safety::disable_interrupts();
 
     // set a flag telling the BSP that this AP has entered Rust code
     AP_READY_FLAG.store(true, Ordering::SeqCst);

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -54,6 +54,10 @@ pub fn kstart_ap(
         processor_id, cpu_id, _stack_start, _stack_end, nmi_lint, nmi_flags
     );
 
+    // As a cheap precaution
+    #[cfg(target_arch = "aarch64")]
+    irq_safety::disable_interrupts();
+
     // set a flag telling the BSP that this AP has entered Rust code
     AP_READY_FLAG.store(true, Ordering::SeqCst);
 
@@ -66,14 +70,10 @@ pub fn kstart_ap(
         || panic!("BUG: kstart_ap(): couldn't get stack created for CPU {}", cpu_id)
     );
 
-    #[cfg(target_arch = "aarch64")] {
-        log::info!("cpu {} is ready!", cpu_id);
-        loop {}
-    }
-
-    // initialize interrupts (including TSS/GDT) for this AP
     let kernel_mmi_ref = get_kernel_mmi_ref().expect("kstart_ap(): kernel_mmi ref was None");
+
     #[cfg(target_arch = "x86_64")] {
+        // initialize interrupts (including TSS/GDT) for this AP
         let (double_fault_stack, privilege_stack) = {
             let mut kernel_mmi = kernel_mmi_ref.lock();
             (
@@ -85,23 +85,27 @@ pub fn kstart_ap(
         };
         let _idt = interrupts::init_ap(cpu_id, double_fault_stack.top_unusable(), privilege_stack.top_unusable())
             .expect("kstart_ap(): failed to initialize interrupts!");
+
+        // Initialize this CPU's Local APIC such that we can use everything that depends on APIC IDs.
+        // This must be done before initializing task spawning, because that relies on the ability to
+        // enable/disable preemption, which is partially implemented by the Local APIC.
+        LocalApic::init(
+            &mut kernel_mmi_ref.lock().page_table,
+            processor_id,
+            Some(cpu_id.value()),
+            false,
+            nmi_lint,
+            nmi_flags,
+        ).unwrap();
     }
 
-    #[cfg(target_arch = "aarch64")]
-    interrupts::init_ap();
+    #[cfg(target_arch = "aarch64")] {
+        interrupts::init_ap();
 
-    // Initialize this CPU's Local APIC such that we can use everything that depends on APIC IDs.
-    // This must be done before initializing task spawning, because that relies on the ability to
-    // enable/disable preemption, which is partially implemented by the Local APIC.
-    #[cfg(target_arch = "x86_64")]
-    LocalApic::init(
-        &mut kernel_mmi_ref.lock().page_table,
-        processor_id,
-        Some(cpu_id.value()),
-        false,
-        nmi_lint,
-        nmi_flags,
-    ).unwrap();
+        // Register this CPU as online in the system
+        // This is the equivalent of `LocalApic::init` on aarch64
+        cpu::register_cpu(false).unwrap();
+    }
 
     // Now that the Local APIC has been initialized for this CPU, we can initialize the
     // task management subsystem and create the idle task for this CPU.

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -112,8 +112,12 @@ pub fn init(
         interrupts::init(double_fault_stack.top_unusable(), privilege_stack.top_unusable())?
     };
 
-    #[cfg(target_arch = "aarch64")]
-    interrupts::init().unwrap();
+    #[cfg(target_arch = "aarch64")] {
+        interrupts::init().unwrap();
+
+        // register BSP CpuId
+        cpu::register_cpu(true).unwrap();
+    }
     
     // get BSP's CPU ID
     let bsp_id = cpu::bootstrap_cpu().ok_or("captain::init(): couldn't get ID of bootstrap CPU!")?;

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -113,10 +113,10 @@ pub fn init(
     };
 
     #[cfg(target_arch = "aarch64")] {
-        interrupts::init().unwrap();
+        interrupts::init()?;
 
         // register BSP CpuId
-        cpu::register_cpu(true).unwrap();
+        cpu::register_cpu(true)?;
     }
     
     // get BSP's CPU ID

--- a/kernel/cpu/Cargo.toml
+++ b/kernel/cpu/Cargo.toml
@@ -15,6 +15,7 @@ apic = { path = "../apic" }
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 tock-registers = "0.7.0"
 cortex-a = "7.5.0"
+irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/cpu/src/aarch64.rs
+++ b/kernel/cpu/src/aarch64.rs
@@ -12,12 +12,11 @@ use super::CpuId;
 // The vector of CpuIds for known and online CPU cores
 static ONLINE_CPUS: RwLockIrqSafe<Vec<CpuId>> = RwLockIrqSafe::new(Vec::new());
 
-/// This must be called once for every CPU core of the system
-/// that should be used for running tasks.
+/// This must be called once for every CPU core in the system.
 ///
 /// The first CPU to register itself is called the BSP (bootstrap processor).
 /// When it does so (from captain), it must set the `bootstrap` parameter
-/// to true. Other cores must set it to false.
+/// to `true`. Other cores must set it to `false`.
 pub fn register_cpu(bootstrap: bool) -> Result<(), &'static str> {
     let mut locked = ONLINE_CPUS.write();
 
@@ -26,12 +25,11 @@ pub fn register_cpu(bootstrap: bool) -> Result<(), &'static str> {
     if bootstrap == locked.is_empty() {
         let cpu_id = current_cpu();
 
-        if locked.contains(&cpu_id) {
-            Err("Tried to register the same CpuId twice")
-        } else {
+        if !locked.contains(&cpu_id) {
             locked.push(cpu_id);
-
             Ok(())
+        } else {
+            Err("Tried to register the same CpuId twice")
         }
     } else {
         match bootstrap {

--- a/kernel/cpu/src/aarch64.rs
+++ b/kernel/cpu/src/aarch64.rs
@@ -10,7 +10,7 @@ use alloc::vec::Vec;
 use super::CpuId;
 
 // The vector of CpuIds for known and online CPU cores
-static ONLINE_CORES: RwLockIrqSafe<Vec<CpuId>> = RwLockIrqSafe::new(Vec::new());
+static ONLINE_CPUS: RwLockIrqSafe<Vec<CpuId>> = RwLockIrqSafe::new(Vec::new());
 
 /// This must be called once for every CPU core of the system
 /// that should be used for running tasks.
@@ -19,7 +19,7 @@ static ONLINE_CORES: RwLockIrqSafe<Vec<CpuId>> = RwLockIrqSafe::new(Vec::new());
 /// When it does so (from captain), it must set the `bootstrap` parameter
 /// to true. Other cores must set it to false.
 pub fn register_cpu(bootstrap: bool) -> Result<(), &'static str> {
-    let mut locked = ONLINE_CORES.write();
+    let mut locked = ONLINE_CPUS.write();
 
     // the vector must be empty when the bootstrap
     // processor registers itself.
@@ -44,13 +44,13 @@ pub fn register_cpu(bootstrap: bool) -> Result<(), &'static str> {
 /// Returns the number of CPUs (SMP cores) that exist and
 /// are currently initialized on this system.
 pub fn cpu_count() -> u32 {
-    ONLINE_CORES.read().len() as u32
+    ONLINE_CPUS.read().len() as u32
 }
 
 /// Returns the ID of the bootstrap CPU (if known), which
 /// is the first CPU to run after system power-on.
 pub fn bootstrap_cpu() -> Option<CpuId> {
-    ONLINE_CORES.read().first().copied()
+    ONLINE_CPUS.read().first().copied()
 }
 
 /// Returns true if the currently executing CPU is the bootstrap

--- a/kernel/cpu/src/aarch64.rs
+++ b/kernel/cpu/src/aarch64.rs
@@ -2,32 +2,61 @@
 
 use cortex_a::registers::MPIDR_EL1;
 use tock_registers::interfaces::Readable;
-
-use core::fmt;
-use super::CpuId;
 use derive_more::{Display, Binary, Octal, LowerHex, UpperHex};
+use irq_safety::RwLockIrqSafe;
+use core::fmt;
+use alloc::vec::Vec;
+
+use super::CpuId;
+
+// The vector of CpuIds for known and online CPU cores
+static ONLINE_CORES: RwLockIrqSafe<Vec<CpuId>> = RwLockIrqSafe::new(Vec::new());
+
+/// This must be called once for every CPU core of the system
+/// that should be used for running tasks.
+///
+/// The first CPU to register itself is called the BSP (bootstrap processor).
+/// When it does so (from captain), it must set the `bootstrap` parameter
+/// to true. Other cores must set it to false.
+pub fn register_cpu(bootstrap: bool) -> Result<(), &'static str> {
+    let mut locked = ONLINE_CORES.write();
+
+    // the vector must be empty when the bootstrap
+    // processor registers itself.
+    if bootstrap == locked.is_empty() {
+        let cpu_id = current_cpu();
+
+        if locked.contains(&cpu_id) {
+            Err("Tried to register the same CpuId twice")
+        } else {
+            locked.push(cpu_id);
+
+            Ok(())
+        }
+    } else {
+        match bootstrap {
+            true  => Err("Tried to register the BSP after another core: invalid"),
+            false => Err("Tried to register a secondary CPU before the BSP: invalid"),
+        }
+    }
+}
 
 /// Returns the number of CPUs (SMP cores) that exist and
 /// are currently initialized on this system.
 pub fn cpu_count() -> u32 {
-    // The ARM port doesn't start secondary cores for the moment.
-    1
+    ONLINE_CORES.read().len() as u32
 }
 
 /// Returns the ID of the bootstrap CPU (if known), which
 /// is the first CPU to run after system power-on.
 pub fn bootstrap_cpu() -> Option<CpuId> {
-    // The ARM port doesn't start secondary cores for the moment,
-    // so the current CPU can only be the "bootstrap" CPU.
-    Some(current_cpu())
+    ONLINE_CORES.read().first().copied()
 }
 
 /// Returns true if the currently executing CPU is the bootstrap
 /// CPU, i.e., the first CPU to run after system power-on.
 pub fn is_bootstrap_cpu() -> bool {
-    // The ARM port doesn't start secondary cores for the moment,
-    // so the current CPU can only be the "bootstrap" CPU.
-    true
+    Some(current_cpu()) == bootstrap_cpu()
 }
 
 /// Returns the ID of the currently executing CPU.

--- a/kernel/cpu/src/lib.rs
+++ b/kernel/cpu/src/lib.rs
@@ -10,6 +10,9 @@
 
 #![no_std]
 
+#[cfg(target_arch = "aarch64")]
+extern crate alloc;
+
 #[cfg_attr(target_arch = "x86_64", path = "x86_64.rs")]
 #[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
 mod arch;

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -125,7 +125,7 @@ pub fn init_ap() {
 
     // Enable the CPU-local timer
     let mut gic = GIC.lock();
-    let gic = gic.as_mut().expect("GIC is uninitialized");
+    let gic = gic.as_mut().expect("BUG: init_ap(): GIC was uninitialized");
     gic.set_interrupt_state(CPU_LOCAL_TIMER_IRQ, true);
 
     enable_timer(true);
@@ -274,7 +274,7 @@ pub fn deregister_interrupt(irq_num: InterruptNumber, func: HandlerFunc) -> Resu
 /// the given interrupt request `irq` has been serviced.
 pub fn eoi(irq_num: InterruptNumber) {
     let mut gic = GIC.lock();
-    let gic = gic.as_mut().expect("GIC is uninitialized");
+    let gic = gic.as_mut().expect("BUG: eoi(): GIC was uninitialized");
     gic.end_of_interrupt(irq_num);
 }
 

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -119,8 +119,16 @@ fn set_vbar_el1() {
 }
 
 /// Sets `VBAR_EL1` to the start of the exception vector
+/// and enables timer interrupts
 pub fn init_ap() {
     set_vbar_el1();
+
+    // Enable the CPU-local timer
+    let mut gic = GIC.lock();
+    let gic = gic.as_mut().expect("GIC is uninitialized");
+    gic.set_interrupt_state(CPU_LOCAL_TIMER_IRQ, true);
+
+    enable_timer(true);
 }
 
 /// Please call this (only once) before using this crate.


### PR DESCRIPTION
Little PR implementing the storage of online CpuIds, enabling further boot of secondary CPUs.
Another change is that the CPU-local timer is also configured for these cores now.