### PR TITLE
`interrupt_controller` crate: an abstraction over Arm GIC & x86 APIC+IOAPIC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "interrupt_controller"
+version = "0.1.0"
+dependencies = [
+ "apic",
+ "arm_boards",
+ "cpu",
+ "gic",
+ "ioapic",
+ "irq_safety",
+ "log",
+ "memory",
+]
+
+[[package]]
 name = "interrupts"
 version = "0.1.0"
 dependencies = [
@@ -1564,6 +1578,7 @@ dependencies = [
  "exceptions_early",
  "gdt",
  "gic",
+ "interrupt_controller",
  "irq_safety",
  "kernel_config",
  "locked_idt",

--- a/kernel/cpu/src/x86_64.rs
+++ b/kernel/cpu/src/x86_64.rs
@@ -12,6 +12,12 @@ impl From<ApicId> for CpuId {
     }
 }
 
+impl From<CpuId> for ApicId {
+    fn from(cpu_id: CpuId) -> Self {
+        ApicId::try_from(cpu_id.value()).expect("An invalid CpuId was encountered")
+    }
+}
+
 impl TryFrom<u32> for CpuId {
     type Error = u32;
     fn try_from(raw_cpu_id: u32) -> Result<Self, Self::Error> {

--- a/kernel/gic/src/gic/dist_interface.rs
+++ b/kernel/gic/src/gic/dist_interface.rs
@@ -137,9 +137,13 @@ pub fn send_ipi_gicv2(registers: &mut GicRegisters, int_num: u32, target: IpiTar
     registers.write_volatile(offset::SGIR, value);
 }
 
+/// Deserialized content of the `IIDR` distributor register
 pub struct Implementer {
+    /// Product Identifier of this distributor.
     pub product_id: u8,
+    /// An arbitrary revision number defined by the implementer.
     pub version: u8,
+    /// Contains the JEP106 code of the company that implemented the distributor.
     pub implementer_jep106: u16,
 }
 

--- a/kernel/gic/src/gic/mod.rs
+++ b/kernel/gic/src/gic/mod.rs
@@ -438,6 +438,18 @@ impl ArmGic {
             Self::V3( _) => cpu_interface_gicv3::set_minimum_priority(priority),
         }
     }
+
+    /// Returns the internal ID of the redistributor (GICv3)
+    ///
+    /// Note #2: this is only provided for debugging purposes
+    /// Note #1: as a compatibility feature, on GICv2, the CPU index is returned.
+    pub fn get_cpu_interface_id(&self) -> u16 {
+        let i = get_current_cpu_redist_index();
+        match self {
+            Self::V3(v3) => redist_interface::get_internal_id(&v3.redistributors[i].redistributor),
+            _ => i as _,
+        }
+    }
 }
 
 impl core::fmt::Debug for ArmGicV3RedistPages {

--- a/kernel/gic/src/gic/redist_interface.rs
+++ b/kernel/gic/src/gic/redist_interface.rs
@@ -133,3 +133,10 @@ pub fn get_sgippi_priority(registers: &GicRegisters, int: InterruptNumber) -> Pr
 pub fn set_sgippi_priority(registers: &mut GicRegisters, int: InterruptNumber, prio: Priority) {
     registers.write_array_volatile::<4>(offset::SGIPPI_IPRIORITYR, int, (u8::MAX - prio) as u32);
 }
+
+/// Returns the internal ID of the redistributor
+///
+/// Note: this is only provided for debugging purposes
+pub fn get_internal_id(registers: &GicRegisters) -> u16 {
+    (registers.read_volatile_64(offset::TYPER) >> 8) as _
+}

--- a/kernel/interrupt_controller/Cargo.toml
+++ b/kernel/interrupt_controller/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+authors = ["Nathan Royer <nathan.royer.pro@gmail.com>"]
+description = "Cross-platform abstraction over interrupt controllers"
+version = "0.1.0"
+edition = "2021"
+name = "interrupt_controller"
+
+[dependencies]
+log = "0.4.8"
+cpu = { path = "../cpu" }
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
+arm_boards = { path = "../arm_boards" }
+memory = { path = "../memory" }
+gic = { path = "../gic" }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+apic = { path = "../apic" }
+ioapic = { path = "../ioapic" }

--- a/kernel/interrupt_controller/src/aarch64.rs
+++ b/kernel/interrupt_controller/src/aarch64.rs
@@ -1,0 +1,69 @@
+use super::*;
+
+#[derive(Debug, Copy, Clone)]
+pub struct SystemInterruptControllerVersion(pub u8);
+#[derive(Debug, Copy, Clone)]
+pub struct      SystemInterruptControllerId(pub u8);
+#[derive(Debug, Copy, Clone)]
+pub struct       LocalInterruptControllerId(pub u16);
+#[derive(Debug, Copy, Clone)]
+pub struct            SystemInterruptNumber(pub(crate) gic::InterruptNumber);
+#[derive(Debug, Copy, Clone)]
+pub struct             LocalInterruptNumber(pub(crate) gic::InterruptNumber);
+
+impl SystemInterruptNumber {
+    /// Constructor
+    ///
+    /// On aarch64, shared-peripheral interrupt numbers must lie
+    /// between 32 & 1019 (inclusive)
+    pub const fn new(raw_num: u32) -> Self {
+        match raw_num {
+            32..=1019 => Self(raw_num),
+            _ => panic!("Invalid SystemInterruptNumber (must lie in 32..1020)"),
+        }
+    }
+}
+
+impl LocalInterruptNumber {
+    /// Constructor
+    ///
+    /// On aarch64, shared-peripheral interrupt numbers must lie
+    /// between 0 & 31 (inclusive)
+    pub const fn new(raw_num: u32) -> Self {
+        match raw_num {
+            0..=31 => Self(raw_num),
+            _ => panic!("Invalid LocalInterruptNumber (must lie in 0..32)"),
+        }
+    }
+}
+
+/// The private global Generic Interrupt Controller singleton
+pub(crate) static INTERRUPT_CONTROLLER: MutexIrqSafe<Option<ArmGic>> = MutexIrqSafe::new(None);
+
+/// Initializes the interrupt controller, on aarch64
+pub fn init() -> Result<(), &'static str> {
+    let mut int_ctrl = INTERRUPT_CONTROLLER.lock();
+    if int_ctrl.is_some() {
+        Err("The interrupt controller has already been initialized!")
+    } else {
+        match BOARD_CONFIG.interrupt_controller {
+            InterruptControllerConfig::GicV3(gicv3_cfg) => {
+                let kernel_mmi_ref = get_kernel_mmi_ref()
+                    .ok_or("interrupts::aarch64::init: couldn't get kernel MMI ref")?;
+
+                let mut mmi = kernel_mmi_ref.lock();
+                let page_table = &mut mmi.deref_mut().page_table;
+
+                *int_ctrl = Some(ArmGic::init(
+                    page_table,
+                    GicVersion::InitV3 {
+                        dist: gicv3_cfg.distributor_base_address,
+                        redist: gicv3_cfg.redistributor_base_addresses,
+                    },
+                )?);
+            },
+        }
+
+        Ok(())
+    }
+}

--- a/kernel/interrupt_controller/src/aarch64.rs
+++ b/kernel/interrupt_controller/src/aarch64.rs
@@ -1,15 +1,25 @@
+use {
+    gic::{ArmGic, SpiDestination, IpiTargetCpu, Version as GicVersion},
+    arm_boards::{BOARD_CONFIG, InterruptControllerConfig},
+    irq_safety::MutexIrqSafe,
+    memory::get_kernel_mmi_ref,
+    core::ops::DerefMut,
+};
+
 use super::*;
+
+pub use gic::Priority;
 
 #[derive(Debug, Copy, Clone)]
 pub struct SystemInterruptControllerVersion(pub u8);
 #[derive(Debug, Copy, Clone)]
-pub struct      SystemInterruptControllerId(pub u8);
+pub struct SystemInterruptControllerId(pub u8);
 #[derive(Debug, Copy, Clone)]
-pub struct       LocalInterruptControllerId(pub u16);
+pub struct LocalInterruptControllerId(pub u16);
 #[derive(Debug, Copy, Clone)]
-pub struct            SystemInterruptNumber(pub(crate) gic::InterruptNumber);
+pub struct SystemInterruptNumber(pub(crate) gic::InterruptNumber);
 #[derive(Debug, Copy, Clone)]
-pub struct             LocalInterruptNumber(pub(crate) gic::InterruptNumber);
+pub struct LocalInterruptNumber(pub(crate) gic::InterruptNumber);
 
 impl SystemInterruptNumber {
     /// Constructor
@@ -65,5 +75,141 @@ pub fn init() -> Result<(), &'static str> {
         }
 
         Ok(())
+    }
+}
+
+/// Structure representing a top-level/system-wide interrupt controller chip,
+/// responsible for routing interrupts between peripherals and CPU cores.
+///
+/// On aarch64 w/ GIC, this corresponds to the Distributor.
+pub struct SystemInterruptController;
+
+/// Struct representing per-cpu-core interrupt controller chips.
+///
+/// On aarch64 w/ GIC, this corresponds to a Redistributor & CPU interface.
+pub struct LocalInterruptController;
+
+// 1st variant: get system controller
+// 2nd variant: get local controller
+macro_rules! get_int_ctlr {
+    ($name:ident, $func:ident, $this:expr) => {
+        let mut $name = INTERRUPT_CONTROLLER.lock();
+        let $name = $name.as_mut().expect(concat!("BUG: ", stringify!($func), "(): INTERRUPT_CONTROLLER was uninitialized"));
+    };
+    ($name:ident, $func:ident) => ( get_int_ctlr!($name, $func, ()) );
+}
+
+impl SystemInterruptControllerApi for SystemInterruptController {
+    fn id(&self) -> SystemInterruptControllerId {
+        get_int_ctlr!(int_ctlr, id, self);
+        SystemInterruptControllerId(int_ctlr.implementer().product_id)
+    }
+
+    fn version(&self) -> SystemInterruptControllerVersion {
+        get_int_ctlr!(int_ctlr, version, self);
+        SystemInterruptControllerVersion(int_ctlr.implementer().version)
+    }
+
+    fn get_destination(
+        &self,
+        interrupt_num: SystemInterruptNumber,
+    ) -> Result<(Vec<InterruptDestination>, Priority), &'static str> {
+        get_int_ctlr!(int_ctlr, get_destination, self);
+
+        let priority = int_ctlr.get_interrupt_priority(interrupt_num.0);
+        let local_number = LocalInterruptNumber(interrupt_num.0);
+
+        let vec = match int_ctlr.get_spi_target(interrupt_num.0)?.canonicalize() {
+            SpiDestination::Specific(cpu) => [InterruptDestination {
+                cpu,
+                local_number,
+            }].to_vec(),
+            SpiDestination::AnyCpuAvailable => BOARD_CONFIG.cpu_ids.map(|mpidr| InterruptDestination {
+                cpu: mpidr.into(),
+                local_number,
+            }).to_vec(),
+            SpiDestination::GICv2TargetList(list) => {
+                let mut vec = Vec::with_capacity(8);
+                for result in list.iter() {
+                    vec.push(InterruptDestination {
+                        cpu: result?,
+                        local_number,
+                    });
+                }
+                vec
+            }
+        };
+
+        Ok((vec, priority))
+    }
+
+    fn set_destination(
+        &self,
+        sys_int_num: SystemInterruptNumber,
+        destination: InterruptDestination,
+        priority: Priority,
+    ) -> Result<(), &'static str> {
+        get_int_ctlr!(int_ctlr, set_destination, self);
+        assert_eq!(sys_int_num.0, destination.local_number.0, "Local & System Interrupt Numbers cannot be different with GIC");
+
+        int_ctlr.set_spi_target(sys_int_num.0, SpiDestination::Specific(destination.cpu));
+        int_ctlr.set_interrupt_priority(sys_int_num.0, priority);
+
+        Ok(())
+    }
+}
+
+impl LocalInterruptControllerApi for LocalInterruptController {
+    fn id(&self) -> LocalInterruptControllerId {
+        get_int_ctlr!(int_ctlr, id);
+        LocalInterruptControllerId(int_ctlr.get_cpu_interface_id())
+    }
+
+    fn get_local_interrupt_priority(&self, num: LocalInterruptNumber) -> Priority {
+        get_int_ctlr!(int_ctlr, get_local_interrupt_priority);
+        int_ctlr.get_interrupt_priority(num.0)
+    }
+
+    fn set_local_interrupt_priority(&self, num: LocalInterruptNumber, priority: Priority) {
+        get_int_ctlr!(int_ctlr, set_local_interrupt_priority);
+        int_ctlr.set_interrupt_priority(num.0, priority);
+    }
+
+    fn is_local_interrupt_enabled(&self, num: LocalInterruptNumber) -> bool {
+        get_int_ctlr!(int_ctlr, is_local_interrupt_enabled);
+        int_ctlr.get_interrupt_state(num.0)
+    }
+
+    fn enable_local_interrupt(&self, num: LocalInterruptNumber, enabled: bool) {
+        get_int_ctlr!(int_ctlr, enable_local_interrupt);
+        int_ctlr.set_interrupt_state(num.0, enabled);
+    }
+
+    fn send_ipi(&self, destination: InterruptDestination) {
+        get_int_ctlr!(int_ctlr, send_ipi);
+        int_ctlr.send_ipi(destination.local_number.0, IpiTargetCpu::Specific(destination.cpu));
+    }
+
+    fn get_minimum_priority(&self) -> Priority {
+        get_int_ctlr!(int_ctlr, get_minimum_priority);
+        int_ctlr.get_minimum_priority()
+    }
+
+    fn set_minimum_priority(&self, priority: Priority) {
+        get_int_ctlr!(int_ctlr, set_minimum_priority);
+        int_ctlr.set_minimum_priority(priority)
+    }
+
+    fn acknowledge_interrupt(&self) -> (LocalInterruptNumber, Priority) {
+        get_int_ctlr!(int_ctlr, acknowledge_interrupt);
+
+        let (num, prio) = int_ctlr.acknowledge_interrupt();
+
+        (LocalInterruptNumber(num), prio)
+    }
+
+    fn end_of_interrupt(&self, number: LocalInterruptNumber) {
+        get_int_ctlr!(int_ctlr, end_of_interrupt);
+        int_ctlr.end_of_interrupt(number.0)
     }
 }

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -1,56 +1,388 @@
+#![no_std]
+#![allow(unused_variables, unused_mut)]
 
