### PR TITLE
Serial port interrupt handling on aarch64 & COM1 console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,7 @@ dependencies = [
  "app_io",
  "async_channel",
  "core2",
+ "hull",
  "io",
  "irq_safety",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,13 +2708,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "pl011_qemu"
-version = "0.2.0"
-source = "git+https://github.com/theseus-os/pl011/?branch=aarch64-qemu-virt-test#2c2cec84ca9653efa9e370460e7e0e1c94140080"
+name = "pl011"
+version = "1.0.0"
+source = "git+https://github.com/theseus-os/pl011/?rev=464dbf22#464dbf2288a5d9e7445b0b1f404ddd41b1fd1c1e"
 dependencies = [
- "cortex-m",
- "embedded-hal",
- "nb 1.0.0",
+ "log",
  "volatile-register",
 ]
 
@@ -3345,7 +3343,7 @@ dependencies = [
  "arm_boards",
  "irq_safety",
  "memory",
- "pl011_qemu",
+ "pl011",
  "port_io",
  "spin 0.9.4",
 ]

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -19,6 +19,7 @@ interrupts = { path = "../interrupts" }
 scheduler = { path = "../scheduler" }
 mod_mgmt = { path = "../mod_mgmt" }
 no_drop = { path = "../no_drop" }
+console = { path = "../console" }
 task_fs = { path = "../task_fs" }
 memory = { path = "../memory" }
 logger = { path = "../logger" }
@@ -37,7 +38,6 @@ tsc = { path = "../tsc" }
 acpi = { path = "../acpi" }
 page_attribute_table = { path = "../page_attribute_table" }
 e1000 = { path = "../e1000" }
-console = { path = "../console" }
 app_io = { path = "../app_io" }
 network_manager = { path = "../network_manager" }
 ota_update_client = { path = "../ota_update_client" }

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4.8"
 irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
 dfqueue = { path = "../../libs/dfqueue", version = "0.1.0" }
 multicore_bringup = { path = "../multicore_bringup" }
+device_manager = { path = "../device_manager" }
 early_printer = { path = "../early_printer" }
 tlb_shootdown = { path = "../tlb_shootdown" }
 kernel_config = { path = "../kernel_config" }
@@ -35,7 +36,6 @@ multiple_heaps = { path = "../multiple_heaps" }
 tsc = { path = "../tsc" }
 acpi = { path = "../acpi" }
 page_attribute_table = { path = "../page_attribute_table" }
-device_manager = { path = "../device_manager" }
 e1000 = { path = "../e1000" }
 console = { path = "../console" }
 app_io = { path = "../app_io" }

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -203,9 +203,6 @@ pub fn init(
     drop_after_init.drop_all();
 
     // 2. Spawn various system tasks/daemons,
-    // arch-gate: no windowing/input support on aarch64 at the moment,
-    // which prevent using any graphical apps such as the console
-    #[cfg(target_arch = "x86_64")]
     console::start_connection_detection()?;
 
     // 3. Start the first application(s).

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -177,11 +177,12 @@ pub fn init(
     #[cfg(target_arch = "x86_64")]
     let (key_producer, mouse_producer) = window_manager::init()?;
 
-    // initialize the rest of our drivers
-    // arch-gate: device_manager currently detects PCI & PS2 devices,
-    // which are unsupported on aarch64 at this point
-    #[cfg(target_arch = "x86_64")]
-    device_manager::init(key_producer, mouse_producer)?;
+    device_manager::init(
+        #[cfg(target_arch = "x86_64")]
+        key_producer,
+        #[cfg(target_arch = "x86_64")]
+        mouse_producer,
+    )?;
 
     task_fs::init()?;
 

--- a/kernel/console/Cargo.toml
+++ b/kernel/console/Cargo.toml
@@ -7,41 +7,23 @@ edition = "2021"
 
 [dependencies]
 log = "0.4.8"
+irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
-[dependencies.core2]
-version = "0.4.0"
-default-features = false
-features = ["alloc", "nightly"]
+async_channel = { path = "../async_channel" }
+serial_port = { path = "../serial_port" }
+app_io = { path = "../app_io" }
+spawn = { path = "../spawn" }
+task = { path = "../task" }
+tty = { path = "../tty" }
+io = { path = "../io" }
 
-[dependencies.async_channel]
-path = "../async_channel"
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+path = { path = "../path" }
+mod_mgmt = { path = "../mod_mgmt" }
 
-[dependencies.app_io]
-path = "../app_io"
-
-[dependencies.serial_port]
-path = "../serial_port"
-
-[dependencies.io]
-path = "../io"
-
-[dependencies.task]
-path = "../task"
-
-[dependencies.spawn]
-path = "../spawn"
-
-[dependencies.tty]
-path = "../tty"
-
-[dependencies.mod_mgmt]
-path = "../mod_mgmt"
-
-[dependencies.path]
-path = "../path"
-
-[dependencies.irq_safety]
-git = "https://github.com/theseus-os/irq_safety"
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+hull = { path = "../../applications/hull" }
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/console/src/lib.rs
+++ b/kernel/console/src/lib.rs
@@ -109,17 +109,27 @@ fn shell_loop(
         .name(format!("{address:?}_to_tty"))
         .spawn()?;
 
-    let new_app_ns = mod_mgmt::create_application_namespace(None)?;
 
-    let (app_file, _ns) =
-        mod_mgmt::CrateNamespace::get_crate_object_file_starting_with(&new_app_ns, "hull-")
-            .expect("Couldn't find shell in default app namespace");
+    let task;
+    #[cfg(target_arch = "x86_64")] {
+        let new_app_ns = mod_mgmt::create_application_namespace(None)?;
 
-    let path = path::Path::new(app_file.lock().get_absolute_path());
-    let task = spawn::new_application_task_builder(path, Some(new_app_ns))?
-        .name(format!("{address:?}_shell"))
-        .block()
-        .spawn()?;
+        let (app_file, _ns) =
+            mod_mgmt::CrateNamespace::get_crate_object_file_starting_with(&new_app_ns, "hull-")
+                .expect("Couldn't find shell in default app namespace");
+
+        let path = path::Path::new(app_file.lock().get_absolute_path());
+        task = spawn::new_application_task_builder(path, Some(new_app_ns))?
+            .name(format!("{address:?}_shell"))
+            .block()
+            .spawn()?;
+    }
+    #[cfg(target_arch = "aarch64")] {
+        task = spawn::new_task_builder(hull::main, alloc::vec::Vec::new())
+            .name(alloc::format!("{address:?}_shell"))
+            .block()
+            .spawn()?;
+    }
 
     let id = task.id;
     let stream = Arc::new(tty.slave());

--- a/kernel/console/src/lib.rs
+++ b/kernel/console/src/lib.rs
@@ -15,7 +15,7 @@ use task::{JoinableTaskRef, KillReason};
 
 /// The serial port being used for the default system logger can optionally
 /// ignore inputs.
-static IGNORED_SERIAL_PORT_INPUT: AtomicU16 = AtomicU16::new(0);
+static IGNORED_SERIAL_PORT_INPUT: AtomicU16 = AtomicU16::new(u16::MAX);
 
 /// Configures the console connection listener to ignore inputs from the given
 /// serial port.

--- a/kernel/deferred_interrupt_tasks/Cargo.toml
+++ b/kernel/deferred_interrupt_tasks/Cargo.toml
@@ -3,24 +3,16 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "deferred_interrupt_tasks"
 description = "Abstractions for deferred interrupt handler tasks"
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 log = "0.4.8"
 
-[dependencies.task]
-path = "../task"
-
-[dependencies.scheduler]
-path = "../scheduler"
-
-[dependencies.spawn]
-path = "../spawn"
-
-[dependencies.interrupts]
-path = "../interrupts"
-
-[dependencies.debugit]
-path = "../../libs/debugit"
+task = { path = "../task" }
+scheduler = { path = "../scheduler" }
+spawn = { path = "../spawn" }
+interrupts = { path = "../interrupts" }
+debugit = { path = "../../libs/debugit" }
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/deferred_interrupt_tasks/src/lib.rs
+++ b/kernel/deferred_interrupt_tasks/src/lib.rs
@@ -44,19 +44,15 @@
 //!
 
 #![no_std]
-#![feature(abi_x86_interrupt)]
+#![cfg_attr(target_arch = "x86_64", feature(abi_x86_interrupt))]
 
 extern crate alloc;
-#[macro_use] extern crate log;
-extern crate task;
-extern crate spawn;
-extern crate scheduler;
-#[macro_use] extern crate debugit;
-extern crate interrupts;
 
+use log::error;
+use debugit::debugit;
 use alloc::string::String;
 use task::{get_my_current_task, JoinableTaskRef};
-use interrupts::InterruptHandler;
+use interrupts::{InterruptHandler, InterruptNumber};
 
 /// The errors that may occur in [`register_interrupt_handler()`].
 #[derive(Debug)]
@@ -64,7 +60,7 @@ pub enum InterruptRegistrationError {
     /// The given `irq` number was already in use and is registered to 
     /// the interrupt handler at the given `existing_handler_address`.
     IrqInUse {
-        irq: u8,
+        irq: InterruptNumber,
         existing_handler_address: usize
     },
     /// The given error occurred when spawning the deferred interrupt task.
@@ -105,7 +101,7 @@ pub enum InterruptRegistrationError {
 ///    long-running loop that repeatedly invokes the given `deferred_interrupt_action`.
 /// * `Err(existing_handler_address)` if the given `interrupt_number` was already in use.
 pub fn register_interrupt_handler<DIA, Arg, Success, Failure, S>(
-    interrupt_number: u8,
+    interrupt_number: InterruptNumber,
     interrupt_handler: InterruptHandler,
     deferred_interrupt_action: DIA,
     deferred_action_argument: Arg,
@@ -116,8 +112,11 @@ pub fn register_interrupt_handler<DIA, Arg, Success, Failure, S>(
           S: Into<String>,
 {
     // First, attempt to register the interrupt handler.
-    interrupts::register_interrupt(interrupt_number, interrupt_handler)
+    interrupts::register_interrupt(interrupt_number as _, interrupt_handler)
         .map_err(|existing_handler_address| {
+            #[cfg(target_arch = "aarch64")]
+            let existing_handler_address = existing_handler_address as usize;
+
             error!("Interrupt number {:#X} was already taken by handler at {:#X}! Sharing IRQs is currently unsupported.",
                 interrupt_number, existing_handler_address
             );

--- a/kernel/device_manager/Cargo.toml
+++ b/kernel/device_manager/Cargo.toml
@@ -3,80 +3,41 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "device_manager"
 description = "Code for handling the sequence required to manage and initialize each driver"
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 spin = "0.9.4"
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
+event_types = { path = "../event_types" }
+serial_port = { path = "../serial_port" }
+console = { path = "../console" }
+logger = { path = "../logger" }
 derive_more = "0.99.0"
 mpmc = "0.1.6"
+log = "0.4.8"
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+memory = { path = "../memory" }
+e1000 = { path = "../e1000" }
+acpi = { path = "../acpi" }
+pci = { path = "../pci" }
+ps2 = { path = "../ps2" }
+keyboard = { path = "../keyboard" }
+mouse = { path = "../mouse" }
+storage_manager = { path = "../storage_manager" }
+network_manager = { path = "../network_manager" }
+ethernet_smoltcp_device = { path = "../ethernet_smoltcp_device" }
+ixgbe = { path = "../ixgbe" }
+io = { path = "../io" }
+mlx5 = { path = "../mlx5" }
+iommu = { path = "../iommu" }
+net = { path = "../net" }
+apic = { path = "../apic" }
 
 [dependencies.fatfs]
 git = "https://github.com/rafalh/rust-fatfs"
 default-features = false
 features = [ "alloc", "lfn", "unicode", "log_level_warn" ]
-
-[dependencies.log]
-version = "0.4.8"
-
-[dependencies.event_types]
-path = "../event_types"
-
-[dependencies.memory]
-path = "../memory"
-
-[dependencies.apic]
-path = "../apic"
-
-[dependencies.serial_port]
-path = "../serial_port"
-
-[dependencies.console]
-path = "../console"
-
-[dependencies.logger]
-path = "../logger"
-
-[dependencies.e1000]
-path = "../e1000"
-
-[dependencies.acpi]
-path = "../acpi"
-
-[dependencies.pci]
-path = "../pci"
-
-[dependencies.ps2]
-path = "../ps2"
-
-[dependencies.keyboard]
-path = "../keyboard"
-
-[dependencies.mouse]
-path = "../mouse"
-
-[dependencies.storage_manager]
-path = "../storage_manager"
-
-[dependencies.network_manager]
-path = "../network_manager"
-
-[dependencies.ethernet_smoltcp_device]
-path = "../ethernet_smoltcp_device"
-
-[dependencies.ixgbe]
-path = "../ixgbe"
-
-[dependencies.io]
-path = "../io"
-
-[dependencies.mlx5]
-path = "../mlx5"
-
-[dependencies.iommu]
-path = "../iommu"
-
-[dependencies.net]
-path = "../net"
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -100,144 +100,144 @@ pub fn init(
 
     // No PCI support on aarch64 at the moment
     #[cfg(target_arch = "x86_64")] {
-        // Initialize/scan the PCI bus to discover PCI devices
-        for dev in pci::pci_device_iter() {
-            debug!("Found pci device: {:X?}", dev);
+    // Initialize/scan the PCI bus to discover PCI devices
+    for dev in pci::pci_device_iter() {
+        debug!("Found pci device: {:X?}", dev);
+    }
+
+    // store all the initialized ixgbe NICs here to be added to the network interface list
+    let mut ixgbe_devs = Vec::new();
+
+    // Iterate over all PCI devices and initialize the drivers for the devices we support.
+
+    for dev in pci::pci_device_iter() {
+        // Currently we skip Bridge devices, since we have no use for them yet. 
+        if dev.class == 0x06 {
+            continue;
         }
 
-        // store all the initialized ixgbe NICs here to be added to the network interface list
-        let mut ixgbe_devs = Vec::new();
+        // If this is a storage device, initialize it as such.
+        match storage_manager::init_device(dev) {
+            // Successfully initialized this storage device.
+            Ok(Some(_storage_controller)) => continue,
 
-        // Iterate over all PCI devices and initialize the drivers for the devices we support.
+            // Not a storage device, so fall through and let another handler deal with it.
+            Ok(None) => { }
+            
+            // Error initializing this device, so skip it.
+            Err(e) => {
+                error!("Failed to initialize storage device, it will be unavailable.\n{:?}\nError: {}", dev, e);
+                continue;
+            }
+        }
 
-        for dev in pci::pci_device_iter() {
-            // Currently we skip Bridge devices, since we have no use for them yet. 
-            if dev.class == 0x06 {
+        // If this is a network device, initialize it as such.
+        // Look for networking controllers, specifically ethernet cards
+        if dev.class == 0x02 && dev.subclass == 0x00 {
+            if dev.vendor_id == e1000::INTEL_VEND && dev.device_id == e1000::E1000_DEV {
+                info!("e1000 PCI device found at: {:?}", dev.location);
+                let nic = e1000::E1000Nic::init(dev)?;
+                let interface = net::register_device(nic);
+                nic.lock().init_interrupts(interface)?;
+
+                let e1000_interface = EthernetNetworkInterface::new_ipv4_interface(nic, DEFAULT_LOCAL_IP, &DEFAULT_GATEWAY_IP)?;
+                add_to_network_interfaces(e1000_interface);
+                
+                continue;
+            }
+            if dev.vendor_id == ixgbe::INTEL_VEND && dev.device_id == ixgbe::INTEL_82599 {
+                info!("ixgbe PCI device found at: {:?}", dev.location);
+                
+                // Initialization parameters of the NIC.
+                // These can be changed according to the requirements specified in the ixgbe init function.
+                const VIRT_ENABLED: bool = true;
+                const RSS_ENABLED: bool = false;
+                const RX_DESCS: u16 = 8;
+                const TX_DESCS: u16 = 8;
+                
+                let ixgbe_nic = ixgbe::IxgbeNic::init(
+                    dev, 
+                    dev.location,
+                    VIRT_ENABLED, 
+                    None, 
+                    RSS_ENABLED, 
+                    ixgbe::RxBufferSizeKiB::Buffer2KiB,
+                    RX_DESCS,
+                    TX_DESCS
+                )?;
+
+                ixgbe_devs.push(ixgbe_nic);
+                continue;
+            }
+            if dev.vendor_id == mlx5::MLX_VEND && (dev.device_id == mlx5::CONNECTX5_DEV || dev.device_id == mlx5::CONNECTX5_EX_DEV) {
+                info!("mlx5 PCI device found at: {:?}", dev.location);
+                const RX_DESCS: usize = 512;
+                const TX_DESCS: usize = 8192;
+                const MAX_MTU:  u16 = 9000;
+
+                mlx5::ConnectX5Nic::init(dev, TX_DESCS, RX_DESCS, MAX_MTU)?;
                 continue;
             }
 
-            // If this is a storage device, initialize it as such.
-            match storage_manager::init_device(dev) {
-                // Successfully initialized this storage device.
-                Ok(Some(_storage_controller)) => continue,
-
-                // Not a storage device, so fall through and let another handler deal with it.
-                Ok(None) => { }
-                
-                // Error initializing this device, so skip it.
-                Err(e) => {
-                    error!("Failed to initialize storage device, it will be unavailable.\n{:?}\nError: {}", dev, e);
-                    continue;
-                }
-            }
-
-            // If this is a network device, initialize it as such.
-            // Look for networking controllers, specifically ethernet cards
-            if dev.class == 0x02 && dev.subclass == 0x00 {
-                if dev.vendor_id == e1000::INTEL_VEND && dev.device_id == e1000::E1000_DEV {
-                    info!("e1000 PCI device found at: {:?}", dev.location);
-                    let nic = e1000::E1000Nic::init(dev)?;
-                    let interface = net::register_device(nic);
-                    nic.lock().init_interrupts(interface)?;
-
-                    let e1000_interface = EthernetNetworkInterface::new_ipv4_interface(nic, DEFAULT_LOCAL_IP, &DEFAULT_GATEWAY_IP)?;
-                    add_to_network_interfaces(e1000_interface);
-                    
-                    continue;
-                }
-                if dev.vendor_id == ixgbe::INTEL_VEND && dev.device_id == ixgbe::INTEL_82599 {
-                    info!("ixgbe PCI device found at: {:?}", dev.location);
-                    
-                    // Initialization parameters of the NIC.
-                    // These can be changed according to the requirements specified in the ixgbe init function.
-                    const VIRT_ENABLED: bool = true;
-                    const RSS_ENABLED: bool = false;
-                    const RX_DESCS: u16 = 8;
-                    const TX_DESCS: u16 = 8;
-                    
-                    let ixgbe_nic = ixgbe::IxgbeNic::init(
-                        dev, 
-                        dev.location,
-                        VIRT_ENABLED, 
-                        None, 
-                        RSS_ENABLED, 
-                        ixgbe::RxBufferSizeKiB::Buffer2KiB,
-                        RX_DESCS,
-                        TX_DESCS
-                    )?;
-
-                    ixgbe_devs.push(ixgbe_nic);
-                    continue;
-                }
-                if dev.vendor_id == mlx5::MLX_VEND && (dev.device_id == mlx5::CONNECTX5_DEV || dev.device_id == mlx5::CONNECTX5_EX_DEV) {
-                    info!("mlx5 PCI device found at: {:?}", dev.location);
-                    const RX_DESCS: usize = 512;
-                    const TX_DESCS: usize = 8192;
-                    const MAX_MTU:  u16 = 9000;
-
-                    mlx5::ConnectX5Nic::init(dev, TX_DESCS, RX_DESCS, MAX_MTU)?;
-                    continue;
-                }
-
-                // here: check for and initialize other ethernet cards
-            }
-
-            warn!("Ignoring PCI device with no handler. {:X?}", dev);
+            // here: check for and initialize other ethernet cards
         }
 
-        // Once all the NICs have been initialized, we can store them and add them to the list of network interfaces.
-        let ixgbe_nics = ixgbe::IXGBE_NICS.call_once(|| ixgbe_devs);
-        for ixgbe_nic_ref in ixgbe_nics.iter() {
-            let ixgbe_interface = EthernetNetworkInterface::new_ipv4_interface(
-                ixgbe_nic_ref, 
-                DEFAULT_LOCAL_IP, 
-                &DEFAULT_GATEWAY_IP
-            )?;
-            add_to_network_interfaces(ixgbe_interface);
-            net::register_device(ixgbe_nic_ref);
-        }
+        warn!("Ignoring PCI device with no handler. {:X?}", dev);
+    }
 
-        // Convenience notification for developers to inform them of no networking devices
-        if network_manager::NETWORK_INTERFACES.lock().is_empty() {
-            warn!("Note: no network devices found on this system.");
-        }
+    // Once all the NICs have been initialized, we can store them and add them to the list of network interfaces.
+    let ixgbe_nics = ixgbe::IXGBE_NICS.call_once(|| ixgbe_devs);
+    for ixgbe_nic_ref in ixgbe_nics.iter() {
+        let ixgbe_interface = EthernetNetworkInterface::new_ipv4_interface(
+            ixgbe_nic_ref, 
+            DEFAULT_LOCAL_IP, 
+            &DEFAULT_GATEWAY_IP
+        )?;
+        add_to_network_interfaces(ixgbe_interface);
+        net::register_device(ixgbe_nic_ref);
+    }
 
-        // Discover filesystems from each storage device on the storage controllers initialized above
-        // and mount each filesystem to the root directory by default.
-        if false {
-            for storage_device in storage_manager::storage_devices() {
-                let disk = fatfs_adapter::FatFsAdapter::new(
-                    ReaderWriter::new(
-                        ByteReaderWriterWrapper::from(
-                            LockableIo::<dyn StorageDevice + Send, spin::Mutex<_>, _>::from(storage_device)
-                        )
-                    ),
+    // Convenience notification for developers to inform them of no networking devices
+    if network_manager::NETWORK_INTERFACES.lock().is_empty() {
+        warn!("Note: no network devices found on this system.");
+    }
+
+    // Discover filesystems from each storage device on the storage controllers initialized above
+    // and mount each filesystem to the root directory by default.
+    if false {
+        for storage_device in storage_manager::storage_devices() {
+            let disk = fatfs_adapter::FatFsAdapter::new(
+                ReaderWriter::new(
+                    ByteReaderWriterWrapper::from(
+                        LockableIo::<dyn StorageDevice + Send, spin::Mutex<_>, _>::from(storage_device)
+                    )
+                ),
+            );
+
+            if let Ok(filesystem) = fatfs::FileSystem::new(disk, fatfs::FsOptions::new()) {
+                debug!("FATFS data:
+                    fat_type: {:?},
+                    volume_id: {:X?},
+                    volume_label: {:?},
+                    cluster_size: {:?},
+                    status_flags: {:?},
+                    stats: {:?}",
+                    filesystem.fat_type(),
+                    filesystem.volume_id(),
+                    filesystem.volume_label(),
+                    filesystem.cluster_size(),
+                    filesystem.read_status_flags(),
+                    filesystem.stats(),
                 );
 
-                if let Ok(filesystem) = fatfs::FileSystem::new(disk, fatfs::FsOptions::new()) {
-                    debug!("FATFS data:
-                        fat_type: {:?},
-                        volume_id: {:X?},
-                        volume_label: {:?},
-                        cluster_size: {:?},
-                        status_flags: {:?},
-                        stats: {:?}",
-                        filesystem.fat_type(),
-                        filesystem.volume_id(),
-                        filesystem.volume_label(),
-                        filesystem.cluster_size(),
-                        filesystem.read_status_flags(),
-                        filesystem.stats(),
-                    );
-
-                    let root = filesystem.root_dir();
-                    debug!("Root directory contents:");
-                    for f in root.iter() {
-                        debug!("\t {:X?}", f.map(|entry| (entry.file_name(), entry.attributes(), entry.len())));
-                    }
+                let root = filesystem.root_dir();
+                debug!("Root directory contents:");
+                for f in root.iter() {
+                    debug!("\t {:X?}", f.map(|entry| (entry.file_name(), entry.attributes(), entry.len())));
                 }
             }
         }
+    }
     }
 
     Ok(())
@@ -245,69 +245,69 @@ pub fn init(
 
 #[cfg(target_arch = "x86_64")]
 mod fatfs_adapter {
-    // TODO: move the following `FatFsAdapter` stuff into a separate crate. 
+// TODO: move the following `FatFsAdapter` stuff into a separate crate. 
 
-    use derive_more::{From, Into};
+use derive_more::{From, Into};
 
-    /// An adapter (wrapper type) that implements traits required by the [`fatfs`] crate
-    /// for any I/O device that wants to be usable by [`fatfs`].
-    ///
-    /// To meet [`fatfs`]'s requirements, the underlying I/O stream must be able to 
-    /// read, write, and seek while tracking its current offset. 
-    /// We use traits from the [`core2`] crate to meet these requirements, 
-    /// thus, the given `IO` parameter must implement those [`core2`] traits.
-    ///
-    /// For example, this allows one to access a FAT filesystem 
-    /// by reading from or writing to a storage device.
-    pub struct FatFsAdapter<IO>(IO);
-    impl<IO> FatFsAdapter<IO> {
-        pub fn new(io: IO) -> FatFsAdapter<IO> { FatFsAdapter(io) }
+/// An adapter (wrapper type) that implements traits required by the [`fatfs`] crate
+/// for any I/O device that wants to be usable by [`fatfs`].
+///
+/// To meet [`fatfs`]'s requirements, the underlying I/O stream must be able to 
+/// read, write, and seek while tracking its current offset. 
+/// We use traits from the [`core2`] crate to meet these requirements, 
+/// thus, the given `IO` parameter must implement those [`core2`] traits.
+///
+/// For example, this allows one to access a FAT filesystem 
+/// by reading from or writing to a storage device.
+pub struct FatFsAdapter<IO>(IO);
+impl<IO> FatFsAdapter<IO> {
+    pub fn new(io: IO) -> FatFsAdapter<IO> { FatFsAdapter(io) }
+}
+/// This tells the `fatfs` crate that our read/write/seek functions
+/// may return errors of the type [`FatFsIoErrorAdapter`],
+/// which is a simple wrapper around [`core2::io::Error`].
+impl<IO> fatfs::IoBase for FatFsAdapter<IO> {
+    type Error = FatFsIoErrorAdapter;
+}
+impl<IO> fatfs::Read for FatFsAdapter<IO> where IO: core2::io::Read {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.0.read(buf).map_err(Into::into)
     }
-    /// This tells the `fatfs` crate that our read/write/seek functions
-    /// may return errors of the type [`FatFsIoErrorAdapter`],
-    /// which is a simple wrapper around [`core2::io::Error`].
-    impl<IO> fatfs::IoBase for FatFsAdapter<IO> {
-        type Error = FatFsIoErrorAdapter;
+}
+impl<IO> fatfs::Write for FatFsAdapter<IO> where IO: core2::io::Write {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.0.write(buf).map_err(Into::into)
     }
-    impl<IO> fatfs::Read for FatFsAdapter<IO> where IO: core2::io::Read {
-        fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-            self.0.read(buf).map_err(Into::into)
-        }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.0.flush().map_err(Into::into)
     }
-    impl<IO> fatfs::Write for FatFsAdapter<IO> where IO: core2::io::Write {
-        fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-            self.0.write(buf).map_err(Into::into)
-        }
-        fn flush(&mut self) -> Result<(), Self::Error> {
-            self.0.flush().map_err(Into::into)
-        }
+}
+impl<IO> fatfs::Seek for FatFsAdapter<IO> where IO: core2::io::Seek {
+    fn seek(&mut self, pos: fatfs::SeekFrom) -> Result<u64, Self::Error> {
+        let core2_pos = match pos {
+            fatfs::SeekFrom::Start(s)   => core2::io::SeekFrom::Start(s),
+            fatfs::SeekFrom::Current(c) => core2::io::SeekFrom::Current(c),
+            fatfs::SeekFrom::End(e)     => core2::io::SeekFrom::End(e),
+        };
+        self.0.seek(core2_pos).map_err(Into::into)
     }
-    impl<IO> fatfs::Seek for FatFsAdapter<IO> where IO: core2::io::Seek {
-        fn seek(&mut self, pos: fatfs::SeekFrom) -> Result<u64, Self::Error> {
-            let core2_pos = match pos {
-                fatfs::SeekFrom::Start(s)   => core2::io::SeekFrom::Start(s),
-                fatfs::SeekFrom::Current(c) => core2::io::SeekFrom::Current(c),
-                fatfs::SeekFrom::End(e)     => core2::io::SeekFrom::End(e),
-            };
-            self.0.seek(core2_pos).map_err(Into::into)
-        }
-    }
+}
 
-    /// This struct exists to enable us to implement the [`fatfs::IoError`] trait
-    /// for the [`core2::io::Error`] trait.
-    /// 
-    /// This is required because Rust prevents implementing foreign traits for foreign types.
-    #[derive(Debug, From, Into)]
-    pub struct FatFsIoErrorAdapter(core2::io::Error);
-    impl fatfs::IoError for FatFsIoErrorAdapter {
-        fn is_interrupted(&self) -> bool {
-            self.0.kind() == core2::io::ErrorKind::Interrupted
-        }
-        fn new_unexpected_eof_error() -> Self {
-            FatFsIoErrorAdapter(core2::io::ErrorKind::UnexpectedEof.into())
-        }
-        fn new_write_zero_error() -> Self {
-            FatFsIoErrorAdapter(core2::io::ErrorKind::WriteZero.into())
-        }
+/// This struct exists to enable us to implement the [`fatfs::IoError`] trait
+/// for the [`core2::io::Error`] trait.
+/// 
+/// This is required because Rust prevents implementing foreign traits for foreign types.
+#[derive(Debug, From, Into)]
+pub struct FatFsIoErrorAdapter(core2::io::Error);
+impl fatfs::IoError for FatFsIoErrorAdapter {
+    fn is_interrupted(&self) -> bool {
+        self.0.kind() == core2::io::ErrorKind::Interrupted
     }
+    fn new_unexpected_eof_error() -> Self {
+        FatFsIoErrorAdapter(core2::io::ErrorKind::UnexpectedEof.into())
+    }
+    fn new_write_zero_error() -> Self {
+        FatFsIoErrorAdapter(core2::io::ErrorKind::WriteZero.into())
+    }
+}
 }

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -1,50 +1,35 @@
 #![no_std]
-#![feature(trait_alias)]
+#![cfg_attr(target_arch = "x86_64", feature(trait_alias))]
 
-#[macro_use] extern crate log;
-extern crate spin;
-extern crate event_types;
-extern crate e1000;
-extern crate memory;
-extern crate apic;
-extern crate acpi;
-extern crate serial_port;
-extern crate console;
-extern crate logger;
-extern crate keyboard;
-extern crate pci;
-extern crate mouse;
-extern crate storage_manager;
-extern crate network_manager;
-extern crate ethernet_smoltcp_device;
-extern crate mpmc;
-extern crate ixgbe;
 extern crate alloc;
-extern crate fatfs;
-extern crate io;
-extern crate core2;
-#[macro_use] extern crate derive_more;
-extern crate mlx5;
-extern crate net;
 
-use core::convert::TryFrom;
-use mpmc::Queue;
-use event_types::Event;
-use memory::MemoryManagementInfo;
-use ethernet_smoltcp_device::EthernetNetworkInterface;
-use network_manager::add_to_network_interfaces;
-use alloc::vec::Vec;
-use io::{ByteReaderWriterWrapper, LockableIo, ReaderWriter};
-use serial_port::{SerialPortAddress, take_serial_port_basic};
-use storage_manager::StorageDevice;
-use memory::PhysicalAddress;
+use log::info;
+use serial_port::SerialPortAddress;
+
+#[cfg(target_arch = "x86_64")]
+use {
+    log::{error, debug, warn},
+    mpmc::Queue,
+    event_types::Event,
+    core::convert::TryFrom,
+    memory::MemoryManagementInfo,
+    ethernet_smoltcp_device::EthernetNetworkInterface,
+    network_manager::add_to_network_interfaces,
+    alloc::vec::Vec,
+    io::{ByteReaderWriterWrapper, LockableIo, ReaderWriter},
+    storage_manager::StorageDevice,
+    memory::PhysicalAddress,
+    serial_port::{init_serial_port, take_serial_port_basic},
+};
 
 /// A randomly chosen IP address that must be outside of the DHCP range.
 /// TODO: use DHCP to acquire an IP address.
+#[cfg(target_arch = "x86_64")]
 const DEFAULT_LOCAL_IP: &str = "10.0.2.15/24"; // the default QEMU user-slirp network gives IP addresses of "10.0.2.*"
 
 /// Standard home router address.
 /// TODO: use DHCP to acquire gateway IP
+#[cfg(target_arch = "x86_64")]
 const DEFAULT_GATEWAY_IP: [u8; 4] = [10, 0, 2, 2]; // the default QEMU user-slirp networking gateway IP
 
 /// Performs early-stage initialization for simple devices needed during early boot.
@@ -52,6 +37,7 @@ const DEFAULT_GATEWAY_IP: [u8; 4] = [10, 0, 2, 2]; // the default QEMU user-slir
 /// This includes:
 /// * local APICs ([`apic`]),
 /// * [`acpi`] tables for system configuration info, including the IOAPIC.
+#[cfg(target_arch = "x86_64")]
 pub fn early_init(
     rsdp_address: Option<PhysicalAddress>,
     kernel_mmi: &mut MemoryManagementInfo
@@ -74,171 +60,186 @@ pub fn early_init(
 /// * The fully-featured system [`logger`],
 /// * The legacy PS2 controller and any connected devices: [`keyboard`] and [`mouse`],
 /// * All other devices discovered on the [`pci`] bus.
-pub fn init(key_producer: Queue<Event>, mouse_producer: Queue<Event>) -> Result<(), &'static str>  {
+pub fn init(
+    #[cfg(target_arch = "x86_64")]
+    key_producer: Queue<Event>,
+    #[cfg(target_arch = "x86_64")]
+    mouse_producer: Queue<Event>,
+) -> Result<(), &'static str>  {
 
     let serial_ports = logger::take_early_log_writers();
     let logger_writers = IntoIterator::into_iter(serial_ports)
         .flatten()
-        .flat_map(|sp| SerialPortAddress::try_from(sp.base_port_address())
-            .ok()
-            .map(|sp_addr| serial_port::init_serial_port(sp_addr, sp))
-        ).cloned();
+        .filter_map(|sp| {
+            SerialPortAddress::try_from(sp.base_port_address())
+                .ok()
+                .and_then(|sp_addr| serial_port::init_serial_port(sp_addr, sp))
+        }).cloned();
 
     logger::init(None, logger_writers);
     info!("Initialized full logger.");
 
-    // Ensure that both COM1 and COM2 are initialized, for logging and/or headless operation.
-    // If a serial port was used for logging (as configured in [`logger::early_init()`]),
-    // ignore its inputs for purposes of starting new console instances.
-    let init_serial_port = |spa: SerialPortAddress| {
-        if let Some(sp) = take_serial_port_basic(spa) {
-            serial_port::init_serial_port(spa, sp);
-        } else {
-            console::ignore_serial_port_input(spa as u16);
-            info!("Ignoring input on {:?} because it is being used for logging.", spa);
-        }
-    };
-    init_serial_port(SerialPortAddress::COM1);
-    init_serial_port(SerialPortAddress::COM2);
-
-    let ps2_controller = ps2::init()?;
-    keyboard::init(ps2_controller.keyboard_ref(), key_producer)?;
-    mouse::init(ps2_controller.mouse_ref(), mouse_producer)?;
-
-    // Initialize/scan the PCI bus to discover PCI devices
-    for dev in pci::pci_device_iter() {
-        debug!("Found pci device: {:X?}", dev);
-    } 
-
-    // store all the initialized ixgbe NICs here to be added to the network interface list
-    let mut ixgbe_devs = Vec::new();
-
-    // Iterate over all PCI devices and initialize the drivers for the devices we support.
-
-    for dev in pci::pci_device_iter() {
-        // Currently we skip Bridge devices, since we have no use for them yet. 
-        if dev.class == 0x06 {
-            continue;
-        }
-
-        // If this is a storage device, initialize it as such.
-        match storage_manager::init_device(dev) {
-            // Successfully initialized this storage device.
-            Ok(Some(_storage_controller)) => continue,
-
-            // Not a storage device, so fall through and let another handler deal with it.
-            Ok(None) => { }
-            
-            // Error initializing this device, so skip it.
-            Err(e) => {
-                error!("Failed to initialize storage device, it will be unavailable.\n{:?}\nError: {}", dev, e);
-                continue;
+    // COM1 is the only UART on aarch64; it's used for logging as well as for the console.
+    #[cfg(target_arch = "x86_64")] {
+        // Ensure that both COM1 and COM2 are initialized, for logging and/or headless operation.
+        // If a serial port was used for logging (as configured in [`logger::early_init()`]),
+        // ignore its inputs for purposes of starting new console instances.
+        let init_serial_port = |spa: SerialPortAddress| {
+            if let Some(sp) = take_serial_port_basic(spa) {
+                init_serial_port(spa, sp);
+            } else {
+                console::ignore_serial_port_input(spa as u16);
+                info!("Ignoring input on {:?} because it is being used for logging.", spa);
             }
-        }
-
-        // If this is a network device, initialize it as such.
-        // Look for networking controllers, specifically ethernet cards
-        if dev.class == 0x02 && dev.subclass == 0x00 {
-            if dev.vendor_id == e1000::INTEL_VEND && dev.device_id == e1000::E1000_DEV {
-                info!("e1000 PCI device found at: {:?}", dev.location);
-                let nic = e1000::E1000Nic::init(dev)?;
-                let interface = net::register_device(nic);
-                nic.lock().init_interrupts(interface)?;
-
-                let e1000_interface = EthernetNetworkInterface::new_ipv4_interface(nic, DEFAULT_LOCAL_IP, &DEFAULT_GATEWAY_IP)?;
-                add_to_network_interfaces(e1000_interface);
-                
-                continue;
-            }
-            if dev.vendor_id == ixgbe::INTEL_VEND && dev.device_id == ixgbe::INTEL_82599 {
-                info!("ixgbe PCI device found at: {:?}", dev.location);
-                
-                // Initialization parameters of the NIC.
-                // These can be changed according to the requirements specified in the ixgbe init function.
-                const VIRT_ENABLED: bool = true;
-                const RSS_ENABLED: bool = false;
-                const RX_DESCS: u16 = 8;
-                const TX_DESCS: u16 = 8;
-                
-                let ixgbe_nic = ixgbe::IxgbeNic::init(
-                    dev, 
-                    dev.location,
-                    VIRT_ENABLED, 
-                    None, 
-                    RSS_ENABLED, 
-                    ixgbe::RxBufferSizeKiB::Buffer2KiB,
-                    RX_DESCS,
-                    TX_DESCS
-                )?;
-
-                ixgbe_devs.push(ixgbe_nic);
-                continue;
-            }
-            if dev.vendor_id == mlx5::MLX_VEND && (dev.device_id == mlx5::CONNECTX5_DEV || dev.device_id == mlx5::CONNECTX5_EX_DEV) {
-                info!("mlx5 PCI device found at: {:?}", dev.location);
-                const RX_DESCS: usize = 512;
-                const TX_DESCS: usize = 8192;
-                const MAX_MTU:  u16 = 9000;
-
-                mlx5::ConnectX5Nic::init(dev, TX_DESCS, RX_DESCS, MAX_MTU)?;
-                continue;
-            }
-
-            // here: check for and initialize other ethernet cards
-        }
-
-        warn!("Ignoring PCI device with no handler. {:X?}", dev);
+        };
+        init_serial_port(SerialPortAddress::COM1);
+        init_serial_port(SerialPortAddress::COM2);
     }
 
-    // Once all the NICs have been initialized, we can store them and add them to the list of network interfaces.
-    let ixgbe_nics = ixgbe::IXGBE_NICS.call_once(|| ixgbe_devs);
-    for ixgbe_nic_ref in ixgbe_nics.iter() {
-        let ixgbe_interface = EthernetNetworkInterface::new_ipv4_interface(
-            ixgbe_nic_ref, 
-            DEFAULT_LOCAL_IP, 
-            &DEFAULT_GATEWAY_IP
-        )?;
-        add_to_network_interfaces(ixgbe_interface);
-        net::register_device(ixgbe_nic_ref);
+    // PS/2 is x86_64 only
+    #[cfg(target_arch = "x86_64")] {
+        let ps2_controller = ps2::init()?;
+        keyboard::init(ps2_controller.keyboard_ref(), key_producer)?;
+        mouse::init(ps2_controller.mouse_ref(), mouse_producer)?;
     }
 
-    // Convenience notification for developers to inform them of no networking devices
-    if network_manager::NETWORK_INTERFACES.lock().is_empty() {
-        warn!("Note: no network devices found on this system.");
-    }
+    // No PCI support on aarch64 at the moment
+    #[cfg(target_arch = "x86_64")] {
+        // Initialize/scan the PCI bus to discover PCI devices
+        for dev in pci::pci_device_iter() {
+            debug!("Found pci device: {:X?}", dev);
+        }
 
-    // Discover filesystems from each storage device on the storage controllers initialized above
-    // and mount each filesystem to the root directory by default.
-    if false {
-        for storage_device in storage_manager::storage_devices() {
-            let disk = FatFsAdapter(
-                ReaderWriter::new(
-                    ByteReaderWriterWrapper::from(
-                        LockableIo::<dyn StorageDevice + Send, spin::Mutex<_>, _>::from(storage_device)
-                    )
-                ),
-            );
+        // store all the initialized ixgbe NICs here to be added to the network interface list
+        let mut ixgbe_devs = Vec::new();
 
-            if let Ok(filesystem) = fatfs::FileSystem::new(disk, fatfs::FsOptions::new()) {
-                debug!("FATFS data:
-                    fat_type: {:?},
-                    volume_id: {:X?},
-                    volume_label: {:?},
-                    cluster_size: {:?},
-                    status_flags: {:?},
-                    stats: {:?}",
-                    filesystem.fat_type(),
-                    filesystem.volume_id(),
-                    filesystem.volume_label(),
-                    filesystem.cluster_size(),
-                    filesystem.read_status_flags(),
-                    filesystem.stats(),
+        // Iterate over all PCI devices and initialize the drivers for the devices we support.
+
+        for dev in pci::pci_device_iter() {
+            // Currently we skip Bridge devices, since we have no use for them yet. 
+            if dev.class == 0x06 {
+                continue;
+            }
+
+            // If this is a storage device, initialize it as such.
+            match storage_manager::init_device(dev) {
+                // Successfully initialized this storage device.
+                Ok(Some(_storage_controller)) => continue,
+
+                // Not a storage device, so fall through and let another handler deal with it.
+                Ok(None) => { }
+                
+                // Error initializing this device, so skip it.
+                Err(e) => {
+                    error!("Failed to initialize storage device, it will be unavailable.\n{:?}\nError: {}", dev, e);
+                    continue;
+                }
+            }
+
+            // If this is a network device, initialize it as such.
+            // Look for networking controllers, specifically ethernet cards
+            if dev.class == 0x02 && dev.subclass == 0x00 {
+                if dev.vendor_id == e1000::INTEL_VEND && dev.device_id == e1000::E1000_DEV {
+                    info!("e1000 PCI device found at: {:?}", dev.location);
+                    let nic = e1000::E1000Nic::init(dev)?;
+                    let interface = net::register_device(nic);
+                    nic.lock().init_interrupts(interface)?;
+
+                    let e1000_interface = EthernetNetworkInterface::new_ipv4_interface(nic, DEFAULT_LOCAL_IP, &DEFAULT_GATEWAY_IP)?;
+                    add_to_network_interfaces(e1000_interface);
+                    
+                    continue;
+                }
+                if dev.vendor_id == ixgbe::INTEL_VEND && dev.device_id == ixgbe::INTEL_82599 {
+                    info!("ixgbe PCI device found at: {:?}", dev.location);
+                    
+                    // Initialization parameters of the NIC.
+                    // These can be changed according to the requirements specified in the ixgbe init function.
+                    const VIRT_ENABLED: bool = true;
+                    const RSS_ENABLED: bool = false;
+                    const RX_DESCS: u16 = 8;
+                    const TX_DESCS: u16 = 8;
+                    
+                    let ixgbe_nic = ixgbe::IxgbeNic::init(
+                        dev, 
+                        dev.location,
+                        VIRT_ENABLED, 
+                        None, 
+                        RSS_ENABLED, 
+                        ixgbe::RxBufferSizeKiB::Buffer2KiB,
+                        RX_DESCS,
+                        TX_DESCS
+                    )?;
+
+                    ixgbe_devs.push(ixgbe_nic);
+                    continue;
+                }
+                if dev.vendor_id == mlx5::MLX_VEND && (dev.device_id == mlx5::CONNECTX5_DEV || dev.device_id == mlx5::CONNECTX5_EX_DEV) {
+                    info!("mlx5 PCI device found at: {:?}", dev.location);
+                    const RX_DESCS: usize = 512;
+                    const TX_DESCS: usize = 8192;
+                    const MAX_MTU:  u16 = 9000;
+
+                    mlx5::ConnectX5Nic::init(dev, TX_DESCS, RX_DESCS, MAX_MTU)?;
+                    continue;
+                }
+
+                // here: check for and initialize other ethernet cards
+            }
+
+            warn!("Ignoring PCI device with no handler. {:X?}", dev);
+        }
+
+        // Once all the NICs have been initialized, we can store them and add them to the list of network interfaces.
+        let ixgbe_nics = ixgbe::IXGBE_NICS.call_once(|| ixgbe_devs);
+        for ixgbe_nic_ref in ixgbe_nics.iter() {
+            let ixgbe_interface = EthernetNetworkInterface::new_ipv4_interface(
+                ixgbe_nic_ref, 
+                DEFAULT_LOCAL_IP, 
+                &DEFAULT_GATEWAY_IP
+            )?;
+            add_to_network_interfaces(ixgbe_interface);
+            net::register_device(ixgbe_nic_ref);
+        }
+
+        // Convenience notification for developers to inform them of no networking devices
+        if network_manager::NETWORK_INTERFACES.lock().is_empty() {
+            warn!("Note: no network devices found on this system.");
+        }
+
+        // Discover filesystems from each storage device on the storage controllers initialized above
+        // and mount each filesystem to the root directory by default.
+        if false {
+            for storage_device in storage_manager::storage_devices() {
+                let disk = fatfs_adapter::FatFsAdapter::new(
+                    ReaderWriter::new(
+                        ByteReaderWriterWrapper::from(
+                            LockableIo::<dyn StorageDevice + Send, spin::Mutex<_>, _>::from(storage_device)
+                        )
+                    ),
                 );
 
-                let root = filesystem.root_dir();
-                debug!("Root directory contents:");
-                for f in root.iter() {
-                    debug!("\t {:X?}", f.map(|entry| (entry.file_name(), entry.attributes(), entry.len())));
+                if let Ok(filesystem) = fatfs::FileSystem::new(disk, fatfs::FsOptions::new()) {
+                    debug!("FATFS data:
+                        fat_type: {:?},
+                        volume_id: {:X?},
+                        volume_label: {:?},
+                        cluster_size: {:?},
+                        status_flags: {:?},
+                        stats: {:?}",
+                        filesystem.fat_type(),
+                        filesystem.volume_id(),
+                        filesystem.volume_label(),
+                        filesystem.cluster_size(),
+                        filesystem.read_status_flags(),
+                        filesystem.stats(),
+                    );
+
+                    let root = filesystem.root_dir();
+                    debug!("Root directory contents:");
+                    for f in root.iter() {
+                        debug!("\t {:X?}", f.map(|entry| (entry.file_name(), entry.attributes(), entry.len())));
+                    }
                 }
             }
         }
@@ -247,66 +248,71 @@ pub fn init(key_producer: Queue<Event>, mouse_producer: Queue<Event>) -> Result<
     Ok(())
 }
 
-// TODO: move the following `FatFsAdapter` stuff into a separate crate. 
+#[cfg(target_arch = "x86_64")]
+mod fatfs_adapter {
+    // TODO: move the following `FatFsAdapter` stuff into a separate crate. 
 
-/// An adapter (wrapper type) that implements traits required by the [`fatfs`] crate
-/// for any I/O device that wants to be usable by [`fatfs`].
-///
-/// To meet [`fatfs`]'s requirements, the underlying I/O stream must be able to 
-/// read, write, and seek while tracking its current offset. 
-/// We use traits from the [`core2`] crate to meet these requirements, 
-/// thus, the given `IO` parameter must implement those [`core2`] traits.
-///
-/// For example, this allows one to access a FAT filesystem 
-/// by reading from or writing to a storage device.
-pub struct FatFsAdapter<IO>(IO);
-impl<IO> FatFsAdapter<IO> {
-    pub fn new(io: IO) -> FatFsAdapter<IO> { FatFsAdapter(io) }
-}
-/// This tells the `fatfs` crate that our read/write/seek functions
-/// may return errors of the type [`FatFsIoErrorAdapter`],
-/// which is a simple wrapper around [`core2::io::Error`].
-impl<IO> fatfs::IoBase for FatFsAdapter<IO> {
-    type Error = FatFsIoErrorAdapter;
-}
-impl<IO> fatfs::Read for FatFsAdapter<IO> where IO: core2::io::Read {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        self.0.read(buf).map_err(Into::into)
-    }
-}
-impl<IO> fatfs::Write for FatFsAdapter<IO> where IO: core2::io::Write {
-    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        self.0.write(buf).map_err(Into::into)
-    }
-    fn flush(&mut self) -> Result<(), Self::Error> {
-        self.0.flush().map_err(Into::into)
-    }
-}
-impl<IO> fatfs::Seek for FatFsAdapter<IO> where IO: core2::io::Seek {
-    fn seek(&mut self, pos: fatfs::SeekFrom) -> Result<u64, Self::Error> {
-        let core2_pos = match pos {
-            fatfs::SeekFrom::Start(s)   => core2::io::SeekFrom::Start(s),
-            fatfs::SeekFrom::Current(c) => core2::io::SeekFrom::Current(c),
-            fatfs::SeekFrom::End(e)     => core2::io::SeekFrom::End(e),
-        };
-        self.0.seek(core2_pos).map_err(Into::into)
-    }
-}
+    use derive_more::{From, Into};
 
-/// This struct exists to enable us to implement the [`fatfs::IoError`] trait
-/// for the [`core2::io::Error`] trait.
-/// 
-/// This is required because Rust prevents implementing foreign traits for foreign types.
-#[derive(Debug, From, Into)]
-pub struct FatFsIoErrorAdapter(core2::io::Error);
-impl fatfs::IoError for FatFsIoErrorAdapter {
-    fn is_interrupted(&self) -> bool {
-        self.0.kind() == core2::io::ErrorKind::Interrupted
+    /// An adapter (wrapper type) that implements traits required by the [`fatfs`] crate
+    /// for any I/O device that wants to be usable by [`fatfs`].
+    ///
+    /// To meet [`fatfs`]'s requirements, the underlying I/O stream must be able to 
+    /// read, write, and seek while tracking its current offset. 
+    /// We use traits from the [`core2`] crate to meet these requirements, 
+    /// thus, the given `IO` parameter must implement those [`core2`] traits.
+    ///
+    /// For example, this allows one to access a FAT filesystem 
+    /// by reading from or writing to a storage device.
+    pub struct FatFsAdapter<IO>(IO);
+    impl<IO> FatFsAdapter<IO> {
+        pub fn new(io: IO) -> FatFsAdapter<IO> { FatFsAdapter(io) }
     }
-    fn new_unexpected_eof_error() -> Self {
-        FatFsIoErrorAdapter(core2::io::ErrorKind::UnexpectedEof.into())
+    /// This tells the `fatfs` crate that our read/write/seek functions
+    /// may return errors of the type [`FatFsIoErrorAdapter`],
+    /// which is a simple wrapper around [`core2::io::Error`].
+    impl<IO> fatfs::IoBase for FatFsAdapter<IO> {
+        type Error = FatFsIoErrorAdapter;
     }
-    fn new_write_zero_error() -> Self {
-        FatFsIoErrorAdapter(core2::io::ErrorKind::WriteZero.into())
+    impl<IO> fatfs::Read for FatFsAdapter<IO> where IO: core2::io::Read {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            self.0.read(buf).map_err(Into::into)
+        }
+    }
+    impl<IO> fatfs::Write for FatFsAdapter<IO> where IO: core2::io::Write {
+        fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+            self.0.write(buf).map_err(Into::into)
+        }
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            self.0.flush().map_err(Into::into)
+        }
+    }
+    impl<IO> fatfs::Seek for FatFsAdapter<IO> where IO: core2::io::Seek {
+        fn seek(&mut self, pos: fatfs::SeekFrom) -> Result<u64, Self::Error> {
+            let core2_pos = match pos {
+                fatfs::SeekFrom::Start(s)   => core2::io::SeekFrom::Start(s),
+                fatfs::SeekFrom::Current(c) => core2::io::SeekFrom::Current(c),
+                fatfs::SeekFrom::End(e)     => core2::io::SeekFrom::End(e),
+            };
+            self.0.seek(core2_pos).map_err(Into::into)
+        }
+    }
+
+    /// This struct exists to enable us to implement the [`fatfs::IoError`] trait
+    /// for the [`core2::io::Error`] trait.
+    /// 
+    /// This is required because Rust prevents implementing foreign traits for foreign types.
+    #[derive(Debug, From, Into)]
+    pub struct FatFsIoErrorAdapter(core2::io::Error);
+    impl fatfs::IoError for FatFsIoErrorAdapter {
+        fn is_interrupted(&self) -> bool {
+            self.0.kind() == core2::io::ErrorKind::Interrupted
+        }
+        fn new_unexpected_eof_error() -> Self {
+            FatFsIoErrorAdapter(core2::io::ErrorKind::UnexpectedEof.into())
+        }
+        fn new_write_zero_error() -> Self {
+            FatFsIoErrorAdapter(core2::io::ErrorKind::WriteZero.into())
+        }
     }
 }

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -11,7 +11,7 @@ use tock_registers::interfaces::Readable;
 use tock_registers::registers::InMemoryRegister;
 
 use kernel_config::time::CONFIG_TIMESLICE_PERIOD_MICROSECONDS;
-use gic::{ArmGic, IpiTargetCpu, Version as GicVersion};
+use gic::{ArmGic, IpiTargetCpu, Version as GicVersion, SpiDestination};
 use arm_boards::{BOARD_CONFIG, InterruptControllerConfig};
 use irq_safety::{RwLockIrqSafe, MutexIrqSafe};
 use memory::get_kernel_mmi_ref;
@@ -33,6 +33,12 @@ static INTERRUPT_CONTROLLER: MutexIrqSafe<Option<ArmGic>> = MutexIrqSafe::new(No
 //
 // aarch64 manuals define the default timer IRQ number to be 30.
 pub const CPU_LOCAL_TIMER_IRQ: InterruptNumber = 30;
+
+/// The IRQ number reserved for the PL011 Single-Serial-Port Controller
+/// which Theseus currently uses for logging and UART console.
+//
+// Qemu attributes number 33 to this interrupt.
+pub const PL011_RX_SPI: InterruptNumber = 33;
 
 /// The IRQ/IPI number for TLB Shootdowns
 ///
@@ -182,6 +188,7 @@ pub fn init() -> Result<(), &'static str> {
 
                 inner.set_minimum_priority(0);
                 inner.set_interrupt_state(TLB_SHOOTDOWN_IPI, true);
+                inner.set_interrupt_state(PL011_RX_SPI, true);
                 *int_ctrl = Some(inner);
             },
         }
@@ -234,6 +241,18 @@ pub fn setup_ipi_handler(handler: InterruptHandler, irq_num: InterruptNumber) ->
         // enable routing of this interrupt
         int_ctrl.set_interrupt_state(irq_num, true);
     }
+
+    Ok(())
+}
+
+/// Enables the PL011 "RX" SPI and routes it to the current CPU.
+pub fn init_pl011_rx_interrupt() -> Result<(), &'static str> {
+    let mut int_ctrl = INTERRUPT_CONTROLLER.lock();
+    let int_ctrl = int_ctrl.as_mut().ok_or("INTERRUPT_CONTROLLER is uninitialized")?;
+
+    // enable routing of this interrupt
+    int_ctrl.set_interrupt_state(PL011_RX_SPI, true);
+    int_ctrl.set_spi_target(PL011_RX_SPI, SpiDestination::Specific(cpu::current_cpu()));
 
     Ok(())
 }

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -11,7 +11,7 @@ use tock_registers::interfaces::Readable;
 use tock_registers::registers::InMemoryRegister;
 
 use kernel_config::time::CONFIG_TIMESLICE_PERIOD_MICROSECONDS;
-use gic::{ArmGic, InterruptNumber, IpiTargetCpu, Version as GicVersion};
+use gic::{ArmGic, IpiTargetCpu, Version as GicVersion};
 use arm_boards::{BOARD_CONFIG, InterruptControllerConfig};
 use irq_safety::{RwLockIrqSafe, MutexIrqSafe};
 use memory::get_kernel_mmi_ref;
@@ -19,6 +19,8 @@ use log::{info, error};
 use spin::Once;
 
 use time::{Monotonic, ClockSource, Instant, Period, register_clock_source};
+
+pub use gic::InterruptNumber;
 
 // This assembly file contains trampolines to `extern "C"` functions defined below.
 global_asm!(include_str!("table.s"));

--- a/kernel/interrupts/src/x86_64/mod.rs
+++ b/kernel/interrupts/src/x86_64/mod.rs
@@ -9,6 +9,7 @@ use memory::VirtualAddress;
 use spin::Once;
 use early_printer::println;
 pub use x86_64::structures::idt::{InterruptStackFrame, HandlerFunc as InterruptHandler};
+pub use core::primitive::u8 as InterruptNumber;
 
 /// The IRQ number reserved for CPU-local timer interrupts,
 /// which Theseus currently uses for preemptive task switching.

--- a/kernel/serial_port/Cargo.toml
+++ b/kernel/serial_port/Cargo.toml
@@ -3,27 +3,20 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "serial_port"
 description = "Advanced support for serial ports (e.g., COM1, COM2) with full interrupt support"
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 log = "0.4.8"
 spin = "0.9.4"
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
-[dependencies.serial_port_basic]
-path = "../serial_port_basic"
-
-[dependencies.irq_safety]
-git = "https://github.com/theseus-os/irq_safety"
-
-[dependencies.interrupts]
-path = "../interrupts"
-
-[dependencies.deferred_interrupt_tasks]
-path = "../deferred_interrupt_tasks"
+serial_port_basic = { path = "../serial_port_basic" }
+irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
+interrupts = { path = "../interrupts" }
+deferred_interrupt_tasks = { path = "../deferred_interrupt_tasks" }
 
 # Dependencies below here are temporary, for console creation testing.
-[dependencies.async_channel]
-path = "../async_channel"
+async_channel = { path = "../async_channel" }
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/serial_port_basic/Cargo.toml
+++ b/kernel/serial_port_basic/Cargo.toml
@@ -13,7 +13,7 @@ spin = "0.9.4"
 port_io = { path = "../../libs/port_io" }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-pl011_qemu = { git = "https://github.com/theseus-os/pl011/", branch = "aarch64-qemu-virt-test" }
+pl011 = { git = "https://github.com/theseus-os/pl011/", rev = "464dbf22" }
 arm_boards = { path = "../arm_boards" }
 memory = { path = "../memory" }
 

--- a/kernel/serial_port_basic/src/aarch64.rs
+++ b/kernel/serial_port_basic/src/aarch64.rs
@@ -92,7 +92,7 @@ impl SerialPort {
 
     /// Enable or disable interrupts on this serial port for various events.
     ///
-    /// Note: currently unimplemented on `aarch64`.
+    /// Note: only [`SerialPortInterruptEvent::DataReceived`] is supported on `aarch64`.
     pub fn enable_interrupt(&mut self, event: SerialPortInterruptEvent, enable: bool) {
         if matches!(event, SerialPortInterruptEvent::DataReceived) {
             self.inner.as_mut().unwrap().enable_rx_interrupt(enable);

--- a/kernel/serial_port_basic/src/aarch64.rs
+++ b/kernel/serial_port_basic/src/aarch64.rs
@@ -2,20 +2,20 @@ use memory::{MappedPages, PteFlags, get_kernel_mmi_ref, allocate_pages, allocate
 use core::{fmt, ops::DerefMut};
 use super::{TriState, SerialPortInterruptEvent};
 use arm_boards::BOARD_CONFIG;
-use pl011_qemu::PL011;
+use pl011::PL011;
 
 /// The base port I/O addresses for COM serial ports.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(usize)]
 pub enum SerialPortAddress {
     /// The base MMIO address for the COM1 serial port.
-    COM1,
+    COM1 = 0,
     /// The base MMIO address for the COM2 serial port.
-    COM2,
+    COM2 = 1,
     /// The base MMIO address for the COM3 serial port.
-    COM3,
+    COM3 = 2,
     /// The base MMIO address for the COM4 serial port.
-    COM4,
+    COM4 = 3,
 }
 
 /// A serial port and its various data and control registers.
@@ -77,10 +77,15 @@ impl SerialPort {
             .expect("serial_port_basic: couldn't map the UART interface");
 
         let addr = mapped_pages.start_address().value();
+        let mut pl011 = PL011::new(addr as *mut _);
+
+        pl011.enable_rx_interrupt(true);
+        pl011.set_fifo_mode(false);
+        // pl011.log_status();
 
         SerialPort {
             port_address: serial_port_address,
-            inner: Some(PL011::new(addr as *mut _)),
+            inner: Some(pl011),
             _mapped_pages: Some(mapped_pages),
         }
     }
@@ -88,8 +93,12 @@ impl SerialPort {
     /// Enable or disable interrupts on this serial port for various events.
     ///
     /// Note: currently unimplemented on `aarch64`.
-    pub fn enable_interrupt(&mut self, _event: SerialPortInterruptEvent, _enable: bool) {
-        unimplemented!()
+    pub fn enable_interrupt(&mut self, event: SerialPortInterruptEvent, enable: bool) {
+        if matches!(event, SerialPortInterruptEvent::DataReceived) {
+            self.inner.as_mut().unwrap().enable_rx_interrupt(enable);
+        } else {
+            unimplemented!()
+        }
     }
 
     /// Write the given string to the serial port, blocking until data can be transmitted.
@@ -98,14 +107,7 @@ impl SerialPort {
     /// Because this function writes strings, it will transmit a carriage return `'\r'`
     /// after transmitting a line feed (new line) `'\n'` to ensure a proper new line.
     pub fn out_str(&mut self, s: &str) {
-        for byte in s.bytes() {
-            self.out_byte(byte);
-            if byte == b'\n' {
-                self.out_byte(b'\r');
-            } else if byte == b'\r' {
-                self.out_byte(b'\n');
-            }
-        }
+        self.out_bytes(s.as_bytes())
     }
 
     /// Write the given byte to the serial port, blocking until data can be transmitted.
@@ -139,15 +141,7 @@ impl SerialPort {
     ///
     /// Returns the number of bytes read into the given `buffer`.
     pub fn in_bytes(&mut self, buffer: &mut [u8]) -> usize {
-        let mut bytes_read = 0;
-        for byte in buffer {
-            if !self.data_available() {
-                break;
-            }
-            *byte = self.inner.as_mut().unwrap().read_byte();
-            bytes_read += 1;
-        }
-        bytes_read
+        self.inner.as_mut().unwrap().read_bytes(buffer)
     }
 
     /// Returns `true` if the serial port is ready to transmit a byte.

--- a/kernel/serial_port_basic/src/x86_64.rs
+++ b/kernel/serial_port_basic/src/x86_64.rs
@@ -263,8 +263,9 @@ impl SerialPort {
         self.line_status.read() & 0x01 == 0x01
     }
 
-    pub fn base_port_address(&self) -> u16 {
-        self.data.port_address()
+    pub fn base_port_address(&self) -> SerialPortAddress {
+        SerialPortAddress::try_from(self.data.port_address())
+            .expect("Invalid port base address")
     }
 
 }


### PR DESCRIPTION
Changes:
- Interrupts from the PL011 serial port are configured in the GIC and handled like on x86_64
- `device_manager` implements serial port configuration only on aarch64
- `deferred_interrupt_tasks` is now compatible with aarch64
- COM1 switches to a `hull` console (which doesn't have any app available) when we write to it. Log messages still appear while this console runs.

We can revert some changes of [4e8a63f](https://github.com/theseus-os/Theseus/pull/948/commits/4e8a63f68c204f00c7a635e123a5ec9cfc34105f) once relocations work on aarch64.