### PR TITLE
Update MacOS setup script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,6 @@ LIMINE_DIR              := $(ROOT_DIR)/limine-prebuilt
 UNAME = $(shell uname -s)
 ifeq ($(UNAME),Darwin)
 	CROSS = x86_64-elf-
-	## The GRUB_CROSS variable must match the build output of "scripts/mac_os_build_setup.sh"
-	GRUB_CROSS = "$(HOME)"/theseus_tools_opt/bin/
 	## macOS uses a different unmounting utility
 	UNMOUNT = diskutil unmount
 	USB_DRIVES = $(shell diskutil list external | grep -s "/dev/" | awk '{print $$1}')
@@ -84,10 +82,10 @@ ifeq ($(boot_spec),uefi)
 	## A bootloader isn't required with UEFI.
 else ifeq ($(bootloader),grub)
 	## Look for `grub-mkrescue` (Debian-like distros) or `grub2-mkrescue` (Fedora)
-	ifneq (,$(shell command -v $(GRUB_CROSS)grub-mkrescue))
-		GRUB_MKRESCUE = $(GRUB_CROSS)grub-mkrescue
-	else ifneq (,$(shell command -v $(GRUB_CROSS)grub2-mkrescue))
-		GRUB_MKRESCUE = $(GRUB_CROSS)grub2-mkrescue
+	ifneq (,$(shell command -v grub-mkrescue))
+		GRUB_MKRESCUE = grub-mkrescue
+	else ifneq (,$(shell command -v grub2-mkrescue))
+		GRUB_MKRESCUE = grub2-mkrescue
 	else
 $(error Error: could not find 'grub-mkrescue' or 'grub2-mkrescue', please install 'grub' or 'grub2')
 	endif

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ If you're on WSL, also do the following steps:
   * **NOTE**: WSL and WSL2 do not currently support using KVM.
 
 ### Building on MacOS
-  * Install [MacPorts](https://www.macports.org/install.php) and [HomeBrew](https://brew.sh/), then run the MacOS build setup script:
+  * Install [HomeBrew](https://brew.sh/), then run the MacOS build setup script:
     ```sh
     sh ./scripts/mac_os_build_setup.sh
     ```
     If things go wrong, remove the following build directories and try to run the script again.
     ```sh
-    rm -rf $HOME/theseus_tools_src $HOME/theseus_tools_opt /opt/local/bin/make
+    rm -rf /tmp/theseus_tools_src
     ```
 
   * If you're building Theseus on an M1-based Mac, you may need to use x86 emulation


### PR DESCRIPTION
Changes:
  - Script now exclusively uses `brew`
  - Tools are installed to `/usr/local` so that the user doesn't need to change `PATH`.
  - Tools are copied into `/tmp/theseus_tools_src` to not clog up the home directory
  - Tools are only installed if they aren't already