### PR TITLE
Fix some typos and wrong links in the book

### DIFF
--- a/book/cspell.json
+++ b/book/cspell.json
@@ -83,6 +83,7 @@
         "linkcheck",
         "manycore",
         "MMIO",
+        "OSDI",
         "Phalereus",
         "reinterpretive",
         "rodata",

--- a/book/src/subsystems/heap.md
+++ b/book/src/subsystems/heap.md
@@ -5,7 +5,6 @@ Heaps are used to dynamically allocate chunks of memory smaller than the granula
 
 In Theseus, the primary purpose of the heap is to enable the usage of Rust's [`alloc`] types, e.g., `Box`, `Arc`, `Vec`, and other dynamically-allocated collections types.
 Heap allocators must implement Rust's [`GlobalAlloc`] trait in order to be used as the backing allocator behind these `alloc` types.
- how we integrate that with Rust's (old) requirement of a single global allocator.
 
 ## Overview of Relevant Crates
 * [`heap`]: the default heap implementation that offers a static singleton fixed-size block allocator.
@@ -19,8 +18,8 @@ Heap allocators must implement Rust's [`GlobalAlloc`] trait in order to be used 
     * It is trivially easy to use `multiple_heaps` in a different way, such as per-task heaps or per-namespace heaps.
 
 
-One unique aspect of Theseus's "combination" heap design is that the early heap, fully-featured heap, and per-core dedicated heaps are all combined into a single heap abstraction that can be accessed via singleton global heap instance.
-It starts out with the simple block allocator described above, and then once more key system functionality has been initialized during OS boot, the [`switch_to_multiple_heaps()`] function is invoked to transparently activate the more complex, per-core heap allocators.
+One unique aspect of Theseus's "combination" heap design is that the early heap, fully-featured heap, and per-core dedicated heaps are all combined into a single heap abstraction that can be accessed via a singleton global heap instance.
+It starts out with the simple block allocator described above, and then, once more key system functionality has been initialized during OS boot, the [`switch_to_multiple_heaps()`] function is invoked to transparently activate the more complex, per-core heap allocators.
 
 Another unique aspect of heaps in Theseus is that all entities across the system use and share the same set of global heaps. This allows allocations to seamlessly flow and be passed among applications, libraries, and kernel entities without the need for inefficient and complex [exchange heaps] used in other SAS OSes. 
 

--- a/book/src/subsystems/memory_mapping.md
+++ b/book/src/subsystems/memory_mapping.md
@@ -73,7 +73,7 @@ These access methods ensure the aforementioned invariants of the `MappedPages` t
     * The same is true for slices: the number of elements of a sized type `T: Sized` plus the offset must not exceed the region's bounds.
 2. If a mutable reference is requested, the underlying memory region must have been mapped as writable.
     * The same is true for functions and executable memory regions.
