### PR TITLE
page allocator: support allocating pages within an address range

### DIFF
--- a/kernel/kernel_config/src/memory.rs
+++ b/kernel/kernel_config/src/memory.rs
@@ -1,4 +1,4 @@
-//! The basic virtual memory map that Theseus assumes.
+//! The basic virtual address ranges (virtual memory map) defined by Theseus.
 //!
 //! Current P4 (top-level page table) mappings:
 //! * 511: kernel text sections.
@@ -53,15 +53,15 @@ pub const TEMPORARY_PAGE_VIRT_ADDR: usize = MAX_VIRTUAL_ADDRESS;
 
 /// Value: 512.
 pub const ENTRIES_PER_PAGE_TABLE: usize = PAGE_SIZE / BYTES_PER_ADDR;
-/// Value: 511. The 511th entry is used for kernel text sections
+/// Value: 511. The 511th entry is used (in part) for kernel text sections.
 pub const KERNEL_TEXT_P4_INDEX: usize = ENTRIES_PER_PAGE_TABLE - 1;
 /// Value: 510. The 510th entry is used to recursively map the current P4 root page table frame
-//              such that it can be accessed and modified just like any other level of page table.
+///             such that it can be accessed and modified just like any other level of page table.
 pub const RECURSIVE_P4_INDEX: usize = ENTRIES_PER_PAGE_TABLE - 2;
-/// Value: 509. The 509th entry is used for the kernel heap
+/// Value: 509. The 509th entry is used for the kernel heap.
 pub const KERNEL_HEAP_P4_INDEX: usize = ENTRIES_PER_PAGE_TABLE - 3;
 /// Value: 508. The 508th entry is used to temporarily recursively map the P4 root page table frame
-//              of an upcoming (new) page table such that it can be accessed and modified.
+///             of an upcoming (new) page table such that it can be accessed and modified.
 pub const UPCOMING_PAGE_TABLE_RECURSIVE_P4_INDEX: usize = ENTRIES_PER_PAGE_TABLE - 4;
 
 
