### PR TITLE
Macro-based cross platform interrupt handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,7 +3338,6 @@ dependencies = [
  "log",
  "serial_port_basic",
  "spin 0.9.4",
- "x86_64",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,6 @@ dependencies = [
  "scheduler",
  "spawn",
  "task",
- "x86_64",
 ]
 
 [[package]]
@@ -1673,7 +1672,6 @@ dependencies = [
  "spin 0.9.4",
  "virtual_nic",
  "volatile 0.2.7",
- "x86_64",
  "zerocopy",
 ]
 

--- a/kernel/deferred_interrupt_tasks/Cargo.toml
+++ b/kernel/deferred_interrupt_tasks/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 
 [dependencies]
 log = "0.4.8"
-x86_64 = "0.14.8"
 
 [dependencies.task]
 path = "../task"

--- a/kernel/deferred_interrupt_tasks/src/lib.rs
+++ b/kernel/deferred_interrupt_tasks/src/lib.rs
@@ -48,7 +48,6 @@
 
 extern crate alloc;
 #[macro_use] extern crate log;
-extern crate x86_64;
 extern crate task;
 extern crate spawn;
 extern crate scheduler;
@@ -57,9 +56,7 @@ extern crate interrupts;
 
 use alloc::string::String;
 use task::{get_my_current_task, JoinableTaskRef};
-
-pub type InterruptHandlerFunction = x86_64::structures::idt::HandlerFunc;
-
+use interrupts::InterruptHandler;
 
 /// The errors that may occur in [`register_interrupt_handler()`].
 #[derive(Debug)]
@@ -109,7 +106,7 @@ pub enum InterruptRegistrationError {
 /// * `Err(existing_handler_address)` if the given `interrupt_number` was already in use.
 pub fn register_interrupt_handler<DIA, Arg, Success, Failure, S>(
     interrupt_number: u8,
-    interrupt_handler: InterruptHandlerFunction,
+    interrupt_handler: InterruptHandler,
     deferred_interrupt_action: DIA,
     deferred_action_argument: Arg,
     deferred_task_name: Option<S>,

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -456,7 +456,7 @@ extern "C" fn current_elx_irq(exc: &mut ExceptionContext) {
         false => default_irq_handler,
     };
 
-    if handler(exc) == EoiBehaviour::CallerMustSignalEoi {
+    if handler(exc) == EoiBehaviour::HandlerDidNotSendEoi {
         // handler has returned, we can lock again
         let mut int_ctrl = INTERRUPT_CONTROLLER.lock();
         int_ctrl.as_mut().unwrap().end_of_interrupt(irq_num);

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -57,9 +57,10 @@ struct EsrEL1(InMemoryRegister<u64, ESR_EL1::Register>);
 
 #[cfg(target_arch = "aarch64")]
 #[macro_export]
+#[doc = include_str!("../macro-doc.md")]
 macro_rules! interrupt_handler {
-    ($name:ident, $x86_64_interrupt_number:expr, $context:ident, $code:block) => {
-        extern "C" fn $name($context: &$crate::InterruptStackFrame) -> $crate::EoiBehaviour $code
+    ($name:ident, $x86_64_eoi_param:expr, $stack_frame:ident, $code:block) => {
+        extern "C" fn $name($stack_frame: &$crate::InterruptStackFrame) -> $crate::EoiBehaviour $code
     }
 }
 

--- a/kernel/interrupts/src/lib.rs
+++ b/kernel/interrupts/src/lib.rs
@@ -9,3 +9,10 @@
 mod arch;
 
 pub use arch::*;
+
+#[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
+pub enum EoiBehaviour {
+    CallerMustSignalEoi,
+    HandlerHasSignaledEoi,
+}

--- a/kernel/interrupts/src/lib.rs
+++ b/kernel/interrupts/src/lib.rs
@@ -13,6 +13,10 @@ pub use arch::*;
 #[derive(Debug, PartialEq, Eq)]
 #[repr(C)]
 pub enum EoiBehaviour {
-    CallerMustSignalEoi,
-    HandlerHasSignaledEoi,
+    /// The interrupt handler hasn't called the [`eoi`] function,
+    /// in which case it will be called automatically once the
+    /// handler returns.
+    HandlerDidNotSendEoi,
+    /// The interrupt handler has called the [`eoi`] function.
+    HandlerSentEoi,
 }

--- a/kernel/interrupts/src/macro-doc.md
+++ b/kernel/interrupts/src/macro-doc.md
@@ -1,0 +1,54 @@
+Macro which helps writing cross-platform interrupt handlers.
+
+# Arguments
+
+- `$name`: the name of the function
+- `$x86_64_eoi_param`: `Some(irq_num)` if this interrupt can be handled while
+  the PIC chip is active and the handler returns `HandlerDidNotSendEoi`; `None` otherwise.
+  Ignored on `aarch64`. See [`eoi`] for more information. If the IRQ number isn't
+  constant and this interrupt can happen with the PIC chip active, call [`eoi`]
+  manually as in Example 2.
+- `$stack_frame`: Name for the [`InterruptStackFrame`] parameter.
+- `$code`: The code for the interrupt handler itself. It must return an [`crate::EoiBehaviour`] enum.
+
+# Example 1
+
+This simply logs the stack frame to the console.
+
+```ignore
+interrupt_handler!(my_int_0x29_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x9), stack_frame, {
+    trace!("my_int_0x29_handler running! stack frame: {:?}", stack_frame);
+
+    // loop {}
+
+    EoiBehaviour::HandlerDidNotSendEoi
+});
+```
+
+# Example 2
+
+Here's how [`eoi`] can be called manually. Note how we can pass `None` as
+`$x86_64_eoi_param`, since we call [`eoi`] in the handler.
+
+```ignore
+interrupt_handler!(my_int_0x29_handler, None, stack_frame, {
+    trace!("my_int_0x29_handler running! stack frame: {:?}", stack_frame);
+
+    #[cfg(target_arch = "x86_64")]
+    let irq_num = 0x29;
+
+    #[cfg(target_arch = "aarch64")]
+    let irq_num = 0x29;
+
+    // Calling `eoi` manually:
+    {
+        #[cfg(target_arch = "x86_64")]
+        eoi(Some(irq_num));
+
+        #[cfg(target_arch = "aarch64")]
+        eoi(irq_num);
+    }
+
+    EoiBehaviour::HandlerSentEoi
+});
+```

--- a/kernel/interrupts/src/x86_64/mod.rs
+++ b/kernel/interrupts/src/x86_64/mod.rs
@@ -37,7 +37,7 @@ macro_rules! interrupt_handler {
     ($name:ident, $x86_64_interrupt_number:expr, $stack_frame:ident, $code:block) => {
         extern "x86-interrupt" fn $name(sf: $crate::InterruptStackFrame) {
             let $stack_frame = &sf;
-            if let CallerMustSignalEoi = $code {
+            if let $crate::EoiBehavior::CallerMustSignalEoi = $code {
                 $crate::eoi($x86_64_interrupt_number);
             }
         }

--- a/kernel/interrupts/src/x86_64/mod.rs
+++ b/kernel/interrupts/src/x86_64/mod.rs
@@ -37,7 +37,7 @@ macro_rules! interrupt_handler {
     ($name:ident, $x86_64_interrupt_number:expr, $stack_frame:ident, $code:block) => {
         extern "x86-interrupt" fn $name(sf: $crate::InterruptStackFrame) {
             let $stack_frame = &sf;
-            if let $crate::EoiBehavior::CallerMustSignalEoi = $code {
+            if let $crate::EoiBehavior::HandlerDidNotSendEoi = $code {
                 $crate::eoi($x86_64_interrupt_number);
             }
         }

--- a/kernel/interrupts/src/x86_64/mod.rs
+++ b/kernel/interrupts/src/x86_64/mod.rs
@@ -33,12 +33,13 @@ static RESERVED_IRQ_LIST: [u8; 3] = [
 
 
 #[macro_export]
+#[doc = include_str!("../macro-doc.md")]
 macro_rules! interrupt_handler {
-    ($name:ident, $x86_64_interrupt_number:expr, $stack_frame:ident, $code:block) => {
+    ($name:ident, $x86_64_eoi_param:expr, $stack_frame:ident, $code:block) => {
         extern "x86-interrupt" fn $name(sf: $crate::InterruptStackFrame) {
             let $stack_frame = &sf;
             if let $crate::EoiBehaviour::HandlerDidNotSendEoi = $code {
-                $crate::eoi($x86_64_interrupt_number);
+                $crate::eoi($x86_64_eoi_param);
             }
         }
     }

--- a/kernel/ixgbe/Cargo.toml
+++ b/kernel/ixgbe/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["Ramla <ijazramla@gmail.com>"]
 [dependencies]
 spin = "0.9.4"
 volatile = "0.2.4"
-x86_64 = "0.14.8"
 bit_field = "0.7.0"
 zerocopy = "0.5.0"
 mpmc = "0.1.6"

--- a/kernel/ixgbe/src/lib.rs
+++ b/kernel/ixgbe/src/lib.rs
@@ -21,7 +21,6 @@ extern crate pci;
 extern crate pit_clock_basic;
 extern crate bit_field;
 extern crate interrupts;
-extern crate x86_64;
 extern crate pic;
 extern crate acpi;
 extern crate volatile;
@@ -57,8 +56,7 @@ use irq_safety::MutexIrqSafe;
 use memory::{PhysicalAddress, MappedPages, Mutable, BorrowedSliceMappedPages, BorrowedMappedPages};
 use pci::{PciDevice, MSIX_CAPABILITY, PciConfigSpaceAccessMechanism, PciLocation};
 use bit_field::BitField;
-use interrupts::register_msi_interrupt;
-use x86_64::structures::idt::HandlerFunc;
+use interrupts::{register_msi_interrupt, InterruptHandler};
 use hpet::get_hpet;
 use network_interface_card::NetworkInterfaceCard;
 use nic_initialization::*;
@@ -262,7 +260,7 @@ impl IxgbeNic {
         ixgbe_pci_dev: &PciDevice,
         dev_id: PciLocation,
         enable_virtualization: bool,
-        interrupts: Option<Vec<HandlerFunc>>,
+        interrupts: Option<Vec<InterruptHandler>>,
         enable_rss: bool,
         rx_buffer_size_kbytes: RxBufferSizeKiB,
         num_rx_descriptors: u16,
@@ -1132,7 +1130,7 @@ impl IxgbeNic {
         regs: &mut IntelIxgbeRegisters1, 
         rxq: &mut Vec<RxQueue<IxgbeRxQueueRegisters,AdvancedRxDescriptor>>, 
         vector_table: &mut MsixVectorTable, 
-        interrupt_handlers: &[HandlerFunc]
+        interrupt_handlers: &[InterruptHandler]
     ) -> Result<HashMap<u8,u8>, &'static str> {
 
         let num_msi_vec_enabled = interrupt_handlers.len();

--- a/kernel/rtc/src/lib.rs
+++ b/kernel/rtc/src/lib.rs
@@ -49,11 +49,11 @@ pub type RtcInterruptFunction = fn(Option<usize>);
 // /// and the given closure that will run on each RTC interrupt.
 // /// The closure is provided with the current number of RTC ticks since boot,
 // /// in the form of an `Option<usize>` because it is not guaranteed that the number of ticks can be retrieved.
-// pub fn init(rtc_freq: usize, interrupt_func: RtcInterruptFunction) -> Result<(HandlerFunc), ()> {
+// pub fn init(rtc_freq: usize, interrupt_func: RtcInterruptFunction) -> Result<(InterruptHandler), ()> {
 //     RTC_INTERRUPT_FUNC.call_once(|| interrupt_func);
 //     enable_rtc_interrupt();
 //     let res = set_rtc_frequency(rtc_freq);
-//     res.map( |_| rtc_interrupt_handler as HandlerFunc )
+//     res.map( |_| rtc_interrupt_handler as InterruptHandler )
 // }
 
 

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -60,7 +60,7 @@ pub fn init() -> Result<(), &'static str> {
     }
 }
 
-// Cross platform scheduling code
+// Architecture-independent timer interrupt handler for preemptive scheduling.
 interrupt_handler!(timer_tick_handler, None, _stack_frame, {
     #[cfg(target_arch = "aarch64")]
     interrupts::schedule_next_timer_tick();

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -89,7 +89,7 @@ interrupt_handler!(timer_tick_handler, None, _stack_frame, {
 
     schedule();
 
-    EoiBehaviour::HandlerHasSignaledEoi
+    EoiBehaviour::HandlerSentEoi
 });
 
 /// Changes the priority of the given task with the given priority level.

--- a/kernel/serial_port/Cargo.toml
+++ b/kernel/serial_port/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 log = "0.4.8"
 spin = "0.9.4"
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
-x86_64 = "0.14.8"
 
 [dependencies.serial_port_basic]
 path = "../serial_port_basic"

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -378,7 +378,7 @@ interrupt_handler!(com1_com3_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET
     if let Some(func) = INTERRUPT_ACTION_COM1_COM3.get() {
         func()
     }
-    EoiBehaviour::CallerMustSignalEoi
+    EoiBehaviour::HandlerDidNotSendEoi
 });
 
 // IRQ 0x23: COM2 and COM4 serial port interrupt handler.
@@ -387,5 +387,5 @@ interrupt_handler!(com2_com4_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET
     if let Some(func) = INTERRUPT_ACTION_COM2_COM4.get() {
         func()
     }
-    EoiBehaviour::CallerMustSignalEoi
+    EoiBehaviour::HandlerDidNotSendEoi
 });

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -36,7 +36,7 @@ use alloc::{boxed::Box, sync::Arc};
 use core::{convert::TryFrom, fmt, ops::{Deref, DerefMut}};
 use irq_safety::MutexIrqSafe;
 use spin::Once;
-use interrupts::{HandlerFunc, EoiBehaviour, interrupt_handler};
+use interrupts::{InterruptHandler, EoiBehaviour, interrupt_handler};
 
 // Dependencies below here are temporary and will be removed
 // after we have support for separate interrupt handling tasks.
@@ -107,7 +107,7 @@ fn static_port_of(
 /// and the interrupt handler function for this serial port.
 fn interrupt_number_handler(
     serial_port_address: &SerialPortAddress
-) -> (u8, HandlerFunc) {
+) -> (u8, InterruptHandler) {
     use interrupts::IRQ_BASE_OFFSET;
     match serial_port_address {
         SerialPortAddress::COM1 | SerialPortAddress::COM3 => (IRQ_BASE_OFFSET + 0x04, com1_com3_interrupt_handler),
@@ -156,7 +156,7 @@ impl SerialPort {
     pub fn register_interrupt_handler(
         serial_port: Arc<MutexIrqSafe<SerialPort>>,
         interrupt_number: u8,
-        interrupt_handler: HandlerFunc,
+        interrupt_handler: InterruptHandler,
     ) -> Result<(), &'static str> {
         let base_port = { 
             let sp = serial_port.lock();

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -375,13 +375,17 @@ static INTERRUPT_ACTION_COM2_COM4: Once<Box<dyn Fn() + Send + Sync>> = Once::new
 // IRQ 0x24: COM1 and COM3 serial port interrupt handler.
 interrupt_handler!(com1_com3_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x4), _stack_frame, {
     // trace!("COM1/COM3 serial handler");
-    INTERRUPT_ACTION_COM1_COM3.get().map(|func| func());
+    if let Some(func) = INTERRUPT_ACTION_COM1_COM3.get() {
+        func()
+    }
     EoiBehaviour::CallerMustSignalEoi
 });
 
 // IRQ 0x23: COM2 and COM4 serial port interrupt handler.
 interrupt_handler!(com2_com4_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x3), _stack_frame, {
     // trace!("COM2/COM4 serial handler");
-    INTERRUPT_ACTION_COM2_COM4.get().map(|func| func());
+    if let Some(func) = INTERRUPT_ACTION_COM2_COM4.get() {
+        func()
+    }
     EoiBehaviour::CallerMustSignalEoi
 });

--- a/kernel/tlb_shootdown/src/lib.rs
+++ b/kernel/tlb_shootdown/src/lib.rs
@@ -117,5 +117,5 @@ fn broadcast_tlb_shootdown(pages_to_invalidate: PageRange) {
 extern "C" fn tlb_shootdown_ipi_handler(_exc: &interrupts::ExceptionContext) -> interrupts::EoiBehaviour {
     let expected = handle_tlb_shootdown_ipi();
     assert!(expected, "Unexpected TLB Shootdown IPI!");
-    interrupts::EoiBehaviour::CallerMustSignalEoi
+    interrupts::EoiBehaviour::HandlerDidNotSendEoi
 }


### PR DESCRIPTION
- This creates a way for interrupt handler to be declared in a cross-platform way:

```rust
// Cross platform scheduling code
interrupt_handler!(timer_tick_handler, None, _stack_frame, {
    // ...
});
```

- Handlers in `scheduler` & `serial_ports` were modified to adopt this.
- Handlers in `exceptions_early`, `exceptions_full`, `keyboard`, `mouse` & `pit_clock` were left untouched as they are x86-specific.
- Handlers in `ata` & `e1000` were not modified because there's no way to test them on aarch64 atm.

There's a debate to have: Is it preferable to use macros (as this PR implements) or to declare handlers as a normal function/callback.

The macro-based approach has the benefit of allowing x86 handlers to be optimized using the "x86-interrupt" special ABI. 

Also, this removes the need to convert the existing x86_64 part of `interrupts`, because there's no need to declare raw interrupt handlers for every possible interrupt number, as would be the case with normal callbacks (or maybe there's another solution that I don't see?).

On the other hand, having all handlers declared as normal callbacks would make the code a bit easier to read and understand.

This is mergeable but I'm open to discussion :ok_hand: