### PR TITLE
Document temporarily unused code in multicore_bringup

### DIFF
--- a/kernel/multicore_bringup/src/aarch64.rs
+++ b/kernel/multicore_bringup/src/aarch64.rs
@@ -65,32 +65,53 @@ pub fn handle_ap_cores(
         let mmu_config_virt_addr = VirtualAddress::new_canonical(&mmu_config as *const _ as usize);
         ap_data.ap_mmu_config.write(page_table.translate(mmu_config_virt_addr).unwrap());
 
-        // Note: this could be variable on aarch64
-        // we'd need a way to find any identity mappable page+frame range
-        const AP_STARTUP: usize = 0x10000;
-
-        // When the AArch64 core will enter startup code, it will do so with MMU disabled,
-        // which means these frames MUST be identity mapped.
-        let ap_startup_frames = memory::allocate_frames_by_bytes_at(PhysicalAddress::new_canonical(AP_STARTUP), PAGE_SIZE)
-            .map_err(|_e| "handle_ap_cores(): failed to allocate AP startup frames")?;
-        let ap_startup_pages  = memory::allocate_pages_at(VirtualAddress::new_canonical(AP_STARTUP), ap_startup_frames.size_in_frames())
-            .map_err(|_e| "handle_ap_cores(): failed to allocate AP startup pages")?;
-
-        // map this RWX
-        let flags = PteFlags::new().valid(true).writable(true);
-        ap_startup_mapped_pages = page_table.map_allocated_pages_to(
-            ap_startup_pages,
-            ap_startup_frames,
-            flags,
-        )?;
-
         // get physical address of the ApTrampolineData structure
         ap_data_phys_addr = page_table.translate(ap_data.ap_data_virt_addr.read()).unwrap();
 
-        // copy the entry point code
-        let dst = ap_startup_mapped_pages.as_slice_mut(0, PAGE_SIZE).unwrap();
-        let src = unsafe { (ap_entry_point as *const [u8; PAGE_SIZE]).as_ref() }.unwrap();
-        dst.copy_from_slice(src);
+        // This block identity-maps one page of writable+executable memory and
+        // copies the machine code of `ap_entry_point` to it. The fact that the
+        // mapping is identity-mapped allows this code to enable paging
+        // transparently without messing up with the PC register.
+        //
+        // However, there is currently no way in Theseus to dynamically find a
+        // memory range that is identity mappable, so the address is hardcoded.
+        //
+        // Another solution was implemented instead, which is why this one is
+        // soft-commented. The CPU has instruction caches, so when paging gets
+        // enabled, it can still execute some instructions located near PC without
+        // using the page directory. This allows us to branch to a physical address,
+        // enable paging, and then branch to a virtual address (even though at the
+        // time of the second branch, PC has an invalid address) where the
+        // initialization can continue.
+        // Note: caches must not be flushed before this second branch.
+        //
+        // It would still be preferable to use the first solution, as it doesn't
+        // rely on a cache trick.
+        if false {
+            // Note: this could be variable on aarch64
+            // we'd need a way to find any identity mappable page+frame range
+            const AP_STARTUP: usize = 0x10000;
+
+            // When the AArch64 core will enter startup code, it will do so with MMU disabled,
+            // which means these frames MUST be identity mapped.
+            let ap_startup_frames = memory::allocate_frames_by_bytes_at(PhysicalAddress::new_canonical(AP_STARTUP), PAGE_SIZE)
+                .map_err(|_e| "handle_ap_cores(): failed to allocate AP startup frames")?;
+            let ap_startup_pages  = memory::allocate_pages_at(VirtualAddress::new_canonical(AP_STARTUP), ap_startup_frames.size_in_frames())
+                .map_err(|_e| "handle_ap_cores(): failed to allocate AP startup pages")?;
+
+            // map this RWX
+            let flags = PteFlags::new().valid(true).writable(true);
+            ap_startup_mapped_pages = page_table.map_allocated_pages_to(
+                ap_startup_pages,
+                ap_startup_frames,
+                flags,
+            )?;
+
+            // copy the entry point code
+            let dst = ap_startup_mapped_pages.as_slice_mut(0, PAGE_SIZE).unwrap();
+            let src = unsafe { (ap_entry_point as *const [u8; PAGE_SIZE]).as_ref() }.unwrap();
+            dst.copy_from_slice(src);
+        }
     }
 
     let mut ap_stack = None;


### PR DESCRIPTION
Tiny PR, title says it all. Documentation added:

```rust
// This block identity-maps one page of writable+executable memory and
// copies the machine code of `ap_entry_point` to it. The fact that the
// mapping is identity-mapped allows this code to enable paging
// transparently without messing up with the PC register.
//
// However, there is currently no way in Theseus to dynamically find a
// memory range that is identity mappable, so the address is hardcoded.
//
// Another solution was implemented instead, which is why this one is
// soft-commented. The CPU has instruction caches, so when paging gets
// enabled, it can still execute some instructions located near PC without
// using the page directory. This allows us to branch to a physical address,
// enable paging, and then branch to a virtual address (even though at the
// time of the second branch, PC has an invalid address) where the
// initialization can continue.
// Note: caches must not be flushed before this second branch.
//
// It would still be preferable to use the first solution, as it doesn't
// rely on a cache trick.
```