### PR TITLE
Move convenience mapping functions from `nic_initialization` to `memory`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,7 +2099,6 @@ dependencies = [
  "memory",
  "mpmc",
  "nic_buffers",
- "nic_initialization",
  "num_enum",
  "volatile 0.2.7",
  "zerocopy",
@@ -2376,7 +2375,6 @@ dependencies = [
  "mpmc",
  "nic_buffers",
  "nic_queues",
- "pci",
  "volatile 0.2.7",
 ]
 

--- a/kernel/e1000/src/lib.rs
+++ b/kernel/e1000/src/lib.rs
@@ -34,13 +34,13 @@ use regs::*;
 use spin::Once; 
 use alloc::{collections::VecDeque, format, sync::Arc, vec::Vec};
 use irq_safety::MutexIrqSafe;
-use memory::{PhysicalAddress, BorrowedMappedPages, BorrowedSliceMappedPages, Mutable};
+use memory::{PhysicalAddress, BorrowedMappedPages, BorrowedSliceMappedPages, Mutable, map_mmio_range};
 use pci::{PciDevice, PCI_INTERRUPT_LINE, PciConfigSpaceAccessMechanism};
 use kernel_config::memory::PAGE_SIZE;
 use interrupts::eoi;
 use x86_64::structures::idt::InterruptStackFrame;
 use network_interface_card:: NetworkInterfaceCard;
-use nic_initialization::{allocate_memory, init_rx_buf_pool, init_rx_queue, init_tx_queue};
+use nic_initialization::{init_rx_buf_pool, init_rx_queue, init_tx_queue};
 use intel_ethernet::descriptors::{LegacyRxDescriptor, LegacyTxDescriptor};
 use nic_buffers::{TransmitBuffer, ReceiveBuffer, ReceivedFrame};
 use nic_queues::{RxQueue, TxQueue, RxQueueRegisters, TxQueueRegisters};
@@ -289,7 +289,7 @@ impl E1000Nic {
     /// * `device`: reference to the nic device
     /// * `mem_base`: the physical address where the NIC's memory starts.
     fn map_e1000_regs(
-        _device: &PciDevice, 
+        _device: &PciDevice,
         mem_base: PhysicalAddress,
     ) -> Result<(
         BorrowedMappedPages<E1000Registers, Mutable>, 
@@ -303,10 +303,10 @@ impl E1000Nic {
         const TX_REGISTERS_SIZE_BYTES: usize = 4096;
         const MAC_REGISTERS_SIZE_BYTES: usize = 114_688;
 
-        let nic_regs_mapped_page     = allocate_memory(mem_base, GENERAL_REGISTERS_SIZE_BYTES)?;
-        let nic_rx_regs_mapped_page  = allocate_memory(mem_base + GENERAL_REGISTERS_SIZE_BYTES, RX_REGISTERS_SIZE_BYTES)?;
-        let nic_tx_regs_mapped_page  = allocate_memory(mem_base + GENERAL_REGISTERS_SIZE_BYTES + RX_REGISTERS_SIZE_BYTES, TX_REGISTERS_SIZE_BYTES)?;
-        let nic_mac_regs_mapped_page = allocate_memory(mem_base + GENERAL_REGISTERS_SIZE_BYTES + RX_REGISTERS_SIZE_BYTES + TX_REGISTERS_SIZE_BYTES, MAC_REGISTERS_SIZE_BYTES)?;
+        let nic_regs_mapped_page     = map_mmio_range(mem_base, GENERAL_REGISTERS_SIZE_BYTES)?;
+        let nic_rx_regs_mapped_page  = map_mmio_range(mem_base + GENERAL_REGISTERS_SIZE_BYTES, RX_REGISTERS_SIZE_BYTES)?;
+        let nic_tx_regs_mapped_page  = map_mmio_range(mem_base + GENERAL_REGISTERS_SIZE_BYTES + RX_REGISTERS_SIZE_BYTES, TX_REGISTERS_SIZE_BYTES)?;
+        let nic_mac_regs_mapped_page = map_mmio_range(mem_base + GENERAL_REGISTERS_SIZE_BYTES + RX_REGISTERS_SIZE_BYTES + TX_REGISTERS_SIZE_BYTES, MAC_REGISTERS_SIZE_BYTES)?;
 
         let regs     = nic_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
         let rx_regs  = nic_rx_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;

--- a/kernel/e1000/src/lib.rs
+++ b/kernel/e1000/src/lib.rs
@@ -34,7 +34,7 @@ use regs::*;
 use spin::Once; 
 use alloc::{collections::VecDeque, format, sync::Arc, vec::Vec};
 use irq_safety::MutexIrqSafe;
-use memory::{PhysicalAddress, BorrowedMappedPages, BorrowedSliceMappedPages, Mutable, map_mmio_range};
+use memory::{PhysicalAddress, BorrowedMappedPages, BorrowedSliceMappedPages, Mutable, map_frame_range, MMIO_FLAGS};
 use pci::{PciDevice, PCI_INTERRUPT_LINE, PciConfigSpaceAccessMechanism};
 use kernel_config::memory::PAGE_SIZE;
 use interrupts::eoi;
@@ -303,14 +303,21 @@ impl E1000Nic {
         const TX_REGISTERS_SIZE_BYTES: usize = 4096;
         const MAC_REGISTERS_SIZE_BYTES: usize = 114_688;
 
-        let nic_regs_mapped_page     = map_mmio_range(mem_base, GENERAL_REGISTERS_SIZE_BYTES)?;
-        let nic_rx_regs_mapped_page  = map_mmio_range(mem_base + GENERAL_REGISTERS_SIZE_BYTES, RX_REGISTERS_SIZE_BYTES)?;
-        let nic_tx_regs_mapped_page  = map_mmio_range(mem_base + GENERAL_REGISTERS_SIZE_BYTES + RX_REGISTERS_SIZE_BYTES, TX_REGISTERS_SIZE_BYTES)?;
-        let nic_mac_regs_mapped_page = map_mmio_range(mem_base + GENERAL_REGISTERS_SIZE_BYTES + RX_REGISTERS_SIZE_BYTES + TX_REGISTERS_SIZE_BYTES, MAC_REGISTERS_SIZE_BYTES)?;
+        let mut offset = mem_base;
 
-        let regs     = nic_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
-        let rx_regs  = nic_rx_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
-        let tx_regs  = nic_tx_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
+        let nic_regs_mapped_page = map_frame_range(offset, GENERAL_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
+        let regs = nic_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
+        offset += GENERAL_REGISTERS_SIZE_BYTES;
+
+        let nic_rx_regs_mapped_page = map_frame_range(offset, RX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
+        let rx_regs = nic_rx_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
+        offset += RX_REGISTERS_SIZE_BYTES;
+
+        let nic_tx_regs_mapped_page = map_frame_range(offset, TX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
+        let tx_regs = nic_tx_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
+        offset += TX_REGISTERS_SIZE_BYTES;
+
+        let nic_mac_regs_mapped_page = map_frame_range(offset, MAC_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
         let mac_regs = nic_mac_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
 
         Ok((regs, rx_regs, tx_regs, mac_regs))

--- a/kernel/e1000/src/lib.rs
+++ b/kernel/e1000/src/lib.rs
@@ -303,21 +303,21 @@ impl E1000Nic {
         const TX_REGISTERS_SIZE_BYTES: usize = 4096;
         const MAC_REGISTERS_SIZE_BYTES: usize = 114_688;
 
-        let mut offset = mem_base;
+        let mut physical_addr = mem_base;
 
-        let nic_regs_mapped_page = map_frame_range(offset, GENERAL_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
+        let nic_regs_mapped_page = map_frame_range(physical_addr, GENERAL_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
         let regs = nic_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
-        offset += GENERAL_REGISTERS_SIZE_BYTES;
+        physical_addr += GENERAL_REGISTERS_SIZE_BYTES;
 
-        let nic_rx_regs_mapped_page = map_frame_range(offset, RX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
+        let nic_rx_regs_mapped_page = map_frame_range(physical_addr, RX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
         let rx_regs = nic_rx_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
-        offset += RX_REGISTERS_SIZE_BYTES;
+        physical_addr += RX_REGISTERS_SIZE_BYTES;
 
-        let nic_tx_regs_mapped_page = map_frame_range(offset, TX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
+        let nic_tx_regs_mapped_page = map_frame_range(physical_addr, TX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
         let tx_regs = nic_tx_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
-        offset += TX_REGISTERS_SIZE_BYTES;
+        physical_addr += TX_REGISTERS_SIZE_BYTES;
 
-        let nic_mac_regs_mapped_page = map_frame_range(offset, MAC_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
+        let nic_mac_regs_mapped_page = map_frame_range(physical_addr, MAC_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
         let mac_regs = nic_mac_regs_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
 
         Ok((regs, rx_regs, tx_regs, mac_regs))

--- a/kernel/ixgbe/src/lib.rs
+++ b/kernel/ixgbe/src/lib.rs
@@ -53,7 +53,7 @@ use alloc::{
     vec::Vec,
 };
 use irq_safety::MutexIrqSafe;
-use memory::{PhysicalAddress, MappedPages, Mutable, BorrowedSliceMappedPages, BorrowedMappedPages, map_mmio_range};
+use memory::{PhysicalAddress, MappedPages, Mutable, BorrowedSliceMappedPages, BorrowedMappedPages, map_frame_range, MMIO_FLAGS};
 use pci::{PciDevice, MSIX_CAPABILITY, PciConfigSpaceAccessMechanism, PciLocation};
 use bit_field::BitField;
 use interrupts::{register_msi_interrupt, InterruptHandler};
@@ -446,25 +446,25 @@ impl IxgbeNic {
 
         // Allocate memory for the registers, making sure each successive memory region begins where the previous region ended.
         let mut offset = mem_base;
-        let nic_regs1_mapped_page = map_mmio_range(offset, GENERAL_REGISTERS_1_SIZE_BYTES)?;
+        let nic_regs1_mapped_page = map_frame_range(offset, GENERAL_REGISTERS_1_SIZE_BYTES, MMIO_FLAGS)?;
 
         offset += GENERAL_REGISTERS_1_SIZE_BYTES;
-        let nic_rx_regs1_mapped_page = map_mmio_range(offset, RX_REGISTERS_SIZE_BYTES)?;
+        let nic_rx_regs1_mapped_page = map_frame_range(offset, RX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
 
         offset += RX_REGISTERS_SIZE_BYTES;
-        let nic_regs2_mapped_page = map_mmio_range(offset, GENERAL_REGISTERS_2_SIZE_BYTES)?;  
+        let nic_regs2_mapped_page = map_frame_range(offset, GENERAL_REGISTERS_2_SIZE_BYTES, MMIO_FLAGS)?;
 
         offset += GENERAL_REGISTERS_2_SIZE_BYTES;
-        let nic_tx_regs_mapped_page = map_mmio_range(offset, TX_REGISTERS_SIZE_BYTES)?;
+        let nic_tx_regs_mapped_page = map_frame_range(offset, TX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
 
         offset += TX_REGISTERS_SIZE_BYTES;
-        let nic_mac_regs_mapped_page = map_mmio_range(offset, MAC_REGISTERS_SIZE_BYTES)?;
+        let nic_mac_regs_mapped_page = map_frame_range(offset, MAC_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
 
         offset += MAC_REGISTERS_SIZE_BYTES;
-        let nic_rx_regs2_mapped_page = map_mmio_range(offset, RX_REGISTERS_SIZE_BYTES)?;   
+        let nic_rx_regs2_mapped_page = map_frame_range(offset, RX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
 
         offset += RX_REGISTERS_SIZE_BYTES;
-        let nic_regs3_mapped_page = map_mmio_range(offset, GENERAL_REGISTERS_3_SIZE_BYTES)?;
+        let nic_regs3_mapped_page = map_frame_range(offset, GENERAL_REGISTERS_3_SIZE_BYTES, MMIO_FLAGS)?;
 
         // Map the memory as the register struct and tie the lifetime of the struct with its backing mapped pages
         let regs1    = nic_regs1_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
@@ -558,7 +558,7 @@ impl IxgbeNic {
 
         // debug!("msi-x vector table bar: {}, base_address: {:#X} and size: {} bytes", bar, mem_base, mem_size_in_bytes);
 
-        let msix_mapped_pages = map_mmio_range(mem_base, mem_size_in_bytes)?;
+        let msix_mapped_pages = map_frame_range(mem_base, mem_size_in_bytes, MMIO_FLAGS)?;
         let vector_table = BorrowedMappedPages::from_mut(msix_mapped_pages, 0)
             .map_err(|(_mp, err)| err)?;
 

--- a/kernel/ixgbe/src/lib.rs
+++ b/kernel/ixgbe/src/lib.rs
@@ -445,26 +445,26 @@ impl IxgbeNic {
         const GENERAL_REGISTERS_3_SIZE_BYTES:   usize = 18 * 4096;
 
         // Allocate memory for the registers, making sure each successive memory region begins where the previous region ended.
-        let mut offset = mem_base;
-        let nic_regs1_mapped_page = map_frame_range(offset, GENERAL_REGISTERS_1_SIZE_BYTES, MMIO_FLAGS)?;
+        let mut physical_addr = mem_base;
+        let nic_regs1_mapped_page = map_frame_range(physical_addr, GENERAL_REGISTERS_1_SIZE_BYTES, MMIO_FLAGS)?;
 
-        offset += GENERAL_REGISTERS_1_SIZE_BYTES;
-        let nic_rx_regs1_mapped_page = map_frame_range(offset, RX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
+        physical_addr += GENERAL_REGISTERS_1_SIZE_BYTES;
+        let nic_rx_regs1_mapped_page = map_frame_range(physical_addr, RX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
 
-        offset += RX_REGISTERS_SIZE_BYTES;
-        let nic_regs2_mapped_page = map_frame_range(offset, GENERAL_REGISTERS_2_SIZE_BYTES, MMIO_FLAGS)?;
+        physical_addr += RX_REGISTERS_SIZE_BYTES;
+        let nic_regs2_mapped_page = map_frame_range(physical_addr, GENERAL_REGISTERS_2_SIZE_BYTES, MMIO_FLAGS)?;
 
-        offset += GENERAL_REGISTERS_2_SIZE_BYTES;
-        let nic_tx_regs_mapped_page = map_frame_range(offset, TX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
+        physical_addr += GENERAL_REGISTERS_2_SIZE_BYTES;
+        let nic_tx_regs_mapped_page = map_frame_range(physical_addr, TX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
 
-        offset += TX_REGISTERS_SIZE_BYTES;
-        let nic_mac_regs_mapped_page = map_frame_range(offset, MAC_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
+        physical_addr += TX_REGISTERS_SIZE_BYTES;
+        let nic_mac_regs_mapped_page = map_frame_range(physical_addr, MAC_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
 
-        offset += MAC_REGISTERS_SIZE_BYTES;
-        let nic_rx_regs2_mapped_page = map_frame_range(offset, RX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
+        physical_addr += MAC_REGISTERS_SIZE_BYTES;
+        let nic_rx_regs2_mapped_page = map_frame_range(physical_addr, RX_REGISTERS_SIZE_BYTES, MMIO_FLAGS)?;
 
-        offset += RX_REGISTERS_SIZE_BYTES;
-        let nic_regs3_mapped_page = map_frame_range(offset, GENERAL_REGISTERS_3_SIZE_BYTES, MMIO_FLAGS)?;
+        physical_addr += RX_REGISTERS_SIZE_BYTES;
+        let nic_regs3_mapped_page = map_frame_range(physical_addr, GENERAL_REGISTERS_3_SIZE_BYTES, MMIO_FLAGS)?;
 
         // Map the memory as the register struct and tie the lifetime of the struct with its backing mapped pages
         let regs1    = nic_regs1_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;

--- a/kernel/ixgbe/src/lib.rs
+++ b/kernel/ixgbe/src/lib.rs
@@ -53,7 +53,7 @@ use alloc::{
     vec::Vec,
 };
 use irq_safety::MutexIrqSafe;
-use memory::{PhysicalAddress, MappedPages, Mutable, BorrowedSliceMappedPages, BorrowedMappedPages};
+use memory::{PhysicalAddress, MappedPages, Mutable, BorrowedSliceMappedPages, BorrowedMappedPages, map_mmio_range};
 use pci::{PciDevice, MSIX_CAPABILITY, PciConfigSpaceAccessMechanism, PciLocation};
 use bit_field::BitField;
 use interrupts::{register_msi_interrupt, InterruptHandler};
@@ -446,25 +446,25 @@ impl IxgbeNic {
 
         // Allocate memory for the registers, making sure each successive memory region begins where the previous region ended.
         let mut offset = mem_base;
-        let nic_regs1_mapped_page = allocate_memory(offset, GENERAL_REGISTERS_1_SIZE_BYTES)?;
+        let nic_regs1_mapped_page = map_mmio_range(offset, GENERAL_REGISTERS_1_SIZE_BYTES)?;
 
         offset += GENERAL_REGISTERS_1_SIZE_BYTES;
-        let nic_rx_regs1_mapped_page = allocate_memory(offset, RX_REGISTERS_SIZE_BYTES)?;
+        let nic_rx_regs1_mapped_page = map_mmio_range(offset, RX_REGISTERS_SIZE_BYTES)?;
 
         offset += RX_REGISTERS_SIZE_BYTES;
-        let nic_regs2_mapped_page = allocate_memory(offset, GENERAL_REGISTERS_2_SIZE_BYTES)?;  
+        let nic_regs2_mapped_page = map_mmio_range(offset, GENERAL_REGISTERS_2_SIZE_BYTES)?;  
 
         offset += GENERAL_REGISTERS_2_SIZE_BYTES;
-        let nic_tx_regs_mapped_page = allocate_memory(offset, TX_REGISTERS_SIZE_BYTES)?;
+        let nic_tx_regs_mapped_page = map_mmio_range(offset, TX_REGISTERS_SIZE_BYTES)?;
 
         offset += TX_REGISTERS_SIZE_BYTES;
-        let nic_mac_regs_mapped_page = allocate_memory(offset, MAC_REGISTERS_SIZE_BYTES)?;
+        let nic_mac_regs_mapped_page = map_mmio_range(offset, MAC_REGISTERS_SIZE_BYTES)?;
 
         offset += MAC_REGISTERS_SIZE_BYTES;
-        let nic_rx_regs2_mapped_page = allocate_memory(offset, RX_REGISTERS_SIZE_BYTES)?;   
+        let nic_rx_regs2_mapped_page = map_mmio_range(offset, RX_REGISTERS_SIZE_BYTES)?;   
 
         offset += RX_REGISTERS_SIZE_BYTES;
-        let nic_regs3_mapped_page = allocate_memory(offset, GENERAL_REGISTERS_3_SIZE_BYTES)?;
+        let nic_regs3_mapped_page = map_mmio_range(offset, GENERAL_REGISTERS_3_SIZE_BYTES)?;
 
         // Map the memory as the register struct and tie the lifetime of the struct with its backing mapped pages
         let regs1    = nic_regs1_mapped_page.into_borrowed_mut(0).map_err(|(_mp, err)| err)?;
@@ -558,7 +558,7 @@ impl IxgbeNic {
 
         // debug!("msi-x vector table bar: {}, base_address: {:#X} and size: {} bytes", bar, mem_base, mem_size_in_bytes);
 
-        let msix_mapped_pages = allocate_memory(mem_base, mem_size_in_bytes)?;
+        let msix_mapped_pages = map_mmio_range(mem_base, mem_size_in_bytes)?;
         let vector_table = BorrowedMappedPages::from_mut(msix_mapped_pages, 0)
             .map_err(|(_mp, err)| err)?;
 

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -85,6 +85,13 @@ pub const MMIO_FLAGS: PteFlags = PteFlags::from_bits_truncate(
     | PteFlags::DEVICE_MEMORY.bits()
 );
 
+/// Mapping flags that can be used to map DMA (Direct Memory Access) memory.
+pub const DMA_FLAGS: PteFlags = PteFlags::from_bits_truncate(
+    PteFlags::new().bits()
+    | PteFlags::VALID.bits()
+    | PteFlags::WRITABLE.bits()
+);
+
 
 /// A convenience function that creates a new memory mapping by allocating frames that are contiguous in physical memory.
 /// If contiguous frames are not required, then see [`create_mapping()`](fn.create_mapping.html).

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -77,6 +77,14 @@ pub struct MemoryManagementInfo {
     pub extra_mapped_pages: Vec<MappedPages>,
 }
 
+/// Mapping flags that can be used to map MMIO registers.
+pub const MMIO_FLAGS: PteFlags = PteFlags::from_bits_truncate(
+    PteFlags::new().bits()
+    | PteFlags::VALID.bits()
+    | PteFlags::WRITABLE.bits()
+    | PteFlags::DEVICE_MEMORY.bits()
+);
+
 
 /// A convenience function that creates a new memory mapping by allocating frames that are contiguous in physical memory.
 /// If contiguous frames are not required, then see [`create_mapping()`](fn.create_mapping.html).
@@ -96,6 +104,37 @@ pub fn create_contiguous_mapping<F: Into<PteFlagsArch>>(
     let starting_phys_addr = allocated_frames.start_address();
     let mp = kernel_mmi_ref.lock().page_table.map_allocated_pages_to(allocated_pages, allocated_frames, flags)?;
     Ok((mp, starting_phys_addr))
+}
+
+
+/// A convenience function that creates a new memory mapping by allocating specific frames from physical memory.
+/// Returns the new `MappedPages`.
+/// 
+/// # Locking / Deadlock
+/// Currently, this function acquires the lock on the frame allocator and the kernel's `MemoryManagementInfo` instance.
+/// Thus, the caller should ensure that the locks on those two variables are not held when invoking this function.
+pub fn map_frame_range<F: Into<PteFlagsArch>>(
+    range: FrameRange,
+    flags: F,
+) -> Result<MappedPages, &'static str> {
+    let kernel_mmi_ref = get_kernel_mmi_ref().ok_or("map_range(): KERNEL_MMI was not yet initialized!")?;
+    let num_frames = range.size_in_frames();
+    let allocated_pages = allocate_pages(num_frames).ok_or("memory::map_range(): couldn't allocate contiguous pages!")?;
+    let allocated_frames = allocate_frames_by_bytes_at(range.start_address(), num_frames)
+        .map_err(|_| "memory::map_range(): couldn't allocate contiguous frames!")?;
+    kernel_mmi_ref.lock().page_table.map_allocated_pages_to(allocated_pages, allocated_frames, flags)
+}
+
+
+/// A convenience function that creates a new memory mapping by allocating specific frames from physical memory
+/// with [`MMIO_FLAGS`] as flags.
+/// Returns the new `MappedPages`.
+/// 
+/// # Locking / Deadlock
+/// Currently, this function acquires the lock on the frame allocator and the kernel's `MemoryManagementInfo` instance.
+/// Thus, the caller should ensure that the locks on those two variables are not held when invoking this function.
+pub fn map_mmio_range(mem_base: PhysicalAddress, mem_size_in_bytes: usize) -> Result<MappedPages, &'static str> {
+    map_frame_range(FrameRange::from_phys_addr(mem_base, mem_size_in_bytes), MMIO_FLAGS)
 }
 
 

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -114,8 +114,7 @@ pub fn create_contiguous_mapping<F: Into<PteFlagsArch>>(
 }
 
 
-/// A convenience function that creates a new memory mapping by allocating specific frames from physical memory.
-/// Returns the new `MappedPages`.
+/// A convenience function that maps randomly-allocated pages to the given range of frames.
 /// 
 /// # Locking / Deadlock
 /// Currently, this function acquires the lock on the frame allocator and the kernel's `MemoryManagementInfo` instance.

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -120,7 +120,7 @@ pub fn map_frame_range<F: Into<PteFlagsArch>>(
     let kernel_mmi_ref = get_kernel_mmi_ref().ok_or("map_range(): KERNEL_MMI was not yet initialized!")?;
     let num_frames = range.size_in_frames();
     let allocated_pages = allocate_pages(num_frames).ok_or("memory::map_range(): couldn't allocate contiguous pages!")?;
-    let allocated_frames = allocate_frames_by_bytes_at(range.start_address(), num_frames)
+    let allocated_frames = allocate_frames_at(range.start_address(), num_frames)
         .map_err(|_| "memory::map_range(): couldn't allocate contiguous frames!")?;
     kernel_mmi_ref.lock().page_table.map_allocated_pages_to(allocated_pages, allocated_frames, flags)
 }

--- a/kernel/mlx5/src/lib.rs
+++ b/kernel/mlx5/src/lib.rs
@@ -29,9 +29,9 @@ extern crate mpmc;
 use spin::Once; 
 use alloc::vec::Vec;
 use irq_safety::MutexIrqSafe;
-use memory::{PhysicalAddress, MappedPages, create_contiguous_mapping, BorrowedMappedPages, Mutable};
+use memory::{PhysicalAddress, MappedPages, create_contiguous_mapping, map_mmio_range, BorrowedMappedPages, Mutable, MMIO_FLAGS};
 use pci::PciDevice;
-use nic_initialization::{NIC_MAPPING_FLAGS, allocate_memory, init_rx_buf_pool};
+use nic_initialization::init_rx_buf_pool;
 use mlx_ethernet::{
     command_queue::{AccessRegisterOpMod, CommandBuilder, CommandOpcode, CommandQueue, CommandQueueEntry, HCACapabilities, ManagePagesOpMod, QueryHcaCapCurrentOpMod, QueryHcaCapMaxOpMod, QueryPagesOpMod}, 
     completion_queue::{CompletionQueue, CompletionQueueEntry, CompletionQueueDoorbellRecord}, 
@@ -175,7 +175,7 @@ impl ConnectX5Nic {
         trace!("total size in bytes of cmdq = {}", size_in_bytes_of_cmdq);
     
         // allocate mapped pages for the command queue
-        let (cmdq_mapped_pages, cmdq_starting_phys_addr) = create_contiguous_mapping(size_in_bytes_of_cmdq, NIC_MAPPING_FLAGS)?;
+        let (cmdq_mapped_pages, cmdq_starting_phys_addr) = create_contiguous_mapping(size_in_bytes_of_cmdq, MMIO_FLAGS)?;
         trace!("cmdq mem base = {}", cmdq_starting_phys_addr);
     
         // cast our physically-contiguous MappedPages into a slice of command queue entries
@@ -364,7 +364,7 @@ impl ConnectX5Nic {
         // execute CREATE_EQ for page request event
         // 1. Allocate pages for EQ
         let num_eq_entries = 64;
-        let (eq_mp, eq_pa) = create_contiguous_mapping(num_eq_entries * core::mem::size_of::<EventQueueEntry>(), NIC_MAPPING_FLAGS)?;
+        let (eq_mp, eq_pa) = create_contiguous_mapping(num_eq_entries * core::mem::size_of::<EventQueueEntry>(), MMIO_FLAGS)?;
     
         let completed_cmd = cmdq.create_and_execute_command(
             CommandBuilder::new(CommandOpcode::CreateEq)
@@ -410,10 +410,10 @@ impl ConnectX5Nic {
         // execute CREATE_CQ for SQ 
 
         // 1. Allocate pages for CQ
-        let (cq_mp, cq_pa) = create_contiguous_mapping(NUM_CQ_ENTRIES_SEND * core::mem::size_of::<CompletionQueueEntry>(), NIC_MAPPING_FLAGS)?;
+        let (cq_mp, cq_pa) = create_contiguous_mapping(NUM_CQ_ENTRIES_SEND * core::mem::size_of::<CompletionQueueEntry>(), MMIO_FLAGS)?;
 
         // 2. Allocate page for doorbell
-        let (db_page, db_pa) = create_contiguous_mapping(core::mem::size_of::<CompletionQueueDoorbellRecord>(), NIC_MAPPING_FLAGS)?;
+        let (db_page, db_pa) = create_contiguous_mapping(core::mem::size_of::<CompletionQueueDoorbellRecord>(), MMIO_FLAGS)?;
         
         let completed_cmd = cmdq.create_and_execute_command(
             CommandBuilder::new(CommandOpcode::CreateCq) 
@@ -439,9 +439,9 @@ impl ConnectX5Nic {
 
         // 1. Allocate pages for CQ
         let cq_entries_r = num_rx_descs; 
-        let (cq_mp, cq_pa) = create_contiguous_mapping(cq_entries_r * core::mem::size_of::<CompletionQueueEntry>(), NIC_MAPPING_FLAGS)?;
+        let (cq_mp, cq_pa) = create_contiguous_mapping(cq_entries_r * core::mem::size_of::<CompletionQueueEntry>(), MMIO_FLAGS)?;
         // 2. Allocate page for doorbell
-        let (db_page, db_pa) = create_contiguous_mapping(core::mem::size_of::<CompletionQueueDoorbellRecord>(), NIC_MAPPING_FLAGS)?;
+        let (db_page, db_pa) = create_contiguous_mapping(core::mem::size_of::<CompletionQueueDoorbellRecord>(), MMIO_FLAGS)?;
         
         let completed_cmd = cmdq.create_and_execute_command(
             CommandBuilder::new(CommandOpcode::CreateCq) 
@@ -467,7 +467,7 @@ impl ConnectX5Nic {
         trace!("CreateTis: {:?}, tisn: {:?}", status, tisn);
 
         // Allocate pages for RQ and SQ, they have to be contiguous      
-        let (q_mp, q_pa) = create_contiguous_mapping(rq_size_in_bytes + sq_size_in_bytes, NIC_MAPPING_FLAGS)?;
+        let (q_mp, q_pa) = create_contiguous_mapping(rq_size_in_bytes + sq_size_in_bytes, MMIO_FLAGS)?;
         let vaddr = q_mp.start_address();
         let (rq_mp, sq_mp) = q_mp.split(memory_structs::Page::containing_address(vaddr + rq_size_in_bytes))
             .map_err(|_e| "Could not split MappedPages")?;
@@ -475,13 +475,13 @@ impl ConnectX5Nic {
         debug!("RQ paddr: {:?}, SQ paddr: {:?}, RQ vaddr: {:?}, SQ vaddr: {:?}", q_pa, sq_pa, rq_mp.start_address(), sq_mp.start_address());
 
         // Allocate page for SQ/RQ doorbell
-        let (db_page, db_pa) = create_contiguous_mapping(core::mem::size_of::<DoorbellRecord>(), NIC_MAPPING_FLAGS)?;
+        let (db_page, db_pa) = create_contiguous_mapping(core::mem::size_of::<DoorbellRecord>(), MMIO_FLAGS)?;
         debug!("doorbell: {:#x}", db_pa);
 
         // Allocate page for UAR. 
         // For the given uar number i, the page is the ith page from the memory base retrieved from the PCI BAR
         let uar_mem_base = mem_base + ((uar as usize) * PAGE_SIZE);
-        let uar_page = allocate_memory(uar_mem_base, PAGE_SIZE)?;
+        let uar_page = map_mmio_range(uar_mem_base, PAGE_SIZE)?;
         debug!("mmio: {:?}, uar: {:?}", mem_base, uar_mem_base);
 
         // Create the SQ
@@ -642,7 +642,7 @@ impl ConnectX5Nic {
     
     /// Returns the memory-mapped initialization segment of the NIC
     fn map_init_segment(mem_base: PhysicalAddress) -> Result<BorrowedMappedPages<InitializationSegment, Mutable>, &'static str> {
-        allocate_memory(mem_base, core::mem::size_of::<InitializationSegment>())?
+        map_mmio_range(mem_base, core::mem::size_of::<InitializationSegment>())?
             .into_borrowed_mut(0)
             .map_err(|(_mp, err)| err)
     }
@@ -653,7 +653,7 @@ impl ConnectX5Nic {
         let mut mp = Vec::with_capacity(num_pages);
         let mut paddr = Vec::with_capacity(num_pages);
         for _ in 0..num_pages {
-            let (page, pa) = create_contiguous_mapping(PAGE_SIZE, NIC_MAPPING_FLAGS)?;
+            let (page, pa) = create_contiguous_mapping(PAGE_SIZE, MMIO_FLAGS)?;
             mp.push(page);
             paddr.push(pa);
         }

--- a/kernel/mlx5/src/lib.rs
+++ b/kernel/mlx5/src/lib.rs
@@ -29,7 +29,7 @@ extern crate mpmc;
 use spin::Once; 
 use alloc::vec::Vec;
 use irq_safety::MutexIrqSafe;
-use memory::{PhysicalAddress, MappedPages, create_contiguous_mapping, map_mmio_range, BorrowedMappedPages, Mutable, MMIO_FLAGS};
+use memory::{PhysicalAddress, MappedPages, create_contiguous_mapping, map_frame_range, BorrowedMappedPages, Mutable, MMIO_FLAGS};
 use pci::PciDevice;
 use nic_initialization::init_rx_buf_pool;
 use mlx_ethernet::{
@@ -481,7 +481,7 @@ impl ConnectX5Nic {
         // Allocate page for UAR. 
         // For the given uar number i, the page is the ith page from the memory base retrieved from the PCI BAR
         let uar_mem_base = mem_base + ((uar as usize) * PAGE_SIZE);
-        let uar_page = map_mmio_range(uar_mem_base, PAGE_SIZE)?;
+        let uar_page = map_frame_range(uar_mem_base, PAGE_SIZE, MMIO_FLAGS)?;
         debug!("mmio: {:?}, uar: {:?}", mem_base, uar_mem_base);
 
         // Create the SQ
@@ -642,7 +642,7 @@ impl ConnectX5Nic {
     
     /// Returns the memory-mapped initialization segment of the NIC
     fn map_init_segment(mem_base: PhysicalAddress) -> Result<BorrowedMappedPages<InitializationSegment, Mutable>, &'static str> {
-        map_mmio_range(mem_base, core::mem::size_of::<InitializationSegment>())?
+        map_frame_range(mem_base, core::mem::size_of::<InitializationSegment>(), MMIO_FLAGS)?
             .into_borrowed_mut(0)
             .map_err(|(_mp, err)| err)
     }

--- a/kernel/mlx_ethernet/Cargo.toml
+++ b/kernel/mlx_ethernet/Cargo.toml
@@ -19,9 +19,6 @@ default-features = false
 [dependencies.memory]
 path = "../memory"
 
-[dependencies.nic_initialization]
-path = "../nic_initialization"
-
 [dependencies.kernel_config]
 path = "../kernel_config"
 

--- a/kernel/mlx_ethernet/src/command_queue.rs
+++ b/kernel/mlx_ethernet/src/command_queue.rs
@@ -4,12 +4,11 @@
 #![allow(clippy::upper_case_acronyms)]
 
 use alloc::{vec::Vec, boxed::Box};
-use memory::{PhysicalAddress, MappedPages, create_contiguous_mapping, BorrowedSliceMappedPages, Mutable};
+use memory::{PhysicalAddress, MappedPages, create_contiguous_mapping, BorrowedSliceMappedPages, Mutable, MMIO_FLAGS};
 use volatile::{ReadOnly,Volatile};
 use bit_field::BitField;
 use zerocopy::{U32, FromBytes};
 use byteorder::BigEndian;
-use nic_initialization::NIC_MAPPING_FLAGS;
 use kernel_config::memory::PAGE_SIZE;
 use core::fmt;
 use num_enum::TryFromPrimitive;
@@ -720,7 +719,7 @@ impl CommandQueue {
         // start off by pre-allocating one page per entry
         let mut mailbox_buffers= Vec::with_capacity(num_cmdq_entries);
         for _ in 0..num_cmdq_entries {
-            let (mp, addr) = create_contiguous_mapping(PAGE_SIZE, NIC_MAPPING_FLAGS)?;
+            let (mp, addr) = create_contiguous_mapping(PAGE_SIZE, MMIO_FLAGS)?;
             mailbox_buffers.push(MailboxBuffer{mp, addr});
         }
 
@@ -974,7 +973,7 @@ impl CommandQueue {
             if let Some(mb_buffer) = self.mailbox_buffers.pop() {
                 command_mailbox_buffers.push(mb_buffer);
             } else {
-                let (mp, addr) = create_contiguous_mapping(PAGE_SIZE, NIC_MAPPING_FLAGS)
+                let (mp, addr) = create_contiguous_mapping(PAGE_SIZE, MMIO_FLAGS)
                     .map_err(|_e| CommandQueueError::PageAllocationFailed)?;
                 command_mailbox_buffers.push(MailboxBuffer{mp, addr});
             }

--- a/kernel/mlx_ethernet/src/lib.rs
+++ b/kernel/mlx_ethernet/src/lib.rs
@@ -20,7 +20,6 @@ extern crate volatile;
 extern crate bit_field;
 extern crate zerocopy;
 extern crate byteorder;
-extern crate nic_initialization;
 extern crate kernel_config;
 extern crate libm;
 extern crate num_enum;

--- a/kernel/mlx_ethernet/src/receive_queue.rs
+++ b/kernel/mlx_ethernet/src/receive_queue.rs
@@ -7,13 +7,12 @@
 use zerocopy::{U32, FromBytes};
 use volatile::Volatile;
 use byteorder::BigEndian;
-use memory::{MappedPages, create_contiguous_mapping, BorrowedSliceMappedPages, Mutable};
+use memory::{MappedPages, create_contiguous_mapping, BorrowedSliceMappedPages, Mutable, MMIO_FLAGS};
 use core::fmt;
 use num_enum::TryFromPrimitive;
 use core::convert::TryFrom;
 use alloc::vec::Vec;
 use nic_buffers::ReceiveBuffer;
-use nic_initialization::NIC_MAPPING_FLAGS;
 
 #[allow(unused_imports)]
 use crate::{Rqn, Lkey, CQN_MASK, command_queue::CommandOpcode, work_queue::WorkQueueEntryReceive, completion_queue::CompletionQueue};
@@ -229,7 +228,7 @@ impl ReceiveQueue {
             let rx_buf = self.pool.pop()
                 .ok_or("Couldn't obtain a ReceiveBuffer from the pool")
                 .or_else(|_e| {
-                    create_contiguous_mapping(buffer_size as usize, NIC_MAPPING_FLAGS)
+                    create_contiguous_mapping(buffer_size as usize, MMIO_FLAGS)
                         .and_then(|(buf_mapped, buf_paddr)|
                             ReceiveBuffer::new(buf_mapped, buf_paddr, buffer_size as u16, mem_pool)
                         )

--- a/kernel/nic_buffers/src/lib.rs
+++ b/kernel/nic_buffers/src/lib.rs
@@ -11,15 +11,6 @@ use core::ops::{Deref, DerefMut};
 use alloc::vec::Vec;
 use memory::{PhysicalAddress, MappedPages, PteFlags, create_contiguous_mapping};
 
-/// The mapping flags used to map NIC device memory,
-/// e.g., MMIO registers, buffers, queues, etc.
-pub const NIC_MAPPING_FLAGS: PteFlags = PteFlags::from_bits_truncate(
-    PteFlags::new().bits()
-    | PteFlags::VALID.bits()
-    | PteFlags::WRITABLE.bits()
-    | PteFlags::DEVICE_MEMORY.bits()
-);
-
 /// A buffer that stores a packet to be transmitted through the NIC
 /// and is guaranteed to be contiguous in physical memory. 
 /// Auto-dereferences into a byte slice that represents its underlying memory. 

--- a/kernel/nic_initialization/Cargo.toml
+++ b/kernel/nic_initialization/Cargo.toml
@@ -14,9 +14,6 @@ version = "0.4.8"
 [dependencies.memory]
 path = "../memory"
 
-[dependencies.pci]
-path = "../pci"
-
 [dependencies.intel_ethernet]
 path = "../intel_ethernet"
 

--- a/kernel/nic_queues/src/lib.rs
+++ b/kernel/nic_queues/src/lib.rs
@@ -18,10 +18,9 @@ use alloc::{
     vec::Vec,
     collections::VecDeque
 };
-use memory::{create_contiguous_mapping, BorrowedSliceMappedPages, Mutable};
+use memory::{create_contiguous_mapping, BorrowedSliceMappedPages, Mutable, MMIO_FLAGS};
 use intel_ethernet::descriptors::{RxDescriptor, TxDescriptor};
 use nic_buffers::{ReceiveBuffer, ReceivedFrame, TransmitBuffer};
-pub use nic_buffers::NIC_MAPPING_FLAGS;
 
 /// The register trait that gives access to only those registers required for receiving a packet.
 /// The Rx queue control registers can only be accessed by the physical NIC.
@@ -99,7 +98,7 @@ impl<S: RxQueueRegisters, T: RxDescriptor> RxQueue<S,T> {
                     warn!("NIC RX BUF POOL WAS EMPTY.... reallocating! This means that no task is consuming the accumulated received ethernet frames.");
                     // if the pool was empty, then we allocate a new receive buffer
                     let len = self.rx_buffer_size_bytes;
-                    let (mp, phys_addr) = create_contiguous_mapping(len as usize, NIC_MAPPING_FLAGS)?;
+                    let (mp, phys_addr) = create_contiguous_mapping(len as usize, MMIO_FLAGS)?;
                     ReceiveBuffer::new(mp, phys_addr, len, self.rx_buffer_pool)?
                 }
             };

--- a/kernel/pci/src/lib.rs
+++ b/kernel/pci/src/lib.rs
@@ -14,7 +14,7 @@ use core::ops::{Deref, DerefMut};
 use alloc::vec::Vec;
 use port_io::Port;
 use spin::{Once, Mutex};
-use memory::{PhysicalAddress, MappedPages, map_mmio_range};
+use memory::{PhysicalAddress, MappedPages, map_frame_range, MMIO_FLAGS};
 use bit_field::BitField;
 
 // The below constants define the PCI configuration space. 
@@ -507,7 +507,7 @@ impl PciDevice {
     pub fn pci_map_bar_mem(&self, bar_index: usize) -> Result<MappedPages, &'static str> {
         let mem_base = self.determine_mem_base(bar_index)?;
         let mem_size = self.determine_mem_size(bar_index);
-        map_mmio_range(mem_base, mem_size as usize)
+        map_frame_range(mem_base, mem_size as usize, MMIO_FLAGS)
     }
 }
 

--- a/kernel/pci/src/lib.rs
+++ b/kernel/pci/src/lib.rs
@@ -500,14 +500,14 @@ impl PciDevice {
         Ok(())  
     }
 
-    /// Allocates memory for the NIC registers
+    /// Maps device memory specified by a Base Address Register.
     /// 
     /// # Arguments 
-    /// * `dev`: reference to pci device 
-    /// * `mem_base`: starting physical address of the device's memory mapped registers
-    pub fn pci_map_bar(&self, bar_index: usize, offset: usize) -> Result<MappedPages, &'static str> {
-        let mem_base = self.determine_mem_base(bar_index)? + offset;
-        map_mmio_range(mem_base, self.determine_mem_size(bar_index) as usize)
+    /// * `bar_index`: index of the Base Address Register to use
+    pub fn pci_map_bar_mem(&self, bar_index: usize) -> Result<MappedPages, &'static str> {
+        let mem_base = self.determine_mem_base(bar_index)?;
+        let mem_size = self.determine_mem_size(bar_index);
+        map_mmio_range(mem_base, mem_size as usize)
     }
 }
 

--- a/kernel/pci/src/lib.rs
+++ b/kernel/pci/src/lib.rs
@@ -14,7 +14,7 @@ use core::ops::{Deref, DerefMut};
 use alloc::vec::Vec;
 use port_io::Port;
 use spin::{Once, Mutex};
-use memory::PhysicalAddress;
+use memory::{PhysicalAddress, MappedPages, map_mmio_range};
 use bit_field::BitField;
 
 // The below constants define the PCI configuration space. 
@@ -498,6 +498,16 @@ impl PciDevice {
         // debug!("MSIX HEADER AFTER ENABLE: {:#X}", ctrl);
 
         Ok(())  
+    }
+
+    /// Allocates memory for the NIC registers
+    /// 
+    /// # Arguments 
+    /// * `dev`: reference to pci device 
+    /// * `mem_base`: starting physical address of the device's memory mapped registers
+    pub fn pci_map_bar(&self, bar_index: usize, offset: usize) -> Result<MappedPages, &'static str> {
+        let mem_base = self.determine_mem_base(bar_index)? + offset;
+        map_mmio_range(mem_base, self.determine_mem_size(bar_index) as usize)
     }
 }
 

--- a/kernel/serial_port_basic/src/aarch64.rs
+++ b/kernel/serial_port_basic/src/aarch64.rs
@@ -1,8 +1,8 @@
-use memory::{MappedPages, PteFlags, get_kernel_mmi_ref, allocate_pages, allocate_frames_at};
-use core::{fmt, ops::DerefMut};
+use memory::{MappedPages, PAGE_SIZE, map_mmio_range};
 use super::{TriState, SerialPortInterruptEvent};
 use arm_boards::BOARD_CONFIG;
 use pl011_qemu::PL011;
+use core::fmt;
 
 /// The base port I/O addresses for COM serial ports.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -57,25 +57,8 @@ impl SerialPort {
             None => panic!("Board doesn't have {:?}", serial_port_address),
         };
 
-        let kernel_mmi_ref = get_kernel_mmi_ref()
-            .expect("serial_port_basic: couldn't get kernel MMI ref");
-
-        let mut locked = kernel_mmi_ref.lock();
-        let page_table = &mut locked.deref_mut().page_table;
-
-        let mmio_flags = PteFlags::DEVICE_MEMORY
-                       | PteFlags::NOT_EXECUTABLE
-                       | PteFlags::WRITABLE;
-
-        let pages = allocate_pages(1)
-            .expect("serial_port_basic: couldn't allocate pages for the UART interface");
-
-        let frames = allocate_frames_at(*mmio_base, 1)
-            .expect("serial_port_basic: couldn't allocate frames for the UART interface");
-
-        let mapped_pages = page_table.map_allocated_pages_to(pages, frames, mmio_flags)
+        let mapped_pages = map_mmio_range(*mmio_base, PAGE_SIZE)
             .expect("serial_port_basic: couldn't map the UART interface");
-
         let addr = mapped_pages.start_address().value();
 
         SerialPort {

--- a/kernel/serial_port_basic/src/aarch64.rs
+++ b/kernel/serial_port_basic/src/aarch64.rs
@@ -1,4 +1,4 @@
-use memory::{MappedPages, PAGE_SIZE, map_mmio_range};
+use memory::{MappedPages, PAGE_SIZE, map_frame_range, MMIO_FLAGS};
 use super::{TriState, SerialPortInterruptEvent};
 use arm_boards::BOARD_CONFIG;
 use pl011_qemu::PL011;
@@ -57,7 +57,7 @@ impl SerialPort {
             None => panic!("Board doesn't have {:?}", serial_port_address),
         };
 
-        let mapped_pages = map_mmio_range(*mmio_base, PAGE_SIZE)
+        let mapped_pages = map_frame_range(*mmio_base, PAGE_SIZE, MMIO_FLAGS)
             .expect("serial_port_basic: couldn't map the UART interface");
         let addr = mapped_pages.start_address().value();
 


### PR DESCRIPTION
This replaces the following items from `nic_initialization`:
- `allocate_memory`
- `allocate_device_register_memory` (which was unused)
- `NIC_MAPPING_FLAGS`

With:
- `memory::MMIO_FLAGS`: Mapping flags that can be used to map MMIO registers.
- `memory::map_frame_range`: A convenience function that creates a new memory mapping by allocating specific frames from physical memory.
- `memory::map_mmio_range`: A convenience function that creates a new memory mapping by allocating specific frames from physical memory with [`MMIO_FLAGS`] as flags.
- `pci::pci_map_bar_mem` as a clean replacement for `allocate_device_register_memory`, even though it's also unused. Maps device memory specified by a Base Address Register.

`gic` & `serial_port_basic` were also modified so that they use `memory::map_mmio_range`.