### PR TITLE
GIC driver fixes & improvements

### DIFF
--- a/kernel/gic/src/gic/dist_interface.rs
+++ b/kernel/gic/src/gic/dist_interface.rs
@@ -184,7 +184,7 @@ impl super::ArmGic {
                 } else {
                     let mpidr = reg & 0xff00ffffff;
                     let cpu_id = MpidrValue::try_from(mpidr)?.into();
-                    return Ok(SpiDestination::Specific(cpu_id));
+                    Ok(SpiDestination::Specific(cpu_id))
                 }
             }
         }

--- a/kernel/gic/src/gic/dist_interface.rs
+++ b/kernel/gic/src/gic/dist_interface.rs
@@ -221,10 +221,10 @@ impl super::ArmGic {
             };
 
             v3.dist_extended.write_volatile_64(offset::P6IROUTER, value);
+        } else {
+            // If we're on gicv2 then affinity routing is off
+            // so we landed in the first block
+            unreachable!()
         }
-
-        // If we're on gicv2 then affinity routing is off
-        // so we landed in the first block
-        unreachable!()
     }
 }

--- a/kernel/gic/src/gic/dist_interface.rs
+++ b/kernel/gic/src/gic/dist_interface.rs
@@ -203,7 +203,7 @@ impl super::ArmGic {
                     SpiDestination::Specific(cpu) => 1 << cpu.value(),
                     SpiDestination::AnyCpuAvailable => {
                         let list = TargetList::new_all_cpus()
-                            .expect("This is invalid: CpuId > 8 AND GICv2 interrupt controller");
+                            .expect("This is invalid: CpuId > 8 AND affinity routing is disabled");
                         list.0 as u32
                     },
                     SpiDestination::GICv2TargetList(list) => list.0 as u32,
@@ -218,7 +218,7 @@ impl super::ArmGic {
                     // value of 1 to target any available cpu
                     SpiDestination::AnyCpuAvailable => P6IROUTER_ANY_AVAILABLE_PE,
                     SpiDestination::GICv2TargetList(_) => {
-                        panic!("Cannot use SpiDestination::GICv2TargetList with GICv3!");
+                        panic!("Cannot use SpiDestination::GICv2TargetList with affinity routing enabled");
                     },
                 };
 

--- a/kernel/gic/src/gic/mod.rs
+++ b/kernel/gic/src/gic/mod.rs
@@ -338,6 +338,13 @@ impl ArmGic {
         }
     }
 
+    pub fn init_secondary_cpu_interface(&mut self) {
+        match self {
+            Self::V2(v2) => cpu_interface_gicv2::init(v2.processor.as_mut()),
+            Self::V3( _) => cpu_interface_gicv3::init(),
+        }
+    }
+
     fn affinity_routing(&self) -> Enabled {
         match self {
             Self::V2( _) => false,

--- a/kernel/gic/src/gic/mod.rs
+++ b/kernel/gic/src/gic/mod.rs
@@ -345,13 +345,6 @@ impl ArmGic {
         }
     }
 
-    fn affinity_routing(&self) -> Enabled {
-        match self {
-            Self::V2( _) => false,
-            Self::V3(v3) => v3.affinity_routing,
-        }
-    }
-
     /// Sends an inter processor interrupt (IPI),
     /// also called software generated interrupt (SGI).
     ///

--- a/kernel/gic/src/gic/mod.rs
+++ b/kernel/gic/src/gic/mod.rs
@@ -79,6 +79,7 @@ impl Iterator for TargetListIterator {
 }
 
 /// Target of a shared-peripheral interrupt
+#[derive(Copy, Clone, Debug)]
 pub enum SpiDestination {
     /// The interrupt must be delivered to a specific CPU.
     Specific(CpuId),
@@ -90,6 +91,7 @@ pub enum SpiDestination {
 }
 
 /// Target of an inter-processor interrupt
+#[derive(Copy, Clone, Debug)]
 pub enum IpiTargetCpu {
     /// The interrupt will be delivered to a specific CPU.
     Specific(CpuId),

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -134,7 +134,10 @@ pub fn init_ap() {
     // Enable the CPU-local timer
     let mut int_ctrl = INTERRUPT_CONTROLLER.lock();
     let int_ctrl = int_ctrl.as_mut().expect("BUG: init_ap(): INTERRUPT_CONTROLLER was uninitialized");
+    int_ctrl.init_secondary_cpu_interface();
     int_ctrl.set_interrupt_state(CPU_LOCAL_TIMER_IRQ, true);
+    int_ctrl.set_interrupt_state(TLB_SHOOTDOWN_IPI, true);
+    int_ctrl.set_minimum_priority(0);
 
     enable_timer(true);
 }
@@ -171,6 +174,7 @@ pub fn init() -> Result<(), &'static str> {
                 )?;
 
                 inner.set_minimum_priority(0);
+                inner.set_interrupt_state(TLB_SHOOTDOWN_IPI, true);
                 *int_ctrl = Some(inner);
             },
         }


### PR DESCRIPTION
- Implement `ArmGic::{get_interrupt_priority, set_interrupt_priority}`
- Implement Copy, Clone & Debug for SpiDestination & IpiTargetCpu
- Fix obvious execution flow issue in `ArmGic::set_spi_target` (method had never been tested)
- Fix GIC configuration for TLB Shootdown IPIs (initialize CPU interface for secondary cores + actually enable the interrupt for the BSP)