### PR TITLE
Use `spin` in `sync`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3558,6 +3558,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "git+https://github.com/mvdnes/spin-rs#1f2e06c9f9d22b234776849c65e313f583ddfade"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin#e006c79280042e27c4f16c7d29633eb2273752ee"
@@ -3699,6 +3704,9 @@ dependencies = [
 [[package]]
 name = "sync"
 version = "0.1.0"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "sync_block"

--- a/kernel/sync_block/src/lib.rs
+++ b/kernel/sync_block/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(negative_impls)]
 #![no_std]
 
-use sync::{mutex, Flavour};
+use sync::{spin, Flavour};
 use wait_queue::WaitQueue;
 
 pub type Mutex<T> = sync::Mutex<T, Block>;
@@ -22,17 +22,17 @@ impl Flavour for Block {
 
     #[inline]
     fn try_lock_mutex<'a, T>(
-        mutex: &'a mutex::SpinMutex<T>,
+        mutex: &'a spin::Mutex<T>,
         _: &'a Self::LockData,
-    ) -> Option<(mutex::SpinMutexGuard<'a, T>, Self::Guard)> {
+    ) -> Option<(spin::MutexGuard<'a, T>, Self::Guard)> {
         mutex.try_lock().map(|guard| (guard, ()))
     }
 
     #[inline]
     fn lock_mutex<'a, T>(
-        mutex: &'a mutex::SpinMutex<T>,
+        mutex: &'a spin::Mutex<T>,
         data: &'a Self::LockData,
-    ) -> (mutex::SpinMutexGuard<'a, T>, Self::Guard) {
+    ) -> (spin::MutexGuard<'a, T>, Self::Guard) {
         // This must be a strong compare exchange, otherwise we could block ourselves
         // when the mutex is unlocked and never be unblocked.
         if let Some(guards) = Self::try_lock_mutex(mutex, data) {

--- a/libs/sync/Cargo.toml
+++ b/libs/sync/Cargo.toml
@@ -3,3 +3,9 @@ name = "sync"
 version = "0.1.0"
 description = "Synchronisation primitive building blocks"
 edition = "2021"
+
+[dependencies.spin_rs]
+package = "spin"
+git = "https://github.com/mvdnes/spin-rs"
+default-features = false
+features = ["spin_mutex", "rwlock"]

--- a/libs/sync/src/mutex.rs
+++ b/libs/sync/src/mutex.rs
@@ -1,10 +1,8 @@
-use crate::Flavour;
+use crate::{spin, Flavour};
 use core::{
-    cell::UnsafeCell,
     fmt,
     mem::ManuallyDrop,
     ops::{Deref, DerefMut},
-    sync::atomic::{AtomicBool, Ordering},
 };
 
 /// A mutual exclusion primitive.
@@ -12,7 +10,7 @@ pub struct Mutex<T, F>
 where
     F: Flavour,
 {
-    inner: SpinMutex<T>,
+    inner: spin::Mutex<T>,
     data: F::LockData,
 }
 
@@ -24,7 +22,7 @@ where
     #[inline]
     pub const fn new(value: T) -> Self {
         Self {
-            inner: SpinMutex::new(value),
+            inner: spin::Mutex::new(value),
             data: F::INIT,
         }
     }
@@ -105,7 +103,7 @@ pub struct MutexGuard<'a, T, F>
 where
     F: Flavour,
 {
-    inner: ManuallyDrop<SpinMutexGuard<'a, T>>,
+    inner: ManuallyDrop<spin::MutexGuard<'a, T>>,
     data: &'a F::LockData,
     _guard: F::Guard,
 }
@@ -142,140 +140,3 @@ where
         F::post_unlock(self.data);
     }
 }
-
-// Types below are copied from spin except that try_lock_weak is exposed.
-
-pub struct SpinMutex<T>
-where
-    T: ?Sized,
-{
-    lock: AtomicBool,
-    data: UnsafeCell<T>,
-}
-
-impl<T> SpinMutex<T> {
-    #[inline]
-    pub const fn new(data: T) -> Self {
-        Self {
-            lock: AtomicBool::new(false),
-            data: UnsafeCell::new(data),
-        }
-    }
-
-    #[inline]
-    pub fn get_mut(&mut self) -> &mut T {
-        self.data.get_mut()
-    }
-
-    #[inline]
-    pub fn into_inner(self) -> T
-    where
-        T: Sized,
-    {
-        self.data.into_inner()
-    }
-
-    #[inline]
-    pub fn is_locked(&self) -> bool {
-        self.lock.load(Ordering::Relaxed)
-    }
-
-    #[inline]
-    pub fn try_lock(&self) -> Option<SpinMutexGuard<'_, T>> {
-        self.lock
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .ok()?;
-
-        Some(unsafe { self.guard() })
-    }
-
-    #[inline]
-    pub fn try_lock_weak(&self) -> Option<SpinMutexGuard<'_, T>> {
-        self.lock
-            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .ok()?;
-
-        Some(unsafe { self.guard() })
-    }
-
-    #[inline]
-    unsafe fn guard(&self) -> SpinMutexGuard<'_, T> {
-        SpinMutexGuard {
-            lock: &self.lock,
-            data: unsafe { &mut *self.data.get() },
-        }
-    }
-}
-
-impl<T> fmt::Debug for SpinMutex<T>
-where
-    T: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut d = f.debug_struct("SpinMutex");
-        match self.try_lock() {
-            Some(guard) => {
-                d.field("data", &&*guard);
-            }
-            None => {
-                struct LockedPlaceholder;
-                impl fmt::Debug for LockedPlaceholder {
-                    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                        f.write_str("<locked>")
-                    }
-                }
-                d.field("data", &LockedPlaceholder);
-            }
-        }
-        d.finish_non_exhaustive()
-    }
-}
-
-#[derive(Debug)]
-pub struct SpinMutexGuard<'a, T>
-where
-    T: ?Sized,
-{
-    lock: &'a AtomicBool,
-    data: *mut T,
-}
-
-impl<'a, T> Deref for SpinMutexGuard<'a, T>
-where
-    T: ?Sized,
-{
-    type Target = T;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.data }
-    }
-}
-
-impl<'a, T> DerefMut for SpinMutexGuard<'a, T>
-where
-    T: ?Sized,
-{
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.data }
-    }
-}
-
-impl<'a, T> Drop for SpinMutexGuard<'a, T>
-where
-    T: ?Sized,
-{
-    #[inline]
-    fn drop(&mut self) {
-        self.lock.store(false, Ordering::Release);
-    }
-}
-
-// Same unsafe impls as `std::sync::Mutex`.
-
-unsafe impl<T: ?Sized + Send> Sync for SpinMutex<T> {}
-unsafe impl<T: ?Sized + Send> Send for SpinMutex<T> {}
-
-unsafe impl<T: ?Sized + Sync> Sync for SpinMutexGuard<'_, T> {}
-unsafe impl<T: ?Sized + Send> Send for SpinMutexGuard<'_, T> {}


### PR DESCRIPTION
Recent upstream changes expose the `try_lock_weak` function on `spin`'s mutexes allowing us to use them in our implementation.