+extern crate alloc;
 
-// The private global Generic Interrupt Controller singleton
-static INTERRUPT_CONTROLLER: MutexIrqSafe<Option<ArmGic>> = MutexIrqSafe::new(None);
+use alloc::vec::Vec;
+use cpu::CpuId;
 
-pub fn init() -> Result<(), &'static str> {
-    // *INTERRUPT_CONTROLLER = Some(...);
+#[cfg(target_arch = "aarch64")]
+use {
+    gic::{ArmGic, SpiDestination, Priority, IpiTargetCpu, Version as GicVersion},
+    arm_boards::{BOARD_CONFIG, InterruptControllerConfig},
+    irq_safety::MutexIrqSafe,
+    memory::get_kernel_mmi_ref,
+    core::ops::DerefMut,
+};
+
+#[cfg(target_arch = "x86_64")]
+use {
+    apic::{get_my_apic, LapicIpiDestination},
+    ioapic::get_ioapic,
+};
+
+/// aarch64-specific definitions
+#[cfg(target_arch = "aarch64")]
+pub mod arch_def {
+    use super::*;
+
+    #[derive(Debug, Copy, Clone)]
+    pub struct SystemInterruptControllerVersion(pub u8);
+    #[derive(Debug, Copy, Clone)]
+    pub struct      SystemInterruptControllerId(pub u8);
+    #[derive(Debug, Copy, Clone)]
+    pub struct       LocalInterruptControllerId(pub u16);
+    #[derive(Debug, Copy, Clone)]
+    pub struct            SystemInterruptNumber(pub(crate) gic::InterruptNumber);
+    #[derive(Debug, Copy, Clone)]
+    pub struct             LocalInterruptNumber(pub(crate) gic::InterruptNumber);
+
+    impl SystemInterruptNumber {
+        /// Constructor
+        ///
+        /// On aarch64, shared-peripheral interrupt numbers must lie
+        /// between 32 & 1019 (inclusive)
+        pub const fn new(raw_num: u32) -> Self {
+            match raw_num {
+                32..=1019 => Self(raw_num),
+                _ => panic!("Invalid SystemInterruptNumber (must lie in 32..1020)"),
+            }
+        }
+    }
+
+    impl LocalInterruptNumber {
+        /// Constructor
+        ///
+        /// On aarch64, shared-peripheral interrupt numbers must lie
+        /// between 0 & 31 (inclusive)
+        pub const fn new(raw_num: u32) -> Self {
+            match raw_num {
+                0..=31 => Self(raw_num),
+                _ => panic!("Invalid LocalInterruptNumber (must lie in 0..32)"),
+            }
+        }
+    }
+
+    /// The private global Generic Interrupt Controller singleton
+    pub(crate) static INTERRUPT_CONTROLLER: MutexIrqSafe<Option<ArmGic>> = MutexIrqSafe::new(None);
+
+    /// Initializes the interrupt controller, on aarch64
+    pub fn init() -> Result<(), &'static str> {
+        let mut int_ctrl = INTERRUPT_CONTROLLER.lock();
+        if int_ctrl.is_some() {
+            Err("The interrupt controller has already been initialized!")
+        } else {
+            match BOARD_CONFIG.interrupt_controller {
+                InterruptControllerConfig::GicV3(gicv3_cfg) => {
+                    let kernel_mmi_ref = get_kernel_mmi_ref()
+                        .ok_or("interrupts::aarch64::init: couldn't get kernel MMI ref")?;
+
+                    let mut mmi = kernel_mmi_ref.lock();
+                    let page_table = &mut mmi.deref_mut().page_table;
+
+                    *int_ctrl = Some(ArmGic::init(
+                        page_table,
+                        GicVersion::InitV3 {
+                            dist: gicv3_cfg.distributor_base_address,
+                            redist: gicv3_cfg.redistributor_base_addresses,
+                        },
+                    )?);
+                },
+            }
+
+            Ok(())
+        }
+    }
 }
 
-pub struct LocalInterruptControllerId(/* arch-specific unsigned int */);
-pub struct GlobalInterruptNumber(/* arch-specific unsigned int */);
-pub struct LocalInterruptNumber(/* arch-specific unsigned int */);
+/// x86_64-specific definitions
+#[cfg(target_arch = "x86_64")]
+pub mod arch_def {
+    #[derive(Debug, Copy, Clone)]
+    pub struct SystemInterruptControllerVersion(pub u32);
+    #[derive(Debug, Copy, Clone)]
+    pub struct      SystemInterruptControllerId(pub u32);
+    #[derive(Debug, Copy, Clone)]
+    pub struct       LocalInterruptControllerId(pub u32);
+    #[derive(Debug, Copy, Clone)]
+    pub struct            SystemInterruptNumber(pub(crate) u8);
+    #[derive(Debug, Copy, Clone)]
+    pub struct             LocalInterruptNumber(pub(crate) u8);
+    #[derive(Debug, Copy, Clone)]
+    pub struct Priority;
 
-/// Singleton representing the main/system-wide interrupt controller chip,
+    /// Initializes the interrupt controller, on aarch64
+    pub fn init() -> Result<(), &'static str> { Ok(()) }
+}
+
+pub use arch_def::*;
+
+#[cfg(target_arch = "aarch64")]
+macro_rules! get_int_ctlr {
+    ($name:ident, $func:ident, $this:expr) => {
+        let mut $name = INTERRUPT_CONTROLLER.lock();
+        let $name = $name.as_mut().expect(concat!("BUG: ", stringify!($func), "(): INTERRUPT_CONTROLLER was uninitialized"));
+    };
+    ($name:ident, $func:ident) => ( get_int_ctlr!($name, $func, ()) );
+}
+
+#[cfg(target_arch = "x86_64")]
+macro_rules! get_int_ctlr {
+    ($name:ident, $func:ident, $this:expr) => {
+        let mut $name = get_ioapic($this.id).expect(concat!("BUG: ", stringify!($func), "(): get_ioapic() returned None"));
+    };
+    ($name:ident, $func:ident) => {
+        let mut $name = get_my_apic().expect(concat!("BUG: ", stringify!($func), "(): get_my_apic() returned None"));
+        let mut $name = $name.write();
+    };
+}
+
+/// The Cpu were this interrupt should be handled, as well as
+/// the local interrupt number this gets translated to.
+///
+/// On aarch64, the system interrupt number and the local interrupt
+/// number must be the same.
+#[derive(Debug, Copy, Clone)]
+pub struct InterruptDestination {
+    pub cpu: CpuId,
+    pub local_number: LocalInterruptNumber,
+}
+
+/// Structure representing a top-level/system-wide interrupt controller chip,
 /// responsible for routing interrupts between peripherals and CPU cores.
 ///
-/// On x86_64, this corresponds to the IoApic.
+/// On x86_64, this corresponds to an IoApic.
 /// On aarch64 w/ GIC, this corresponds to the Distributor.
-pub struct GlobalInterruptController {}
+pub struct SystemInterruptController {
+    #[cfg(target_arch = "x86_64")]
+    id: u8,
+}
 
 /// Struct representing per-cpu-core interrupt controller chips.
 ///
-/// On x86_64, this corresponds to the LocalApic.
-/// On aarch64 w/ GIC, this corresponds to the Redistributor.
+/// On x86_64, this corresponds to a LocalApic.
+/// On aarch64 w/ GIC, this corresponds to a Redistributor & CPU interface.
 pub struct LocalInterruptController {}
 
-/// Allows code to control the currently pending or active interrupt.
-///
-/// On x86_64, this uses the LocalApic.
-/// On aarch64 w/ GIC, this uses the CPU Interface.
-pub struct CurrentInterrupt {}
+impl SystemInterruptController {
+    pub fn id(&self) -> SystemInterruptControllerId {
+        get_int_ctlr!(int_ctlr, id, self);
 
-// Should I implement Index & IndexMut instead?
-impl GlobalInterruptController {
-    pub fn get_destination(&self, interrupt_num: GlobalInterruptNumber) -> Option<(CpuId, LocalInterruptNumber, Priority)> {
-        todo!()
+        #[cfg(target_arch = "aarch64")] {
+            SystemInterruptControllerId(int_ctlr.implementer().product_id)
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            SystemInterruptControllerId(int_ctlr.id())
+        }
     }
 
-    pub fn set_destination(&mut self, interrupt_num: GlobalInterruptNumber, destination: Option<(CpuId, LocalInterruptNumber, Priority)>) {
-        todo!()
+    pub fn version(&self) -> SystemInterruptControllerVersion {
+        get_int_ctlr!(int_ctlr, version, self);
+
+        #[cfg(target_arch = "aarch64")] {
+            SystemInterruptControllerVersion(int_ctlr.implementer().version)
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            SystemInterruptControllerVersion(int_ctlr.version())
+        }
+    }
+
+    pub fn get_destination(&self, interrupt_num: SystemInterruptNumber) -> Result<(Vec<InterruptDestination>, Priority), &'static str> {
+        get_int_ctlr!(int_ctlr, get_destination, self);
+
+        #[cfg(target_arch = "aarch64")] {
+            let priority = int_ctlr.get_interrupt_priority(interrupt_num.0);
+            let local_number = LocalInterruptNumber(interrupt_num.0);
+
+            let vec = match int_ctlr.get_spi_target(interrupt_num.0)?.canonicalize() {
+                SpiDestination::Specific(cpu) => [InterruptDestination {
+                    cpu,
+                    local_number,
+                }].to_vec(),
+                SpiDestination::AnyCpuAvailable => BOARD_CONFIG.cpu_ids.map(|mpidr| InterruptDestination {
+                    cpu: mpidr.into(),
+                    local_number,
+                }).to_vec(),
+                SpiDestination::GICv2TargetList(list) => {
+                    let mut vec = Vec::with_capacity(8);
+                    for result in list.iter() {
+                        vec.push(InterruptDestination {
+                            cpu: result?,
+                            local_number,
+                        });
+                    }
+                    vec
+                }
+            };
+
+            Ok((vec, priority))
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            // no way to read the destination for an IRQ number in IoApic
+            unimplemented!()
+        }
+    }
+
+    pub fn set_destination(&self, sys_int_num: SystemInterruptNumber, destination: InterruptDestination, priority: Priority) -> Result<(), &'static str> {
+        get_int_ctlr!(int_ctlr, set_destination, self);
+
+        #[cfg(target_arch = "aarch64")] {
+            assert_eq!(sys_int_num.0, destination.local_number.0, "Local & System Interrupt Numbers cannot be different with GIC");
+
+            int_ctlr.set_spi_target(sys_int_num.0, SpiDestination::Specific(destination.cpu));
+            int_ctlr.set_interrupt_priority(sys_int_num.0, priority);
+
+            Ok(())
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            // no support for priority on x86_64
+            let _ = priority;
+
+            int_ctlr.set_irq(sys_int_num.0, destination.cpu.into(), destination.local_number.0)
+        }
     }
 }
 
 impl LocalInterruptController {
-    pub fn cpu_id(&self) -> CpuId
+    pub fn id(&self) -> LocalInterruptControllerId {
+        get_int_ctlr!(int_ctlr, id);
 
-    pub fn get_min_priority(&self) -> Priority {
-        todo!()
+        #[cfg(target_arch = "aarch64")] {
+            LocalInterruptControllerId(int_ctlr.get_cpu_interface_id())
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            // this or the Apic ID ?
+            LocalInterruptControllerId(int_ctlr.processor_id())
+        }
     }
 
-    pub fn set_min_priority(&mut self, priority: Priority) {
-        todo!()
+    pub fn get_local_interrupt_priority(&self, num: LocalInterruptNumber) -> Priority {
+        get_int_ctlr!(int_ctlr, get_local_interrupt_priority);
+
+        #[cfg(target_arch = "aarch64")] {
+            int_ctlr.get_interrupt_priority(num.0)
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            // No priority support on x86_64
+            Priority
+        }
     }
 
+    pub fn set_local_interrupt_priority(&self, num: LocalInterruptNumber, priority: Priority) {
+        get_int_ctlr!(int_ctlr, set_local_interrupt_priority);
 
+        #[cfg(target_arch = "aarch64")] {
+            int_ctlr.set_interrupt_priority(num.0, priority);
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            // No priority support on x86_64
+            let _ = priority;
+        }
+    }
+
+    pub fn is_local_interrupt_enabled(&self, num: LocalInterruptNumber) -> bool {
+        get_int_ctlr!(int_ctlr, is_local_interrupt_enabled);
+
+        #[cfg(target_arch = "aarch64")] {
+            int_ctlr.get_interrupt_state(num.0)
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            todo!()
+        }
+    }
+
+    pub fn enable_local_interrupt(&self, num: LocalInterruptNumber, enabled: bool) {
+        get_int_ctlr!(int_ctlr, enable_local_interrupt);
+
+        #[cfg(target_arch = "aarch64")] {
+            int_ctlr.set_interrupt_state(num.0, enabled);
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            todo!()
+        }
+    }
+
+    /// Sends an inter-processor interrupt to a specific CPU.
+    pub fn send_ipi(&self, destination: InterruptDestination) {
+        get_int_ctlr!(int_ctlr, send_ipi);
+
+        #[cfg(target_arch = "aarch64")] {
+            int_ctlr.send_ipi(destination.local_number.0, IpiTargetCpu::Specific(destination.cpu));
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            int_ctlr.send_ipi(destination.local_number.0, LapicIpiDestination::One(destination.cpu.into()))
+        }
+    }
+
+    /// Reads the minimum priority for an interrupt to reach this CPU.
+    ///
+    /// Note: aarch64-only, at the moment.
+    pub fn get_minimum_priority(&self) -> Priority {
+        get_int_ctlr!(int_ctlr, get_minimum_priority);
+
+        #[cfg(target_arch = "aarch64")] {
+            int_ctlr.get_minimum_priority()
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            // No priority support on x86_64
+            Priority
+        }
+    }
+
+    /// Changes the minimum priority for an interrupt to reach this CPU.
+    ///
+    /// Note: aarch64-only, at the moment.
+    pub fn set_minimum_priority(&self, priority: Priority) {
+        get_int_ctlr!(int_ctlr, set_minimum_priority);
+
+        #[cfg(target_arch = "aarch64")] {
+            int_ctlr.set_minimum_priority(priority)
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            // No priority support on x86_64
+            let _ = priority;
+        }
+    }
+
+    /// Aarch64-specific way to read the current pending interrupt number & priority.
+    #[cfg(target_arch = "aarch64")]
+    pub fn acknowledge_interrupt(&self) -> (LocalInterruptNumber, Priority) {
+        get_int_ctlr!(int_ctlr, acknowledge_interrupt);
+
+        #[cfg(target_arch = "aarch64")] {
+            let (num, prio) = int_ctlr.acknowledge_interrupt();
+
+            (LocalInterruptNumber(num), prio)
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            panic!("This is an aarch64-only mechanism.");
+        }
+    }
+
+    /// Tell the interrupt controller that the current interrupt handling as ended.
+    pub fn end_of_interrupt(&self, number: LocalInterruptNumber) {
+        get_int_ctlr!(int_ctlr, end_of_interrupt);
+
+        #[cfg(target_arch = "aarch64")] {
+            int_ctlr.end_of_interrupt(number.0)
+        }
+
+        #[cfg(target_arch = "x86_64")] {
+            // what do we do with the IRQ number?
+            int_ctlr.eoi();
+        }
+    }
 }

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -21,121 +21,11 @@ use {
     ioapic::get_ioapic,
 };
 
-/// aarch64-specific definitions
-#[cfg(target_arch = "aarch64")]
-pub mod arch_def {
-    use super::*;
-
-    #[derive(Debug, Copy, Clone)]
-    pub struct SystemInterruptControllerVersion(pub u8);
-    #[derive(Debug, Copy, Clone)]
-    pub struct      SystemInterruptControllerId(pub u8);
-    #[derive(Debug, Copy, Clone)]
-    pub struct       LocalInterruptControllerId(pub u16);
-    #[derive(Debug, Copy, Clone)]
-    pub struct            SystemInterruptNumber(pub(crate) gic::InterruptNumber);
-    #[derive(Debug, Copy, Clone)]
-    pub struct             LocalInterruptNumber(pub(crate) gic::InterruptNumber);
-
-    impl SystemInterruptNumber {
-        /// Constructor
-        ///
-        /// On aarch64, shared-peripheral interrupt numbers must lie
-        /// between 32 & 1019 (inclusive)
-        pub const fn new(raw_num: u32) -> Self {
-            match raw_num {
-                32..=1019 => Self(raw_num),
-                _ => panic!("Invalid SystemInterruptNumber (must lie in 32..1020)"),
-            }
-        }
-    }
-
-    impl LocalInterruptNumber {
-        /// Constructor
-        ///
-        /// On aarch64, shared-peripheral interrupt numbers must lie
-        /// between 0 & 31 (inclusive)
-        pub const fn new(raw_num: u32) -> Self {
-            match raw_num {
-                0..=31 => Self(raw_num),
-                _ => panic!("Invalid LocalInterruptNumber (must lie in 0..32)"),
-            }
-        }
-    }
-
-    /// The private global Generic Interrupt Controller singleton
-    pub(crate) static INTERRUPT_CONTROLLER: MutexIrqSafe<Option<ArmGic>> = MutexIrqSafe::new(None);
-
-    /// Initializes the interrupt controller, on aarch64
-    pub fn init() -> Result<(), &'static str> {
-        let mut int_ctrl = INTERRUPT_CONTROLLER.lock();
-        if int_ctrl.is_some() {
-            Err("The interrupt controller has already been initialized!")
-        } else {
-            match BOARD_CONFIG.interrupt_controller {
-                InterruptControllerConfig::GicV3(gicv3_cfg) => {
-                    let kernel_mmi_ref = get_kernel_mmi_ref()
-                        .ok_or("interrupts::aarch64::init: couldn't get kernel MMI ref")?;
-
-                    let mut mmi = kernel_mmi_ref.lock();
-                    let page_table = &mut mmi.deref_mut().page_table;
-
-                    *int_ctrl = Some(ArmGic::init(
-                        page_table,
-                        GicVersion::InitV3 {
-                            dist: gicv3_cfg.distributor_base_address,
-                            redist: gicv3_cfg.redistributor_base_addresses,
-                        },
-                    )?);
-                },
-            }
-
-            Ok(())
-        }
-    }
-}
-
-/// x86_64-specific definitions
-#[cfg(target_arch = "x86_64")]
-pub mod arch_def {
-    #[derive(Debug, Copy, Clone)]
-    pub struct SystemInterruptControllerVersion(pub u32);
-    #[derive(Debug, Copy, Clone)]
-    pub struct      SystemInterruptControllerId(pub u32);
-    #[derive(Debug, Copy, Clone)]
-    pub struct       LocalInterruptControllerId(pub u32);
-    #[derive(Debug, Copy, Clone)]
-    pub struct            SystemInterruptNumber(pub(crate) u8);
-    #[derive(Debug, Copy, Clone)]
-    pub struct             LocalInterruptNumber(pub(crate) u8);
-    #[derive(Debug, Copy, Clone)]
-    pub struct Priority;
-
-    /// Initializes the interrupt controller, on aarch64
-    pub fn init() -> Result<(), &'static str> { Ok(()) }
-}
-
-pub use arch_def::*;
+pub mod aarch64;
+pub mod x86_64;
 
 #[cfg(target_arch = "aarch64")]
-macro_rules! get_int_ctlr {
-    ($name:ident, $func:ident, $this:expr) => {
-        let mut $name = INTERRUPT_CONTROLLER.lock();
-        let $name = $name.as_mut().expect(concat!("BUG: ", stringify!($func), "(): INTERRUPT_CONTROLLER was uninitialized"));
-    };
-    ($name:ident, $func:ident) => ( get_int_ctlr!($name, $func, ()) );
-}
-
-#[cfg(target_arch = "x86_64")]
-macro_rules! get_int_ctlr {
-    ($name:ident, $func:ident, $this:expr) => {
-        let mut $name = get_ioapic($this.id).expect(concat!("BUG: ", stringify!($func), "(): get_ioapic() returned None"));
-    };
-    ($name:ident, $func:ident) => {
-        let mut $name = get_my_apic().expect(concat!("BUG: ", stringify!($func), "(): get_my_apic() returned None"));
-        let mut $name = $name.write();
-    };
-}
+pub use aarch64::*;
 
 /// The Cpu where this interrupt should be handled, as well as
 /// the local interrupt number this gets translated to.
@@ -379,4 +269,27 @@ impl LocalInterruptController {
             int_ctlr.eoi();
         }
     }
+}
+
+#[cfg(target_arch = "aarch64")]
+macro_rules! get_int_ctlr {
+    ($name:ident, $func:ident, $this:expr) => {
+        let mut $name = INTERRUPT_CONTROLLER.lock();
+        let $name = $name.as_mut().expect(concat!("BUG: ", stringify!($func), "(): INTERRUPT_CONTROLLER was uninitialized"));
+    };
+    ($name:ident, $func:ident) => ( get_int_ctlr!($name, $func, ()) );
+}
+
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::*;
+
+#[cfg(target_arch = "x86_64")]
+macro_rules! get_int_ctlr {
+    ($name:ident, $func:ident, $this:expr) => {
+        let mut $name = get_ioapic($this.id).expect(concat!("BUG: ", stringify!($func), "(): get_ioapic() returned None"));
+    };
+    ($name:ident, $func:ident) => {
+        let mut $name = get_my_apic().expect(concat!("BUG: ", stringify!($func), "(): get_my_apic() returned None"));
+        let mut $name = $name.write();
+    };
 }

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -7,21 +7,6 @@ use alloc::vec::Vec;
 use cpu::CpuId;
 
 #[cfg(target_arch = "aarch64")]
