### PR TITLE
Buffer early log messages for future display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -963,6 +963,11 @@ gdb:
 		-ex "symbol-file $(DEBUG_SYMBOLS_DIR)/`basename $(nano_core_binary)`.dbg" \
 		-ex "target remote :1234"
 
+gdb_aarch64 : override nano_core_binary=$(NANO_CORE_BUILD_DIR)/nano_core-aarch64.bin
+gdb_aarch64:
+	@gdb-multiarch "$(nano_core_binary)" \
+		-ex "symbol-file $(DEBUG_SYMBOLS_DIR)/`basename $(nano_core_binary)`.dbg" \
+		-ex "target remote :1234"
 
 
 ### builds and runs Theseus in Bochs

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -84,7 +84,7 @@ pub fn init(key_producer: Queue<Event>, mouse_producer: Queue<Event>) -> Result<
             .map(|sp_addr| serial_port::init_serial_port(sp_addr, sp))
         ).cloned();
 
-    logger::init(None, logger_writers).map_err(|_e| "BUG: logger::init() failed")?;
+    logger::init(None, logger_writers);
     info!("Initialized full logger.");
 
     // Ensure that both COM1 and COM2 are initialized, for logging and/or headless operation.

--- a/kernel/logger/src/lib.rs
+++ b/kernel/logger/src/lib.rs
@@ -96,11 +96,11 @@ impl<const SIZE: usize> LoggerBuffer<SIZE> {
     /// to an empty buffer.
     pub fn try_flush(&mut self) -> Result<(), &'static str> {
         let as_str = from_utf8(&self.array[..self.length])
-            .unwrap_or("[Invalid UTF8 in log message]");
+            .unwrap_or("[Invalid UTF8 in log message]\r\n");
 
         DUMMY_LOGGER.try_write_fmt(format_args!("{}", as_str))?;
         if self.truncated {
-            let msg = "[log output was truncated; try increasing BUFSIZE]";
+            let msg = "[log output was truncated; try increasing BUFSIZE]\r\n";
             DUMMY_LOGGER.try_write_fmt(format_args!("{}", msg))?;
         }
 

--- a/kernel/logger/src/lib.rs
+++ b/kernel/logger/src/lib.rs
@@ -98,10 +98,10 @@ impl<const SIZE: usize> LoggerBuffer<SIZE> {
         let as_str = from_utf8(&self.array[..self.length])
             .unwrap_or("[Invalid UTF8 in log message]\r\n");
 
-        DUMMY_LOGGER.try_write_fmt(format_args!("{}", as_str))?;
+        DUMMY_LOGGER.try_write_fmt(format_args!("{as_str}"))?;
         if self.truncated {
             let msg = "[log output was truncated; try increasing BUFSIZE]\r\n";
-            DUMMY_LOGGER.try_write_fmt(format_args!("{}", msg))?;
+            DUMMY_LOGGER.try_write_fmt(format_args!("{msg}"))?;
         }
 
         self.length = 0;
@@ -184,10 +184,10 @@ impl<const BUFSIZE: usize> DummyLogger<BUFSIZE> {
     /// otherwise, it falls back to writing to the [`EARLY_LOGGER`] instead.
     /// If none of these is available, the message is written to the internal buffer.
     fn write_fmt(&self, arguments: fmt::Arguments) -> fmt::Result {
-        if let Err(_) = self.try_write_fmt(arguments) {
+        if self.try_write_fmt(arguments).is_err() {
             let mut buffer = self.buffer.lock();
             let length_backup = buffer.length;
-            if let Err(_) = buffer.write_fmt(arguments) {
+            if buffer.write_fmt(arguments).is_err() {
                 buffer.truncate(length_backup);
             }
         }

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -130,8 +130,8 @@ where
     #[cfg(target_arch = "aarch64")] {
         let logger_ports = [take_serial_port(SerialPortAddress::COM1)];
         logger::early_init(None, IntoIterator::into_iter(logger_ports).flatten());
-        log::info!("initialized early logger");
-        println!("nano_core(): initialized early logger.");
+        log::info!("initialized early logger with aarch64 serial ports.");
+        println!("nano_core(): initialized early logger  with aarch64 serial ports.");
     }
 
     println!("nano_core(): initialized memory subsystem.");


### PR DESCRIPTION
This adds an internal buffer to `DummyLogger`, allowing very early aarch64 log messages to be preserved.
I set the buffer sizes to 0 on x86_64 & 16384 on aarch64, after testing lower values (note: I only tested powers of two).
If the buffer is too little, this appears in the log:
```
... (buffered log messages)
[log output was truncated; try increasing BUFSIZE]
... (post-logger update log messages)
```

From Kevin:
* add a aarch64 GDB command to the Makefile
* make logger::init functions infallible
* clarify truncated message