### PR TITLE
Enable `BorrowedMappedPages` to use `Arc`, `Rc`, `&'static` `MappedPages`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,6 +2001,7 @@ dependencies = [
  "page_table_entry",
  "pte_flags",
  "spin 0.9.4",
+ "static_assertions",
  "x86_64",
  "xmas-elf",
  "zerocopy",

--- a/kernel/memory/Cargo.toml
+++ b/kernel/memory/Cargo.toml
@@ -13,6 +13,7 @@ bit_field = "0.7.0"
 zerocopy = "0.5.0"
 log = "0.4.8"
 lazy_static = { features = ["spin_no_std"], version = "1.4.0" }
+static_assertions = "1.1.0"
 
 atomic_linked_list = { path = "../../libs/atomic_linked_list" }
 boot_info = { path = "../boot_info" }

--- a/kernel/memory/src/paging/mapper.rs
+++ b/kernel/memory/src/paging/mapper.rs
@@ -1014,7 +1014,7 @@ impl<T: FromBytes, B: Borrow<MappedPages>> BorrowedMappedPages<T, Immutable, B> 
     ///    * This can be any "owned" type that wraps `MappedPages` without requiring a lifetime
     ///      and implements the `Borrow` trait, e.g., `MappedPages` itself,
     ///      `Arc<MappedPages>`, `Rc<MappedPages>`, `&'static MappedPages`.
-    ///    * You cannot use a wrapper type that requires a lifetime, e.g.,
+    ///    * You cannot use a wrapper type that requires a non-`static` lifetime, e.g.,
     ///      `&'a MappedPages`, `&'a mut MappedPages`, `Cow<'a, MappedPages>`, etc.
     /// * `byte_offset`: the offset (in number of bytes) from the beginning of the `MappedPages`
     ///    memory region at which the struct `T` is located (where it should start).
@@ -1170,7 +1170,7 @@ impl<T: FromBytes, B: Borrow<MappedPages>> BorrowedSliceMappedPages<T, Immutable
     ///    * This can be any "owned" type that wraps `MappedPages` without requiring a lifetime
     ///      and implements the `Borrow` trait, e.g., `MappedPages` itself,
     ///      `Arc<MappedPages>`, `Rc<MappedPages>`, `&'static MappedPages`.
-    ///    * You cannot use a wrapper type that requires a lifetime, e.g.,
+    ///    * You cannot use a wrapper type that requires a non-`static` lifetime, e.g.,
     ///      `&'a MappedPages`, `&'a mut MappedPages`, `Cow<'a, MappedPages>`, etc.
     /// * `byte_offset`: the offset (in number of bytes) from the beginning of the `MappedPages`
     ///    memory region at which the struct `T` is located (where it should start).

--- a/kernel/memory/src/paging/mapper.rs
+++ b/kernel/memory/src/paging/mapper.rs
@@ -1065,12 +1065,14 @@ impl<T: FromBytes> BorrowedMappedPages<T, Mutable, MappedPages> {
 }
 
 impl<T: FromBytes, M: Mutability, B: Borrow<MappedPages>> BorrowedMappedPages<T, M, B> {
-    /// Consumes this object and returns the inner `MappedPages`.
+    /// Consumes this object and returns the inner `MappedPages` value
+    /// (more specifically, the `Borrow`-able container holding the `MappedPages`).
     pub fn into_inner(self) -> B {
         self.mp
     }
 
-    /// Returns a reference to the inner borrowed `MappedPages`.
+    /// Returns a reference to the inner `MappedPages` value
+    /// (more specifically, the `Borrow`-able container holding the `MappedPages`).
     pub fn inner_ref(&self) -> &B {
         &self.mp
     }


### PR DESCRIPTION
* Previously, the `BorrowedMappedPages` and `BorrowedSliceMappedPages` types could only accommodate a plain `MappedPages` owned object, which made it impossible to have multiple different instances of a `BorrowedMappedPages` object that all refer to the same underlying `MappedPages` memory region.

* This is now possible by creating a `BorrowedMappedPages` based on any owned (non-lifetime) type that implements `Borrow<MappedPages>`, such as `Arc<MappedPages>`, which you can then clone and repeatedly pass to `BorrowedMappedPages::from()`.

* You can also obtain a reference to the inner `Borrow<MappedPages>` object via the `inner_ref()` method.