-use {
-    gic::{ArmGic, SpiDestination, Priority, IpiTargetCpu, Version as GicVersion},
-    arm_boards::{BOARD_CONFIG, InterruptControllerConfig},
-    irq_safety::MutexIrqSafe,
-    memory::get_kernel_mmi_ref,
-    core::ops::DerefMut,
-};
-
-#[cfg(target_arch = "x86_64")]
-use {
-    apic::{get_my_apic, LapicIpiDestination},
-    ioapic::get_ioapic,
-};
-
-#[cfg(target_arch = "aarch64")]
 #[path = "aarch64.rs"]
 pub mod arch;
 
@@ -29,27 +14,16 @@ pub mod arch;
 #[path = "x86_64.rs"]
 pub mod arch;
 
-pub use arch::*;
-
-#[cfg(target_arch = "aarch64")]
-macro_rules! get_int_ctlr {
-    ($name:ident, $func:ident, $this:expr) => {
-        let mut $name = INTERRUPT_CONTROLLER.lock();
-        let $name = $name.as_mut().expect(concat!("BUG: ", stringify!($func), "(): INTERRUPT_CONTROLLER was uninitialized"));
-    };
-    ($name:ident, $func:ident) => ( get_int_ctlr!($name, $func, ()) );
-}
-
-#[cfg(target_arch = "x86_64")]
-macro_rules! get_int_ctlr {
-    ($name:ident, $func:ident, $this:expr) => {
-        let mut $name = get_ioapic($this.id).expect(concat!("BUG: ", stringify!($func), "(): get_ioapic() returned None"));
-    };
-    ($name:ident, $func:ident) => {
-        let mut $name = get_my_apic().expect(concat!("BUG: ", stringify!($func), "(): get_my_apic() returned None"));
-        let mut $name = $name.write();
-    };
-}
+pub use arch::{
+    SystemInterruptControllerVersion,
+    SystemInterruptControllerId,
+    LocalInterruptControllerId,
+    SystemInterruptNumber,
+    LocalInterruptNumber,
+    Priority,
+    SystemInterruptController,
+    LocalInterruptController,
+};
 
 /// The Cpu where this interrupt should be handled, as well as
 /// the local interrupt number this gets translated to.
@@ -62,235 +36,48 @@ pub struct InterruptDestination {
     pub local_number: LocalInterruptNumber,
 }
 
-/// Structure representing a top-level/system-wide interrupt controller chip,
-/// responsible for routing interrupts between peripherals and CPU cores.
-///
-/// On x86_64, this corresponds to an IoApic.
-/// On aarch64 w/ GIC, this corresponds to the Distributor.
-pub struct SystemInterruptController {
-    #[cfg(target_arch = "x86_64")]
-    id: u8,
+pub trait SystemInterruptControllerApi {
+    fn id(&self) -> SystemInterruptControllerId;
+    fn version(&self) -> SystemInterruptControllerVersion;
+
+    fn get_destination(
+        &self,
+        interrupt_num: SystemInterruptNumber,
+    ) -> Result<(Vec<InterruptDestination>, Priority), &'static str>;
+
+    fn set_destination(
+        &self,
+        sys_int_num: SystemInterruptNumber,
+        destination: InterruptDestination,
+        priority: Priority,
+    ) -> Result<(), &'static str>;
 }
 
-/// Struct representing per-cpu-core interrupt controller chips.
-///
-/// On x86_64, this corresponds to a LocalApic.
-/// On aarch64 w/ GIC, this corresponds to a Redistributor & CPU interface.
-pub struct LocalInterruptController {}
-
-impl SystemInterruptController {
-    pub fn id(&self) -> SystemInterruptControllerId {
-        get_int_ctlr!(int_ctlr, id, self);
-
-        #[cfg(target_arch = "aarch64")] {
-            SystemInterruptControllerId(int_ctlr.implementer().product_id)
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            SystemInterruptControllerId(int_ctlr.id())
-        }
-    }
-
-    pub fn version(&self) -> SystemInterruptControllerVersion {
-        get_int_ctlr!(int_ctlr, version, self);
-
-        #[cfg(target_arch = "aarch64")] {
-            SystemInterruptControllerVersion(int_ctlr.implementer().version)
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            SystemInterruptControllerVersion(int_ctlr.version())
-        }
-    }
-
-    pub fn get_destination(&self, interrupt_num: SystemInterruptNumber) -> Result<(Vec<InterruptDestination>, Priority), &'static str> {
-        get_int_ctlr!(int_ctlr, get_destination, self);
-
-        #[cfg(target_arch = "aarch64")] {
-            let priority = int_ctlr.get_interrupt_priority(interrupt_num.0);
-            let local_number = LocalInterruptNumber(interrupt_num.0);
-
-            let vec = match int_ctlr.get_spi_target(interrupt_num.0)?.canonicalize() {
-                SpiDestination::Specific(cpu) => [InterruptDestination {
-                    cpu,
-                    local_number,
-                }].to_vec(),
-                SpiDestination::AnyCpuAvailable => BOARD_CONFIG.cpu_ids.map(|mpidr| InterruptDestination {
-                    cpu: mpidr.into(),
-                    local_number,
-                }).to_vec(),
-                SpiDestination::GICv2TargetList(list) => {
-                    let mut vec = Vec::with_capacity(8);
-                    for result in list.iter() {
-                        vec.push(InterruptDestination {
-                            cpu: result?,
-                            local_number,
-                        });
-                    }
-                    vec
-                }
-            };
-
-            Ok((vec, priority))
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            // no way to read the destination for an IRQ number in IoApic
-            unimplemented!()
-        }
-    }
-
-    pub fn set_destination(&self, sys_int_num: SystemInterruptNumber, destination: InterruptDestination, priority: Priority) -> Result<(), &'static str> {
-        get_int_ctlr!(int_ctlr, set_destination, self);
-
-        #[cfg(target_arch = "aarch64")] {
-            assert_eq!(sys_int_num.0, destination.local_number.0, "Local & System Interrupt Numbers cannot be different with GIC");
-
-            int_ctlr.set_spi_target(sys_int_num.0, SpiDestination::Specific(destination.cpu));
-            int_ctlr.set_interrupt_priority(sys_int_num.0, priority);
-
-            Ok(())
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            // no support for priority on x86_64
-            let _ = priority;
-
-            int_ctlr.set_irq(sys_int_num.0, destination.cpu.into(), destination.local_number.0)
-        }
-    }
-}
-
-impl LocalInterruptController {
-    pub fn id(&self) -> LocalInterruptControllerId {
-        get_int_ctlr!(int_ctlr, id);
-
-        #[cfg(target_arch = "aarch64")] {
-            LocalInterruptControllerId(int_ctlr.get_cpu_interface_id())
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            // this or the Apic ID ?
-            LocalInterruptControllerId(int_ctlr.processor_id())
-        }
-    }
-
-    pub fn get_local_interrupt_priority(&self, num: LocalInterruptNumber) -> Priority {
-        get_int_ctlr!(int_ctlr, get_local_interrupt_priority);
-
-        #[cfg(target_arch = "aarch64")] {
-            int_ctlr.get_interrupt_priority(num.0)
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            // No priority support on x86_64
-            Priority
-        }
-    }
-
-    pub fn set_local_interrupt_priority(&self, num: LocalInterruptNumber, priority: Priority) {
-        get_int_ctlr!(int_ctlr, set_local_interrupt_priority);
-
-        #[cfg(target_arch = "aarch64")] {
-            int_ctlr.set_interrupt_priority(num.0, priority);
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            // No priority support on x86_64
-            let _ = priority;
-        }
-    }
-
-    pub fn is_local_interrupt_enabled(&self, num: LocalInterruptNumber) -> bool {
-        get_int_ctlr!(int_ctlr, is_local_interrupt_enabled);
-
-        #[cfg(target_arch = "aarch64")] {
-            int_ctlr.get_interrupt_state(num.0)
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            todo!()
-        }
-    }
-
-    pub fn enable_local_interrupt(&self, num: LocalInterruptNumber, enabled: bool) {
-        get_int_ctlr!(int_ctlr, enable_local_interrupt);
-
-        #[cfg(target_arch = "aarch64")] {
-            int_ctlr.set_interrupt_state(num.0, enabled);
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            todo!()
-        }
-    }
+pub trait LocalInterruptControllerApi {
+    fn id(&self) -> LocalInterruptControllerId;
+    fn get_local_interrupt_priority(&self, num: LocalInterruptNumber) -> Priority;
+    fn set_local_interrupt_priority(&self, num: LocalInterruptNumber, priority: Priority);
+    fn is_local_interrupt_enabled(&self, num: LocalInterruptNumber) -> bool;
+    fn enable_local_interrupt(&self, num: LocalInterruptNumber, enabled: bool);
 
     /// Sends an inter-processor interrupt to a specific CPU.
-    pub fn send_ipi(&self, destination: InterruptDestination) {
-        get_int_ctlr!(int_ctlr, send_ipi);
-
-        #[cfg(target_arch = "aarch64")] {
-            int_ctlr.send_ipi(destination.local_number.0, IpiTargetCpu::Specific(destination.cpu));
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            int_ctlr.send_ipi(destination.local_number.0, LapicIpiDestination::One(destination.cpu.into()))
-        }
-    }
+    fn send_ipi(&self, destination: InterruptDestination);
 
     /// Reads the minimum priority for an interrupt to reach this CPU.
     ///
     /// Note: aarch64-only, at the moment.