-3. These methods all return *references* to the requested type or slice, in which the lifetime of the returned reference (`&T`, `in order to prevent use-after-free errors. 
+3. These methods all return *references* to the requested type or slice, in which the lifetime of the returned reference (`&T`) is dependent upon the lifetime of the `MappedPages` object, in order to prevent use-after-free errors.
     * One cannot obtain an owned instance of a type `T` from an underlying `MappedPages` memory region, because that would remove the semantic connection between the type `T` and the existence of the underlying memory mapping.
 
 In comparison, other OSes typically return raw virtual address values from a memory mapping operation, which you must then unsafely cast to a typed pointer of your choice. 
@@ -105,9 +105,9 @@ However, Theseus's design vastly simplifies the procedure of reclaiming unused p
 The single address space design and guaranteed bijective (1-to-1) mappings mean that a frame is mapped *exclusively* by a single page; when that page is no longer mapped to that frame, the frame can be deallocated.
 We refer to this as exclusive mappings, and they are realized via a combination of several crates:
 1. When frame(s) are unmapped in the [`page_table_entry`] crate, it creates an [`UnmapResult`] that may contain a set of [`UnmappedFrames`].
-    * The primary function of interest is [`PageTableEntry::set_unmapped()`](https://theseus-os.github.io/Theseus/doc/page_table_entry/struct.PageTableEntry.html#method.set_unmapped).
+    * The primary function of interest is [`PageTableEntry::set_unmapped()`].
 2. Using strong type safety, the [`frame_allocator`] is able to accept a set of `UnmappedFrames` as a trusted "token" stating that the included frames cannot possibly still be mapped by any pages. It can therefore safely deallocate them.
-    * Deallocation occurs seamlessly because an `UnmappedFrames` object can be converted into an `AllocatedFrames` object, [see here for details](https://theseus-os.github.io/Theseus/doc/src/frame_allocator/lib.rs.html#393).
+    * Deallocation occurs seamlessly because an `UnmappedFrames` object can be converted into an `AllocatedFrames` object, [see here for details and source].
 
 
 <!-- Links below -->
@@ -133,4 +133,6 @@ We refer to this as exclusive mappings, and they are realized via a combination 
 [`page_table_entry`]: https://theseus-os.github.io/Theseus/doc/page_table_entry/index.html
 [`UnmapResult`]: https://theseus-os.github.io/Theseus/doc/page_table_entry/enum.UnmapResult.html
 [`UnmappedFrames`]: https://theseus-os.github.io/Theseus/doc/page_table_entry/struct.UnmappedFrames.html
+[`PageTableEntry::set_unmapped()`]: https://theseus-os.github.io/Theseus/doc/page_table_entry/struct.PageTableEntry.html#method.set_unmapped
+[see here for details and source]: https://www.theseus-os.com/Theseus/doc/frame_allocator/fn.init.html#return
 [stacks]: https://theseus-os.github.io/Theseus/doc/stack/struct.Stack.html

--- a/book/src/subsystems/memory_mapping.md
+++ b/book/src/subsystems/memory_mapping.md
@@ -73,14 +73,14 @@ These access methods ensure the aforementioned invariants of the `MappedPages` t
     * The same is true for slices: the number of elements of a sized type `T: Sized` plus the offset must not exceed the region's bounds.
 2. If a mutable reference is requested, the underlying memory region must have been mapped as writable.
     * The same is true for functions and executable memory regions.
-3. These methods all return *references* to the requested type or slice, in which the lifetime of the returned reference (`&T`) is dependent upon the lifetime of the `MappedPages` object, in order to prevent use-after-free errors.
+3. These methods all return *references* to the requested type or slice, in which the lifetime of the returned reference (`&T`) is dependent upon the lifetime of the `MappedPages` object, in order to statically prevent use-after-free errors.
     * One cannot obtain an owned instance of a type `T` from an underlying `MappedPages` memory region, because that would remove the semantic connection between the type `T` and the existence of the underlying memory mapping.
 
 In comparison, other OSes typically return raw virtual address values from a memory mapping operation, which you must then unsafely cast to a typed pointer of your choice. 
 With raw addresses, there is no lifetime guarantee to ensure that the mapping persists for as long as those virtual addresses are used. 
 As such, Theseus removes at compile time the potential to easily cause unsafe, undefined behavior by using a raw virtual address after it has been unmapped.
 
-For more details, see the Theseus paper from OSDI 2020, or Kevin Boos' dissertation, both [available here](../misc/papers_presentations.md#selected-papers-and-theses).
+For more details, see the Theseus paper from OSDI 2020, or Kevin Boos's dissertation, both [available here](../misc/papers_presentations.md#selected-papers-and-theses).
 
 
 The `MappedPages` type also exposes other convenient utility methods:

--- a/book/src/subsystems/memory_mapping.md
+++ b/book/src/subsystems/memory_mapping.md
@@ -80,7 +80,7 @@ In comparison, other OSes typically return raw virtual address values from a mem
 With raw addresses, there is no lifetime guarantee to ensure that the mapping persists for as long as those virtual addresses are used. 
 As such, Theseus removes at compile time the potential to easily cause unsafe, undefined behavior by using a raw virtual address after it has been unmapped.
 
-For more details, see the Theseus paper from OSDI 2020, or Kevin Boos's dissertation, both [available here](../misc/papers_presentations.md#selected-papers-and-theses).
+For more details, see the Theseus paper from OSDI 2020, or Kevin Boos' dissertation, both [available here](../misc/papers_presentations.md#selected-papers-and-theses).
 
 
 The `MappedPages` type also exposes other convenient utility methods:

--- a/book/src/subsystems/task.md
+++ b/book/src/subsystems/task.md
@@ -132,7 +132,7 @@ This scheduling function is the same function that is invoked by the aforementio
 
 Theseus tasks follow a typical task lifecycle, which is in-part demonstrated by the possible variants of the [`RunState`] enum. 
 
-* **Initing**: the task is being created.
+* **Initializing**: the task is being created.
 * **Running**: the task is executing.
     * A runnable task may be *blocked* to temporarily prevent it from being scheduled in.
     * A blocked task may be *unblocked* to mark it as runnable again.

--- a/book/src/subsystems/task.md
+++ b/book/src/subsystems/task.md
@@ -132,7 +132,7 @@ This scheduling function is the same function that is invoked by the aforementio
 
 Theseus tasks follow a typical task lifecycle, which is in-part demonstrated by the possible variants of the [`RunState`] enum. 
 
-* **Initing**: the task is being created.
+* **Initializing**: the task is being created.
     * After the task is finished being created and is fully spawned, its runstate will be set to Runnable.
 * **Runnable**: the task is able to be scheduled in (but is not necessarily currently executing).
     * A runnable task may be *blocked* to prevent it from being scheduled in until it is subsequently unblocked.

--- a/book/src/subsystems/task.md
+++ b/book/src/subsystems/task.md
@@ -22,7 +22,7 @@ In this way, tasks in Theseus are effectively a combination of the concept of la
 
 There is one instance of the `Task` struct for each task that currently exists in the system.
 A task is often thought of as an *execution context*, and the task struct includes key information about the execution of a given program's code.
-Compare to that of other OSes, the [`Task`] struct in Theseus is quite minimal in size and scope,
+Compared to that of other OSes, the [`Task`] struct in Theseus is quite minimal in size and scope,
 because our state management philosophy strives to keep only states relevant to a given subsystem in that subsystem. 
 For example, scheduler-related states are not present in Theseus's task struct; rather, they are found in the relevant scheduler crate in which they are used.
 In other words, Theseus's task struct is not monolithic and all-encompassing.
@@ -91,7 +91,7 @@ In OS terminology, the term "context switch" is often incorrectly overloaded and
 Only number 1 above is what we consider to be a true context switch, and that is what we refer to here when we say "context switch." 
 Number 2 above is an *address space switch*, e.g., switching page tables, a different action that could potentially occur when switching to a different task, if the next task is in a different process/address space than the current task.
 Number 3 above is a *mode switch* that generally does not result in the full execution context being saved or restored; only some registers may be pushed or popped onto the stack, depending on the calling convention employed by a given platform's system calls.
-Number 4 above is similar to number 3, but is trigger by the hardware rather than userspace software, so more execution context states may need to be saved/restored. 
+Number 4 above is similar to number 3, but is triggered by the hardware rather than userspace software, so more execution context states may need to be saved/restored. 
 
 One key aspect of context switching is that it is transparent to the actual code that is currently executing, as the lower layers of the OS kernel will save and restore execution context as needed before resuming.
 Thus, context switching (with preemption) allows for multiple untrusted and uncooperative tasks to transparently share the CPU, while maintaining the idealistic model that they each are the only task executing in the entire system and have exclusive access to the CPU.
@@ -132,7 +132,7 @@ This scheduling function is the same function that is invoked by the aforementio
 
 Theseus tasks follow a typical task lifecycle, which is in-part demonstrated by the possible variants of the [`RunState`] enum. 
 
-* **Spawning**: the task is being created.
+* **Initing**: the task is being created.
 * **Running**: the task is executing.
     * A runnable task may be *blocked* to temporarily prevent it from being scheduled in.
     * A blocked task may be *unblocked* to mark it as runnable again.
@@ -200,7 +200,7 @@ Note that the procedure of stack unwinding accomplishes the release of most reso
 [`TaskLocalData`]: https://github.com/theseus-os/Theseus/blob/d6b86b6c46004513735079bed47ae21fc5d4b29d/kernel/task/src/lib.rs#L1085
 [`context_switch`]: https://theseus-os.github.io/Theseus/doc/context_switch/index.html
 [`context_switch()`]: https://theseus-os.github.io/Theseus/doc/context_switch_regular/fn.context_switch_regular.html
-[`task_switch()`]: https://theseus-os.github.io/Theseus/doc/task/struct.Task.html#method.task_switch
+[`task_switch()`]: https://theseus-os.github.io/Theseus/doc/task//fn.task_switch.html
 [`new_task_builder()`]: https://theseus-os.github.io/Theseus/doc/spawn/fn.new_task_builder.html
 [`task_wrapper()`]: https://github.com/theseus-os/Theseus/blob/d6b86b6c46004513735079bed47ae21fc5d4b29d/kernel/spawn/src/lib.rs#L500
 [`task_cleanup_success()`]: https://github.com/theseus-os/Theseus/blob/d6b86b6c46004513735079bed47ae21fc5d4b29d/kernel/spawn/src/lib.rs#L547

--- a/book/src/subsystems/task.md
+++ b/book/src/subsystems/task.md
@@ -11,7 +11,7 @@ One could also consider the entirety of Theseus to be a single "process" in that
 In general, the interfaces exposed by the task management subsystem in Theseus follows the Rust standard library's [model for threading](https://doc.rust-lang.org/std/thread/), with several similarities:
 * You can spawn (create) a new task with a function or a closure as the entry point.
 * You can customize a new task using a convenient builder pattern.
-* You can wait on a task to exit by *joining* it.
+* You can wait on a task to exit by [`join`]ing it.
 * You can use any standard synchronization types for inter-task communication, e.g., shared memory or channels.
 * You can catch the action of stack unwinding after a panic or exception occurs in a task.
 
@@ -132,16 +132,24 @@ This scheduling function is the same function that is invoked by the aforementio
 
 Theseus tasks follow a typical task lifecycle, which is in-part demonstrated by the possible variants of the [`RunState`] enum. 
 
-* **Initializing**: the task is being created.
-* **Running**: the task is executing.
-    * A runnable task may be *blocked* to temporarily prevent it from being scheduled in.
-    * A blocked task may be *unblocked* to mark it as runnable again.
+* **Initing**: the task is being created.
+    * After the task is finished being created and is fully spawned, its runstate will be set to Runnable.
+* **Runnable**: the task is able to be scheduled in (but is not necessarily currently executing).
+    * A runnable task may be *blocked* to prevent it from being scheduled in until it is subsequently unblocked.
     > Note: "running" and "runnable" are not the same thing.
     > * A task is considering runnable after it has spawned and before it has exited, as long as it is not blocked.
     > * A task is only said to be *running* while it is currently executing on a given CPU core, and is merely considered runnable when it is waiting to be scheduled in whilst other tasks execute.
+* **Blocked**: the task is blocked on some other condition and is not able to be scheduled in.
+    * A blocked task may be *unblocked* to mark it as runnable again.
 * **Exited**: the task is no longer executing and will never execute again.
-    * Completed: the task ran to completion normally and finished as expected.
-    * Failed: the task stopped executing prematurely as a result of a crash (language-level panic or machine-level exception) or as a result of a kill request.
+    * An exited task has an [`ExitValue`], which is one of:
+        * Completed -- the task ran to completion normally and finished as expected.
+        * Killed -- the task stopped executing prematurely as a result of a crash (language-level panic or machine-level exception) or as a result of a kill request.
+    * An exited task must not cleaned up until ist has been "reaped" (see below).
+* **Reaped**: the task has exited and its [`ExitValue`] has been taken by another `Task`.
+    * A task is cleaned up and removed from the system once it has been reaped.
+    * An exited task will be auto-reaped by the system if no other task is waiting on it to exit.
+      See [`JoinableTaskRef`] for more info on how this works.
 
 
 ### Spawning new Tasks
@@ -185,6 +193,8 @@ Note that the procedure of stack unwinding accomplishes the release of most reso
 [`Task`]: https://theseus-os.github.io/Theseus/doc/task/struct.Task.html
 [`TaskInner`]: https://github.com/theseus-os/Theseus/blob/d6b86b6c46004513735079bed47ae21fc5d4b29d/kernel/task/src/lib.rs#L237
 [`TaskRef`]: https://theseus-os.github.io/Theseus/doc/task/struct.TaskRef.html
+[`JoinableTaskRef`]: https://www.theseus-os.com/Theseus/doc/task/struct.JoinableTaskRef.html
+[`join`]: https://www.theseus-os.com/Theseus/doc/task/struct.JoinableTaskRef.html#method.join
 [environment]: https://theseus-os.github.io/Theseus/doc/environment/struct.Environment.html
 [`schedule()`]: https://theseus-os.github.io/Theseus/doc/scheduler/fn.schedule.html
 [`LocalApic`]: https://theseus-os.github.io/Theseus/doc/apic/struct.LocalApic.html
@@ -200,7 +210,7 @@ Note that the procedure of stack unwinding accomplishes the release of most reso
 [`TaskLocalData`]: https://github.com/theseus-os/Theseus/blob/d6b86b6c46004513735079bed47ae21fc5d4b29d/kernel/task/src/lib.rs#L1085
 [`context_switch`]: https://theseus-os.github.io/Theseus/doc/context_switch/index.html
 [`context_switch()`]: https://theseus-os.github.io/Theseus/doc/context_switch_regular/fn.context_switch_regular.html
-[`task_switch()`]: https://theseus-os.github.io/Theseus/doc/task//fn.task_switch.html
+[`task_switch()`]: https://theseus-os.github.io/Theseus/doc/task/fn.task_switch.html
 [`new_task_builder()`]: https://theseus-os.github.io/Theseus/doc/spawn/fn.new_task_builder.html
 [`task_wrapper()`]: https://github.com/theseus-os/Theseus/blob/d6b86b6c46004513735079bed47ae21fc5d4b29d/kernel/spawn/src/lib.rs#L500
 [`task_cleanup_success()`]: https://github.com/theseus-os/Theseus/blob/d6b86b6c46004513735079bed47ae21fc5d4b29d/kernel/spawn/src/lib.rs#L547

--- a/kernel/task_struct/src/lib.rs
+++ b/kernel/task_struct/src/lib.rs
@@ -124,7 +124,7 @@ pub enum ExitValue {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RunState {
     /// This task is in the midst of being initialized/spawned.
-    Initializing,
+    Initing,
     /// This task is able to be scheduled in, but not necessarily currently running.
     /// To check whether it is currently running, use [`Task::is_running()`].
     Runnable,

--- a/kernel/task_struct/src/lib.rs
+++ b/kernel/task_struct/src/lib.rs
@@ -109,32 +109,35 @@ impl fmt::Display for KillReason {
 /// The two ways a `Task` can exit, including possible return values and conditions.
 #[derive(Debug)]
 pub enum ExitValue {
-    /// The `Task` ran to completion and returned the enclosed [`Any`] value.
+    /// The `Task` ran to completion
+    /// and returned the enclosed [`Any`] value from its entry point function.
     ///
-    /// The caller of this type should know what type this Task returned,
-    /// and should therefore be able to downcast it appropriately.
+    /// The caller of this task's entry point function should know which concrete type
+    /// this Task returned, and is thus able to downcast it appropriately.
     Completed(Box<dyn Any + Send>),
     /// The `Task` did NOT run to completion but was instead killed for the enclosed reason.
     Killed(KillReason),
 }
 
 
-/// The set of possible runstates that a `Task` can have.
+/// The set of possible runstates that a `Task` can be in.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RunState {
-    /// in the midst of setting up the task
+    /// This task is in the midst of being initialized/spawned.
     Initing,
-    /// able to be scheduled in, but not necessarily currently running. 
-    /// To check whether it is currently running, use [`Task::is_running`]
+    /// This task is able to be scheduled in, but not necessarily currently running.
+    /// To check whether it is currently running, use [`Task::is_running()`].
     Runnable,
-    /// blocked on something, like I/O or a wait event
+    /// This task is blocked on something and is *not* able to be scheduled in.
     Blocked,
-    /// The `Task` has exited and can no longer be run,
-    /// either by running to completion or being killed. 
+    /// This `Task` has exited and can no longer be run.
+    /// This covers both the case when a task ran to completion or was killed;
+    /// see [`ExitValue`] for more details.
     Exited,
-    /// This `Task` had already exited and its `ExitValue` has been taken;
-    /// its exit value can only be taken once, and consumed by another `Task`.
-    /// This `Task` is now useless, and can be deleted and removed from the Task list.
+    /// This `Task` had already exited, and now its [`ExitValue`] has been taken
+    /// (either by another task that `join`ed it, or by the system).
+    /// Because a task's exit value can only be taken once, a repaed task
+    /// is useless and will be cleaned up and removed from the system.
     Reaped,
 }
 

--- a/kernel/task_struct/src/lib.rs
+++ b/kernel/task_struct/src/lib.rs
@@ -125,7 +125,7 @@ pub enum RunState {
     /// in the midst of setting up the task
     Initing,
     /// able to be scheduled in, but not necessarily currently running. 
-    /// To check whether it is currently running, use [`is_running`](#method.is_running)
+    /// To check whether it is currently running, use [`Task::is_running`]
     Runnable,
     /// blocked on something, like I/O or a wait event
     Blocked,

--- a/kernel/task_struct/src/lib.rs
+++ b/kernel/task_struct/src/lib.rs
@@ -124,7 +124,7 @@ pub enum ExitValue {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RunState {
     /// This task is in the midst of being initialized/spawned.
-    Initing,
+    Initializing,
     /// This task is able to be scheduled in, but not necessarily currently running.
     /// To check whether it is currently running, use [`Task::is_running()`].
     Runnable,


### PR DESCRIPTION
also changed Spawning -> Initializing in the book to match the actual code, spell checker said "Initing" isn't a word