### PR TITLE
Clone run queue in `rq` app

### DIFF
--- a/applications/rq/src/lib.rs
+++ b/applications/rq/src/lib.rs
@@ -42,7 +42,7 @@ pub fn main(args: Vec<String>) -> isize {
 
         println!("\n{} (apic: {}, proc: {})", core_type, apic_id, processor); 
         
-        if let Some(runqueue) = runqueue::get_runqueue(apic_id.value() as u8).map(|rq| rq.read()) {
+        if let Some(runqueue) = runqueue::get_runqueue(apic_id.value() as u8).map(|rq| rq.read().clone()) {
             let mut runqueue_contents = String::new();
             for task in runqueue.iter() {
                 writeln!(runqueue_contents, "    {} ({}) {}", 


### PR DESCRIPTION
Avoids disabling preemption for the duration of the program which can interfere with printing to the terminal.