-    pub fn get_minimum_priority(&self) -> Priority {
-        get_int_ctlr!(int_ctlr, get_minimum_priority);
-
-        #[cfg(target_arch = "aarch64")] {
-            int_ctlr.get_minimum_priority()
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            // No priority support on x86_64
-            Priority
-        }
-    }
+    fn get_minimum_priority(&self) -> Priority;
 
     /// Changes the minimum priority for an interrupt to reach this CPU.
     ///
     /// Note: aarch64-only, at the moment.
-    pub fn set_minimum_priority(&self, priority: Priority) {
-        get_int_ctlr!(int_ctlr, set_minimum_priority);
-
-        #[cfg(target_arch = "aarch64")] {
-            int_ctlr.set_minimum_priority(priority)
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            // No priority support on x86_64
-            let _ = priority;
-        }
-    }
+    fn set_minimum_priority(&self, priority: Priority);
 
     /// Aarch64-specific way to read the current pending interrupt number & priority.
-    #[cfg(target_arch = "aarch64")]
-    pub fn acknowledge_interrupt(&self) -> (LocalInterruptNumber, Priority) {
-        get_int_ctlr!(int_ctlr, acknowledge_interrupt);
-
-        let (num, prio) = int_ctlr.acknowledge_interrupt();
-
-        (LocalInterruptNumber(num), prio)
-    }
+    ///
+    /// Always panics on x86_64.
+    fn acknowledge_interrupt(&self) -> (LocalInterruptNumber, Priority);
 
     /// Tell the interrupt controller that the current interrupt has been handled.
-    pub fn end_of_interrupt(&self, number: LocalInterruptNumber) {
-        get_int_ctlr!(int_ctlr, end_of_interrupt);
-
-        #[cfg(target_arch = "aarch64")] {
-            int_ctlr.end_of_interrupt(number.0)
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            // On x86, passing the LocalInterruptNumber isn't required.
-            int_ctlr.eoi();
-        }
-    }
+    fn end_of_interrupt(&self, number: LocalInterruptNumber);
 }

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -137,7 +137,7 @@ macro_rules! get_int_ctlr {
     };
 }
 
-/// The Cpu were this interrupt should be handled, as well as
+/// The Cpu where this interrupt should be handled, as well as
 /// the local interrupt number this gets translated to.
 ///
 /// On aarch64, the system interrupt number and the local interrupt
@@ -372,7 +372,7 @@ impl LocalInterruptController {
         }
     }
 
-    /// Tell the interrupt controller that the current interrupt handling as ended.
+    /// Tell the interrupt controller that the current interrupt has been handled.
     pub fn end_of_interrupt(&self, number: LocalInterruptNumber) {
         get_int_ctlr!(int_ctlr, end_of_interrupt);
 

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -1,0 +1,56 @@
+
+
+// The private global Generic Interrupt Controller singleton
+static INTERRUPT_CONTROLLER: MutexIrqSafe<Option<ArmGic>> = MutexIrqSafe::new(None);
+
+pub fn init() -> Result<(), &'static str> {
+    // *INTERRUPT_CONTROLLER = Some(...);
+}
+
+pub struct LocalInterruptControllerId(/* arch-specific unsigned int */);
+pub struct GlobalInterruptNumber(/* arch-specific unsigned int */);
+pub struct LocalInterruptNumber(/* arch-specific unsigned int */);
+
+/// Singleton representing the main/system-wide interrupt controller chip,
+/// responsible for routing interrupts between peripherals and CPU cores.
+///
+/// On x86_64, this corresponds to the IoApic.
+/// On aarch64 w/ GIC, this corresponds to the Distributor.
+pub struct GlobalInterruptController {}
+
+/// Struct representing per-cpu-core interrupt controller chips.
+///
+/// On x86_64, this corresponds to the LocalApic.
+/// On aarch64 w/ GIC, this corresponds to the Redistributor.
+pub struct LocalInterruptController {}
+
+/// Allows code to control the currently pending or active interrupt.
+///
+/// On x86_64, this uses the LocalApic.
+/// On aarch64 w/ GIC, this uses the CPU Interface.
+pub struct CurrentInterrupt {}
+
+// Should I implement Index & IndexMut instead?
+impl GlobalInterruptController {
+    pub fn get_destination(&self, interrupt_num: GlobalInterruptNumber) -> Option<(CpuId, LocalInterruptNumber, Priority)> {
+        todo!()
+    }
+
+    pub fn set_destination(&mut self, interrupt_num: GlobalInterruptNumber, destination: Option<(CpuId, LocalInterruptNumber, Priority)>) {
+        todo!()
+    }
+}
+
+impl LocalInterruptController {
+    pub fn cpu_id(&self) -> CpuId
+
+    pub fn get_min_priority(&self) -> Priority {
+        todo!()
+    }
+
+    pub fn set_min_priority(&mut self, priority: Priority) {
+        todo!()
+    }
+
+
+}

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -361,15 +361,9 @@ impl LocalInterruptController {
     pub fn acknowledge_interrupt(&self) -> (LocalInterruptNumber, Priority) {
         get_int_ctlr!(int_ctlr, acknowledge_interrupt);
 
-        #[cfg(target_arch = "aarch64")] {
-            let (num, prio) = int_ctlr.acknowledge_interrupt();
+        let (num, prio) = int_ctlr.acknowledge_interrupt();
 
-            (LocalInterruptNumber(num), prio)
-        }
-
-        #[cfg(target_arch = "x86_64")] {
-            panic!("This is an aarch64-only mechanism.");
-        }
+        (LocalInterruptNumber(num), prio)
     }
 
     /// Tell the interrupt controller that the current interrupt has been handled.
