### PR TITLE
Remove `Deref` connection from `AllocatedPages` --> `PageRange`

### DIFF
--- a/kernel/early_printer/src/lib.rs
+++ b/kernel/early_printer/src/lib.rs
@@ -143,7 +143,7 @@ pub fn init(
                 .ok()
             )
             .and_then(|mp| {
-                staging_fb_range = Some(mp.deref().clone());
+                staging_fb_range = Some(mp.range().clone());
                 mp.into_borrowed_slice_mut(0, fb_pixel_count).ok()
             });
             

--- a/kernel/page_allocator/src/lib.rs
+++ b/kernel/page_allocator/src/lib.rs
@@ -212,12 +212,6 @@ pub struct AllocatedPages {
 // AllocatedPages must not be Cloneable, and it must not expose its inner pages as mutable.
 assert_not_impl_any!(AllocatedPages: DerefMut, Clone);
 
-impl Deref for AllocatedPages {
-    type Target = PageRange;
-    fn deref(&self) -> &PageRange {
-        &self.pages
-    }
-}
 impl fmt::Debug for AllocatedPages {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "AllocatedPages({:?})", self.pages)
@@ -231,6 +225,61 @@ impl AllocatedPages {
         AllocatedPages {
 			pages: PageRange::empty()
 		}
+	}
+
+	///	Returns the starting `VirtualAddress` in this range of pages.
+    pub fn start_address(&self) -> VirtualAddress {
+        self.pages.start_address()
+    }
+
+	///	Returns the size in bytes of this range of pages.
+    pub fn size_in_bytes(&self) -> usize {
+        self.pages.size_in_bytes()
+    }
+
+	///	Returns the size in number of pages of this range of pages.
+    pub fn size_in_pages(&self) -> usize {
+        self.pages.size_in_pages()
+    }
+
+	///	Returns the starting `Page` in this range of pages.
+	pub fn start(&self) -> &Page {
+		self.pages.start()
+	}
+
+	///	Returns the ending `Page` (inclusive) in this range of pages.
+	pub fn end(&self) -> &Page {
+		self.pages.end()
+	}
+
+	///	Returns a reference to the inner `PageRange`, which is cloneable/iterable.
+	pub fn range(&self) -> &PageRange {
+		&self.pages
+	}
+
+	/// Returns the offset of the given `VirtualAddress` within this range of pages,
+	/// i.e., `addr - self.start_address()`.
+	///
+	/// If the given `addr` is not covered by this range of pages, this returns `None`.
+	///
+	/// ## Examples
+	/// If the range covers addresses `0x2000` to `0x4000`,
+	/// then `offset_of_address(0x3500)` would return `Some(0x1500)`.
+	pub const fn offset_of_address(&self, addr: VirtualAddress) -> Option<usize> {
+		self.pages.offset_of_address(addr)
+	}
+
+	/// Returns the `VirtualAddress` at the given offset into this range of pages,
+	/// i.e., `self.start_address() + offset`.
+	///
+	/// If the given `offset` is not within this range of pages, this returns `None`.
+	///
+	/// ## Examples
+	/// If the range covers addresses `0x2000` through `0x3FFF`,
+	/// then `address_at_offset(0x1500)` would return `Some(0x3500)`,
+	/// and `address_at_offset(0x2000)` would return `None`.
+	pub const fn address_at_offset(&self, offset: usize) -> Option<VirtualAddress> {
+		self.pages.address_at_offset(offset)
 	}
 
 	/// Merges the given `AllocatedPages` object `ap` into this `AllocatedPages` object (`self`).

--- a/kernel/page_allocator/src/lib.rs
+++ b/kernel/page_allocator/src/lib.rs
@@ -227,32 +227,32 @@ impl AllocatedPages {
 		}
 	}
 
-	///	Returns the starting `VirtualAddress` in this range of pages.
+	/// Returns the starting `VirtualAddress` in this range of pages.
     pub fn start_address(&self) -> VirtualAddress {
         self.pages.start_address()
     }
 
-	///	Returns the size in bytes of this range of pages.
+	/// Returns the size in bytes of this range of pages.
     pub fn size_in_bytes(&self) -> usize {
         self.pages.size_in_bytes()
     }
 
-	///	Returns the size in number of pages of this range of pages.
+	/// Returns the size in number of pages of this range of pages.
     pub fn size_in_pages(&self) -> usize {
         self.pages.size_in_pages()
     }
 
-	///	Returns the starting `Page` in this range of pages.
+	/// Returns the starting `Page` in this range of pages.
 	pub fn start(&self) -> &Page {
 		self.pages.start()
 	}
 
-	///	Returns the ending `Page` (inclusive) in this range of pages.
+	/// Returns the ending `Page` (inclusive) in this range of pages.
 	pub fn end(&self) -> &Page {
 		self.pages.end()
 	}
 
-	///	Returns a reference to the inner `PageRange`, which is cloneable/iterable.
+	/// Returns a reference to the inner `PageRange`, which is cloneable/iterable.
 	pub fn range(&self) -> &PageRange {
 		&self.pages
 	}

--- a/kernel/stack/src/lib.rs
+++ b/kernel/stack/src/lib.rs
@@ -133,6 +133,6 @@ impl Stack {
     /// Guard pages are virtual pages that are reserved/owned by this stack
     /// but are not mapped, causing any access to them to result in a page fault. 
     pub fn guard_page(&self) -> &memory_structs::PageRange {
-        &self.guard_page
+        self.guard_page.range()
     }
 }


### PR DESCRIPTION
This is problematic for a huge pages implementation, since the underlying range of pages for a particular `AllocatedPages` (and `MappedPages`) will not always be the same single `PageRange` type -- it could be a range of 4KiB normal pages or 2MiB / 1GiB huge pages.

Instead, `AllocatedPages` now exposes a few wrapper functions that allow access to the commonly-used functions from `PageRange`.

MappedPages now derefs to `AllocatedPages`, not directly to `PageRange`.