### PR TITLE
Fix real hardware graphics mode picking

### DIFF
--- a/kernel/nano_core/src/asm/ap_realmode.asm
+++ b/kernel/nano_core/src/asm/ap_realmode.asm
@@ -181,9 +181,10 @@ get_vbe_card_info:
     jne .next_mode          ; We failed to get info about this mode. Go back and try the next mode.
 
     ; Check whether the current mode is supported by the hardware.
+    ; If bit 0 is clear, the mode is unsupported, so continue on to the next mode.
     mov word ax, [VBEModeInfo.attributes]
     test word ax, 1
-    jz .next_mode ; if first bit is clear, mode is unsupported, so fall through.
+    jz .next_mode
 
     ; We only support modes with 32-bit pixel sizes
     cmp byte [VBEModeInfo.bitsperpixel], 32

--- a/kernel/nano_core/src/asm/ap_realmode.asm
+++ b/kernel/nano_core/src/asm/ap_realmode.asm
@@ -173,16 +173,22 @@ get_vbe_card_info:
     ; Here, we attempt to get the mode info for the mode we just iterated to
     push esi
     mov [current.mode], cx  ; Store the current mode in `current.mode`
-    mov ax, 0x4F01          ; 0x4F01 is the argument fo the BIOS 0x10 interrupt used to get the currrent mode information
+    mov ax, 0x4F01          ; 0x4F01 is the argument for the BIOS 0x10 interrupt used to get the current mode information
     mov di, VBEModeInfo     ; Set `di` to the address where the mode information will be written
     int 0x10
     pop esi
     cmp al, 0x4F            ; The result is placed into `al`. A result of `0x4f` means the query was successful.
     jne .next_mode          ; We failed to get info about this mode. Go back and try the next mode.
 
+    ; Check whether the current mode is supported by the hardware.
+    mov word ax, [VBEModeInfo.attributes]
+    test word ax, 1
+    jz .next_mode ; if first bit is clear, mode is unsupported, so fall through.
+
     ; We only support modes with 32-bit pixel sizes
     cmp byte [VBEModeInfo.bitsperpixel], 32
     jne .next_mode
+
     ; Check whether the current mode is higher resolution than our maximum resolution.
     ; If it is, then continue iterating through the modes.
     mov word ax, [VBEModeInfo.width]
@@ -191,6 +197,7 @@ get_vbe_card_info:
     mov word ax, [VBEModeInfo.height]
     cmp word ax, [es:AP_MAX_FB_HEIGHT]
     ja .next_mode
+
     ; Check whether the current mode is higher resolution than the "best" mode thus far.
     ; If not, continue iterating through the modes. 
     mov word ax, [best_mode.width]


### PR DESCRIPTION
full context from discord:
> After startup (after switching away from captain), I see 4 windows mirroring each other, side by side. And they're striped black horizontally.

> https://github.com/theseus-os/Theseus/blob/40805a7934710f16f90000f65497d3a61bb7b681/kernel/multicore_bringup/src/x86_64.rs#L59 I would keep this at the start of the struct, like the field definition in https://github.com/theseus-os/Theseus/blob/40805a7934710f16f90000f65497d3a61bb7b681/kernel/nano_core/src/asm/ap_realmode.asm#L66. I also tried doing this without changing https://github.com/theseus-os/Theseus/blob/40805a7934710f16f90000f65497d3a61bb7b681/kernel/nano_core/src/asm/ap_realmode.asm#L258 to be at the first byte, and for some reason that worked for my laptop? So I hypothesize mode or width is causing the visual glitches.

> mode is 292 / 0x124 / 0001_0010_0100

> GraphicInfo._attributes is 0xBA is 0b10111010, sooo, the best_mode.mode we select is not supported?
> see VBE core functions, ModeAttributes
> ![0 means unsupported by hardware](https://user-images.githubusercontent.com/108802164/236742101-d0e8fda8-4adc-40af-a825-8a837da78b7c.png)

There's just a small visual bug left at the end of captain, which I think is happening because we set the VGA card via BIOS interrupt immediately on the last AP's init in handle_ap_cores, so it changes graphic modes while still logging to the screen (and maybe BIOS or the window manager or sth doesn't like that).
