### PR TITLE
Add middle path for blocking mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3712,6 +3712,7 @@ name = "sync_block"
 version = "0.1.0"
 dependencies = [
  "cpu_local_preemption",
+ "log",
  "mpmc_queue",
  "scheduler",
  "sync",

--- a/kernel/sync_block/Cargo.toml
+++ b/kernel/sync_block/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 cpu_local_preemption = { path = "../cpu_local_preemption" }
 mpmc_queue = { path = "../../libs/mpmc_queue" }
+log = "0.4.8"
 scheduler = { path = "../scheduler" }
 sync = { path = "../../libs/sync" }
 task = { path = "../task" }

--- a/kernel/sync_block/src/lib.rs
+++ b/kernel/sync_block/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(negative_impls)]
+#![feature(negative_impls, let_chains)]
 #![no_std]
 
 mod condvar;
@@ -76,7 +76,7 @@ impl MutexFlavor for Block {
         // Middle path: Wait for one timeslice (see below) of the mutex holder to see if
         // they release the lock.
         let holder_id = data.holder.load(Ordering::Acquire);
-        if let Some(holder_task) = task::get_task(holder_id).and_then(|task| task.upgrade()) {
+        if holder_id != 0 && let Some(holder_task) = task::get_task(holder_id).and_then(|task| task.upgrade()) {
             // Hypothetically, if holder_task is running on another core and is perfectly in
             // sync with us, we would only ever check if they are running when we are also
             // running and so we wouldn't detect when their timeslice is over. However, the

--- a/kernel/sync_block/src/lib.rs
+++ b/kernel/sync_block/src/lib.rs
@@ -83,7 +83,7 @@ impl MutexFlavor for Block {
             // likelihood of this is infinitesimally small and the code, is still correct as
             // once the lock is released the holder will still set data.holder to 0 and we
             // will exit the loop.
-            while holder_task.running_on_cpu().is_some()
+            while holder_task.is_running()
                 && data.holder.load(Ordering::Acquire) == holder_id
             {
                 core::hint::spin_loop();

--- a/kernel/sync_block/src/lib.rs
+++ b/kernel/sync_block/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod condvar;
 
+use core::sync::atomic::{AtomicUsize, Ordering};
 use sync::{spin, MutexFlavor, RwLockFlavor};
 use wait_queue::WaitQueue;
 
@@ -22,21 +23,39 @@ pub struct Block {}
 
 impl MutexFlavor for Block {
     #[allow(clippy::declare_interior_mutable_const)]
-    const INIT: Self::LockData = WaitQueue::new();
+    const INIT: Self::LockData = Self::LockData {
+        queue: WaitQueue::new(),
+        holder: AtomicUsize::new(0),
+    };
 
-    type LockData = WaitQueue;
+    type LockData = MutexData;
 
     type Guard = ();
 
     #[inline]
     fn try_lock<'a, T>(
         mutex: &'a spin::Mutex<T>,
-        _: &'a Self::LockData,
+        data: &'a Self::LockData,
     ) -> Option<(spin::MutexGuard<'a, T>, Self::Guard)>
     where
         T: ?Sized,
     {
-        mutex.try_lock().map(|guard| (guard, ()))
+        let guard = mutex.try_lock()?;
+        // There is an interleaving where we are here, the previous holder hasn't yet
+        // ran post_unlock, and another thread A acquires the holder_id for the middle
+        // path all at the same time. This will result in thread A waiting on the old
+        // holder of the lock. This isn't great, but it is still correct, as the thread
+        // would only do so for a short period of time. It does however mean that the
+        // middle path would be "useless" because as soon as the holder changes, thread
+        // A would enter the slow path.
+        //
+        // We can prevent this by using an atomic usize in the inner spin lock rather
+        // than an atomic bool. A non-zero value would represent the task ID of the
+        // holder, and a zero would represent the unlocked state. However, this
+        // would be very hard to integrate with the current sync API.
+        data.holder
+            .store(task::get_my_current_task_id(), Ordering::Release);
+        Some((guard, ()))
     }
 
     #[inline]
@@ -47,19 +66,53 @@ impl MutexFlavor for Block {
     where
         T: ?Sized,
     {
+        // Fast path
         // This must be a strong compare exchange, otherwise we could block ourselves
         // when the mutex is unlocked and never be unblocked.
         if let Some(guards) = Self::try_lock(mutex, data) {
-            guards
-        } else {
-            data.wait_until(|| Self::try_lock(mutex, data))
+            return guards;
         }
+
+        // Middle path: Wait for one timeslice (see below) of the mutex holder to see if
+        // they release the lock.
+        let holder_id = data.holder.load(Ordering::Acquire);
+        if let Some(holder_task) = task::get_task(holder_id).and_then(|task| task.upgrade()) {
+            // Hypothetically, if holder_task is running on another core and is perfectly in
+            // sync with us, we would only ever check if they are running when we are also
+            // running and so we wouldn't detect when their timeslice is over. However, the
+            // likelihood of this is infinitesimally small and the code, is still correct as
+            // once the lock is released the holder will still set data.holder to 0 and we
+            // will exit the loop.
+            while holder_task.running_on_cpu().is_some()
+                && data.holder.load(Ordering::Acquire) == holder_id
+            {
+                core::hint::spin_loop();
+            }
+            if let Some(guards) = Self::try_lock(mutex, data) {
+                return guards;
+            }
+        } else {
+            // Unlikely case that another thread just acquired the lock, but hasn't yet set
+            // data.holder.
+            log::warn!("could not get holder task for mutex middle path");
+        }
+
+        // Slow path
+        data.queue.wait_until(|| Self::try_lock(mutex, data))
     }
 
     #[inline]
     fn post_unlock(data: &Self::LockData) {
-        data.notify_one();
+        // See comments in try_lock and lock on why this is necessary.
+        data.holder.store(0, Ordering::Release);
+        data.queue.notify_one();
     }
+}
+
+#[doc(hidden)]
+pub struct MutexData {
+    queue: WaitQueue,
+    holder: AtomicUsize,
 }
 
 impl RwLockFlavor for Block {

--- a/kernel/task_struct/src/lib.rs
+++ b/kernel/task_struct/src/lib.rs
@@ -307,7 +307,8 @@ impl Task {
         stack: Option<Stack>,
         states_to_inherit: InheritedStates,
     ) -> Result<Task, &'static str> {
-        /// The counter of task IDs
+        /// The counter of task IDs. We start at `1` such that `0` can be used 
+        /// as a task ID that indicates the absence of a task, e.g., in sync primitives. 
         static TASKID_COUNTER: AtomicUsize = AtomicUsize::new(1);
 
         let (mmi, namespace, env, app_crate) = states_to_inherit.into_tuple();

--- a/kernel/task_struct/src/lib.rs
+++ b/kernel/task_struct/src/lib.rs
@@ -308,7 +308,7 @@ impl Task {
         states_to_inherit: InheritedStates,
     ) -> Result<Task, &'static str> {
         /// The counter of task IDs
-        static TASKID_COUNTER: AtomicUsize = AtomicUsize::new(0);
+        static TASKID_COUNTER: AtomicUsize = AtomicUsize::new(1);
 
         let (mmi, namespace, env, app_crate) = states_to_inherit.into_tuple();
         let kstack = stack


### PR DESCRIPTION
Starting the task ID counters at 1 rather than 0 also lets us represent task IDs using NonZeroUsize permitting niche optimisations e.g. `Option<TaskId>` taking up as much space as a `usize`. This would however involve some unsafe and even if we do decide to implement it, is better left for another PR.

Closes #577.