@@ -89,12 +89,9 @@ pub const KERNEL_OFFSET: usize = canonicalize(MAX_VIRTUAL_ADDRESS - (TWO_GIGABYT
 /// Actual value on x86_64: 0o177777_777_000_000_000_0000, or 0xFFFF_FF80_0000_0000
 pub const KERNEL_TEXT_START: usize = canonicalize(KERNEL_TEXT_P4_INDEX << (P4_INDEX_SHIFT + PAGE_SHIFT));
 
-/// The size in bytes, not in pages.
-///
-/// the KERNEL_OFFSET starts at (MAX_ADDR - 2GiB),
-/// and .text contains nano_core, so this is the
-/// first 510GiB of the 511th P4 entry.
-pub const KERNEL_TEXT_MAX_SIZE: usize = ADDRESSABILITY_PER_P4_ENTRY - TWO_GIGABYTES;
+/// The start of the virtual address range covered by the 510th P4 entry,
+/// i.e., [`RECURSIVE_P4_INDEX`];
+pub const RECURSIVE_P4_START: usize = canonicalize(RECURSIVE_P4_INDEX << (P4_INDEX_SHIFT + PAGE_SHIFT));
 
 /// The higher-half heap gets the 512GB address range starting at the 509th P4 entry,
 /// which is the slot right below the recursive P4 entry (510).
@@ -103,12 +100,12 @@ pub const KERNEL_HEAP_START: usize = canonicalize(KERNEL_HEAP_P4_INDEX << (P4_IN
 
 #[cfg(not(debug_assertions))]
 pub const KERNEL_HEAP_INITIAL_SIZE: usize = 64 * 1024 * 1024; // 64 MiB
-
 #[cfg(debug_assertions)]
 pub const KERNEL_HEAP_INITIAL_SIZE: usize = 256 * 1024 * 1024; // 256 MiB, debug builds require more heap space.
 
-/// the kernel heap gets the whole 509th P4 entry.
+/// The kernel heap is allowed to grow to fill the entirety of its P4 entry.
 pub const KERNEL_HEAP_MAX_SIZE: usize = ADDRESSABILITY_PER_P4_ENTRY;
 
-/// The system (page allocator) must not use addresses at or above this address.
-pub const UPCOMING_PAGE_TABLE_RECURSIVE_MEMORY_START: usize = canonicalize(UPCOMING_PAGE_TABLE_RECURSIVE_P4_INDEX << (P4_INDEX_SHIFT + PAGE_SHIFT));
+/// The start of the virtual address range covered by the 508th P4 entry,
+/// i.e., [`UPCOMING_PAGE_TABLE_RECURSIVE_P4_INDEX`];
+pub const UPCOMING_PAGE_TABLE_RECURSIVE_P4_START: usize = canonicalize(UPCOMING_PAGE_TABLE_RECURSIVE_P4_INDEX << (P4_INDEX_SHIFT + PAGE_SHIFT));

--- a/kernel/logger/src/lib.rs
+++ b/kernel/logger/src/lib.rs
@@ -37,7 +37,7 @@ pub const LOG_MAX_WRITERS: usize = 2;
 /// The size of the buffer used to save early log messages.
 pub const EARLY_LOG_BUFFER_SIZE: usize = {
     #[cfg(target_arch = "x86_64")]  { 0 }
-    #[cfg(target_arch = "aarch64")] { 16 * 1024 }
+    #[cfg(target_arch = "aarch64")] { 32 * 1024 }
 };
 
 /// The early logger used before dynamic heap allocation is available.

--- a/kernel/logger/src/lib.rs
+++ b/kernel/logger/src/lib.rs
@@ -37,7 +37,7 @@ pub const LOG_MAX_WRITERS: usize = 2;
 /// The size of the buffer used to save early log messages.
 pub const EARLY_LOG_BUFFER_SIZE: usize = {
     #[cfg(target_arch = "x86_64")]  { 0 }
-    #[cfg(target_arch = "aarch64")] { 32 * 1024 }
+    #[cfg(target_arch = "aarch64")] { 16 * 1024 }
 };
 
 /// The early logger used before dynamic heap allocation is available.

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -23,15 +23,8 @@ pub use self::paging::{
 };
 
 pub use memory_structs::*;
-pub use page_allocator::{
-    AllocatedPages, allocate_pages, allocate_pages_at,
-    allocate_pages_by_bytes, allocate_pages_by_bytes_at,
-};
-
-pub use frame_allocator::{
-    AllocatedFrames, MemoryRegionType, PhysicalMemoryRegion,
-    allocate_frames, allocate_frames_at, allocate_frames_by_bytes_at, allocate_frames_by_bytes,
-};
+pub use page_allocator::*;
+pub use frame_allocator::*;
 
 #[cfg(target_arch = "x86_64")]
 use memory_x86_64::{ tlb_flush_virt_addr, tlb_flush_all, get_p4, find_section_memory_bounds, get_vga_mem_addr };

--- a/kernel/mod_mgmt/src/lib.rs
+++ b/kernel/mod_mgmt/src/lib.rs
@@ -2987,10 +2987,10 @@ fn allocate_section_pages(elf_file: &ElfFile, kernel_mmi_ref: &MmiRef) -> Result
     let alloc_sec = |size_in_bytes: usize, within_range: Option<&PageRange>, flags: PteFlags| {
         let allocated_pages = if let Some(range) = within_range {
             allocate_pages_by_bytes_in_range(size_in_bytes, range)
-                .map_err(|_| "Couldn't allocated pages in text section address range")?
+                .map_err(|_| "Couldn't allocate pages in text section address range")?
         } else {
             allocate_pages_by_bytes(size_in_bytes)
-                .ok_or("Couldn't allocate pages for new read-only or read-write section")?
+                .ok_or("Couldn't allocate pages for new section")?
         };
     
         kernel_mmi_ref.lock().page_table.map_allocated_pages(

--- a/kernel/nano_core/linker_higher_half-aarch64.ld
+++ b/kernel/nano_core/linker_higher_half-aarch64.ld
@@ -27,6 +27,18 @@ SECTIONS {
         *(.text .text.*)
     }
 
+    /*
+     * Currently, we are unable to force aarch64 to emit branch (call/jump) instructions
+     * that are capable of addressing a destination instruction pointer more than 128MiB away,
+     * even when specifying the "large" code model with `-C code-model=large`.
+     *
+     * Thus, as a workaround, we reserve the 128MiB chunk of virtual address space that
+     * directly follows the initial base kernel image's executable .text section,
+     * ensuring it can only be used by the page allocator when allocating pages for
+     * newly-loaded .text sections.
+     */
+    . = ALIGN(128M);
+
     .rodata ALIGN(4K) : AT(ADDR(.rodata) - KERNEL_OFFSET)
     {
         *(.rodata .rodata.*)

--- a/kernel/page_allocator/src/lib.rs
+++ b/kernel/page_allocator/src/lib.rs
@@ -682,15 +682,6 @@ pub fn allocate_pages_deferred(
 }
 
 
-/// Allocates the given number of pages with the constraint they they must be
-/// within the given inclusive `range` of pages.
-pub fn allocate_pages_in_range(
-	num_pages: usize,
-	range: &PageRange,
-) -> Result<(AllocatedPages, DeferredAllocAction<'static>), &'static str> {
-	allocate_pages_deferred(None, num_pages, Some(range))
-}
-
 /// Similar to [`allocated_pages_deferred()`](fn.allocate_pages_deferred.html),
 /// but accepts a size value for the allocated pages in number of bytes instead of number of pages. 
 /// 
@@ -747,6 +738,27 @@ pub fn allocate_pages_by_bytes_at(vaddr: VirtualAddress, num_bytes: usize) -> Re
 pub fn allocate_pages_at(vaddr: VirtualAddress, num_pages: usize) -> Result<AllocatedPages, &'static str> {
 	allocate_pages_deferred(Some(vaddr), num_pages, None)
 		.map(|(ap, _action)| ap)
+}
+
+
+/// Allocates the given number of pages with the constraint that
+/// they must be within the given inclusive `range` of pages.
+pub fn allocate_pages_in_range(
+	num_pages: usize,
+	range: &PageRange,
+) -> Result<(AllocatedPages, DeferredAllocAction<'static>), &'static str> {
+	allocate_pages_deferred(None, num_pages, Some(range))
+}
+
+
+/// Allocates pages with a size given in number of bytes with the constraint that
+/// they must be within the given inclusive `range` of pages.
+pub fn allocate_pages_by_bytes_in_range(
+	num_bytes: usize,
+	range: &PageRange,
+) -> Result<(AllocatedPages, DeferredAllocAction<'static>), &'static str> {
+	let num_pages = (num_bytes + PAGE_SIZE - 1) / PAGE_SIZE; // round up
+	allocate_pages_deferred(None, num_pages, Some(range))
 }
 
 

--- a/kernel/page_allocator/src/lib.rs
+++ b/kernel/page_allocator/src/lib.rs
@@ -560,7 +560,7 @@ fn find_any_chunk(
 			// for c in eligible_chunks { ... }
 			// ```
 			//
-			// RBTree doesn't have a `range_mut()` method, so we use cursors for two round of iteration.
+			// RBTree doesn't have a `range_mut()` method, so we use cursors for two rounds of iteration.
 			// The first iterates over the lower designated region, from higher addresses to lower, down to zero.
 			let mut cursor = tree.upper_bound_mut(Bound::Included(designated_low_end));
 			while let Some(chunk) = cursor.get().map(|w| w.deref()) {


### PR DESCRIPTION
This is only needed on aarch64 for a workaround to allow #940 to work.

Currently, based on the needs of aarch64, we reserve 128MiB of virtual address space for executable text sections. This region is contiguous with the base kernel image's .text section.