@@ -381,7 +375,7 @@ impl LocalInterruptController {
         }
 
         #[cfg(target_arch = "x86_64")] {
-            // what do we do with the IRQ number?
+            // On x86, passing the LocalInterruptNumber isn't required.
             int_ctlr.eoi();
         }
     }

--- a/kernel/interrupt_controller/src/x86_64.rs
+++ b/kernel/interrupt_controller/src/x86_64.rs
@@ -1,0 +1,15 @@
+#[derive(Debug, Copy, Clone)]
+pub struct SystemInterruptControllerVersion(pub u32);
+#[derive(Debug, Copy, Clone)]
+pub struct      SystemInterruptControllerId(pub u32);
+#[derive(Debug, Copy, Clone)]
+pub struct       LocalInterruptControllerId(pub u32);
+#[derive(Debug, Copy, Clone)]
+pub struct            SystemInterruptNumber(pub(crate) u8);
+#[derive(Debug, Copy, Clone)]
+pub struct             LocalInterruptNumber(pub(crate) u8);
+#[derive(Debug, Copy, Clone)]
+pub struct Priority;
+
+    /// Initializes the interrupt controller, on aarch64
+pub fn init() -> Result<(), &'static str> { Ok(()) }

--- a/kernel/interrupt_controller/src/x86_64.rs
+++ b/kernel/interrupt_controller/src/x86_64.rs
@@ -1,15 +1,142 @@
+use super::*;
+
+use {
+    apic::{get_my_apic, LapicIpiDestination},
+    ioapic::get_ioapic,
+};
+
 #[derive(Debug, Copy, Clone)]
 pub struct SystemInterruptControllerVersion(pub u32);
 #[derive(Debug, Copy, Clone)]
-pub struct      SystemInterruptControllerId(pub u32);
+pub struct SystemInterruptControllerId(pub u32);
 #[derive(Debug, Copy, Clone)]
-pub struct       LocalInterruptControllerId(pub u32);
+pub struct LocalInterruptControllerId(pub u32);
 #[derive(Debug, Copy, Clone)]
-pub struct            SystemInterruptNumber(pub(crate) u8);
+pub struct SystemInterruptNumber(pub(crate) u8);
 #[derive(Debug, Copy, Clone)]
-pub struct             LocalInterruptNumber(pub(crate) u8);
+pub struct LocalInterruptNumber(pub(crate) u8);
 #[derive(Debug, Copy, Clone)]
 pub struct Priority;
 
     /// Initializes the interrupt controller, on aarch64
 pub fn init() -> Result<(), &'static str> { Ok(()) }
+
+/// Structure representing a top-level/system-wide interrupt controller chip,
+/// responsible for routing interrupts between peripherals and CPU cores.
+///
+/// On x86_64, this corresponds to an IoApic.
+pub struct SystemInterruptController {
+    id: u8,
+}
+
+/// Struct representing per-cpu-core interrupt controller chips.
+///
+/// On x86_64, this corresponds to a LocalApic.
+pub struct LocalInterruptController;
+
+// 1st variant: get system controller
+// 2nd variant: get local controller
+macro_rules! get_int_ctlr {
+    ($name:ident, $func:ident, $this:expr) => {
+        let mut $name = get_ioapic($this.id).expect(concat!("BUG: ", stringify!($func), "(): get_ioapic() returned None"));
+    };
+    ($name:ident, $func:ident) => {
+        let mut $name = get_my_apic().expect(concat!("BUG: ", stringify!($func), "(): get_my_apic() returned None"));
+        let mut $name = $name.write();
+    };
+}
+
+impl SystemInterruptControllerApi for SystemInterruptController {
+    fn id(&self) -> SystemInterruptControllerId {
+        get_int_ctlr!(int_ctlr, id, self);
+        SystemInterruptControllerId(int_ctlr.id())
+    }
+
+    fn version(&self) -> SystemInterruptControllerVersion {
+        get_int_ctlr!(int_ctlr, version, self);
+        SystemInterruptControllerVersion(int_ctlr.version())
+    }
+
+    fn get_destination(
+        &self,
+        interrupt_num: SystemInterruptNumber,
+    ) -> Result<(Vec<InterruptDestination>, Priority), &'static str> {
+        // no way to read the destination for an IRQ number in IoApic
+        unimplemented!()
+    }
+
+    fn set_destination(
+        &self,
+        sys_int_num: SystemInterruptNumber,
+        destination: InterruptDestination,
+        priority: Priority,
+    ) -> Result<(), &'static str> {
+        get_int_ctlr!(int_ctlr, set_destination, self);
+
+        // no support for priority on x86_64
+        let _ = priority;
+
+        int_ctlr.set_irq(sys_int_num.0, destination.cpu.into(), destination.local_number.0)
+    }
+}
+
+
+impl LocalInterruptControllerApi for LocalInterruptController {
+    fn id(&self) -> LocalInterruptControllerId {
+        get_int_ctlr!(int_ctlr, id);
+
+        LocalInterruptControllerId(int_ctlr.processor_id())
+    }
+
+    fn get_local_interrupt_priority(&self, num: LocalInterruptNumber) -> Priority {
+        get_int_ctlr!(int_ctlr, get_local_interrupt_priority);
+
+        // No priority support on x86_64
+        Priority
+    }
+
+    fn set_local_interrupt_priority(&self, num: LocalInterruptNumber, priority: Priority) {
+        get_int_ctlr!(int_ctlr, set_local_interrupt_priority);
+
+        // No priority support on x86_64
+        let _ = priority;
+    }
+
+    fn is_local_interrupt_enabled(&self, num: LocalInterruptNumber) -> bool {
+        todo!()
+    }
+
+    fn enable_local_interrupt(&self, num: LocalInterruptNumber, enabled: bool) {
+        todo!()
+    }
+
+    fn send_ipi(&self, destination: InterruptDestination) {
+        get_int_ctlr!(int_ctlr, send_ipi);
+        int_ctlr.send_ipi(destination.local_number.0, LapicIpiDestination::One(destination.cpu.into()))
+    }
+
+    fn get_minimum_priority(&self) -> Priority {
+        get_int_ctlr!(int_ctlr, get_minimum_priority);
+
+        // No priority support on x86_64
+        Priority
+    }
+
+    fn set_minimum_priority(&self, priority: Priority) {
+        get_int_ctlr!(int_ctlr, set_minimum_priority);
+
+        // No priority support on x86_64
+        let _ = priority;
+    }
+
+    fn acknowledge_interrupt(&self) -> (LocalInterruptNumber, Priority) {
+        panic!("This must not be used on x86_64")
+    }
+
+    fn end_of_interrupt(&self, _number: LocalInterruptNumber) {
+        get_int_ctlr!(int_ctlr, end_of_interrupt);
+
+        // On x86, passing the LocalInterruptNumber isn't required.
+        int_ctlr.eoi();
+    }
+}

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 log = "0.4.8"
 
+interrupt_controller = { path = "../interrupt_controller" }
 memory = { path = "../memory" }
 cpu = { path = "../cpu" }
 spin = "0.9.4"


### PR DESCRIPTION
This PR introduces the `interrupt_controller` crate, which acts as an abstraction over:
- Arm Generic Interrupt Controllers (GIC), on aarch64
- the APIC & IOAPIC, on x86_64.

The PR doesn't include any use of the crate, as this is a first draft.
Please share your opinion on this before I continue.