### PR TITLE
task_switch: explicitly drop current task's TLS reference

### DIFF
--- a/kernel/task/src/lib.rs
+++ b/kernel/task/src/lib.rs
@@ -816,7 +816,7 @@ fn task_switch_inner(
     cpu_id: CpuId,
     preemption_guard: PreemptionGuard,
 ) -> Result<TaskSwitchInnerRet, (bool, PreemptionGuard)> {
-    let Some(ref curr) = curr_task_tls_slot.as_ref() else {
+    let Some(curr) = curr_task_tls_slot.as_ref() else {
         error!("BUG: task_switch_inner(): couldn't get current task");
         return Err((false, preemption_guard));
     };


### PR DESCRIPTION
* In the inner task switching routine, pass in access to the actual `RefMut<Option<TaskRef>>` object that was borrowed from the `CURRENT_TASK` TLS area, such that the actual task switch logic can explicitly drop it at the right point -- just before switching to the next task.

* This change ensures that the `CURRENT_TASK` TLS variable that is used in task switching is dropped before switching to the next task, in order to ensure that `RefCell`'s runtime borrowing mechanic always works across task switches.