### PR TITLE
Implement `time::ClockSource` for TSC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "stack",
  "task",
  "task_fs",
+ "time",
  "tlb_shootdown",
  "tsc",
  "window_manager",
@@ -1792,7 +1793,7 @@ dependencies = [
  "root",
  "shapes",
  "text_display",
- "tsc",
+ "time",
  "window",
  "window_manager",
 ]
@@ -4165,6 +4166,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "pit_clock_basic",
+ "time",
 ]
 
 [[package]]

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -34,6 +34,7 @@ first_application = { path = "../first_application" }
 window_manager = { path = "../window_manager" }
 exceptions_full = { path = "../exceptions_full" }
 multiple_heaps = { path = "../multiple_heaps" }
+time = { path = "../time" }
 tsc = { path = "../tsc" }
 acpi = { path = "../acpi" }
 page_attribute_table = { path = "../page_attribute_table" }

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -87,8 +87,11 @@ pub fn init(
     // calculate TSC period and initialize it
     // not strictly necessary, but more accurate if we do it early on before interrupts, multicore, and multitasking
     #[cfg(target_arch = "x86_64")]
-    let _tsc_freq = tsc::get_tsc_frequency()?;
-    // info!("TSC frequency calculated: {}", _tsc_freq);
+    if let Some(period) = tsc::get_tsc_period() {
+        time::register_clock_source::<tsc::Tsc>(period);
+    } else {
+        log::warn!("Couldn't get TSC period");
+    }
 
     // now we initialize early driver stuff, like APIC/ACPI
     // arch-gate: device_manager currently detects PCI & PS2 devices,

--- a/kernel/libterm/Cargo.toml
+++ b/kernel/libterm/Cargo.toml
@@ -48,8 +48,8 @@ path = "../window_manager"
 [dependencies.window]
 path = "../window"
 
-[dependencies.tsc]
-path = "../tsc"
+[dependencies.time]
+path = "../time"
 
 [dependencies.font]
 path = "../font"

--- a/kernel/libterm/src/lib.rs
+++ b/kernel/libterm/src/lib.rs
@@ -19,7 +19,7 @@ extern crate font;
 extern crate framebuffer;
 extern crate framebuffer_drawer;
 extern crate framebuffer_printer;
-extern crate tsc;
+extern crate time;
 extern crate window_manager;
 extern crate window;
 extern crate text_display;
@@ -35,16 +35,16 @@ use displayable::Displayable;
 use event_types::Event;
 use font::{CHARACTER_HEIGHT, CHARACTER_WIDTH};
 use framebuffer::{Framebuffer, Pixel};
-use color::{Color};
+use color::Color;
 use shapes::{Coord, Rectangle};
-use tsc::{tsc_ticks, TscTicks};
 use window::Window;
+use time::Duration;
 
 pub mod cursor;
 
 pub const FONT_FOREGROUND_COLOR: Color = color::LIGHT_GREEN;
 pub const FONT_BACKGROUND_COLOR: Color = color::BLACK;
-const DEFAULT_CURSOR_FREQ: u128 = 400000000;
+const DEFAULT_CURSOR_FREQ: Duration = Duration::from_millis(530);
 
 /// Error type for tracking different scroll errors that a terminal
 /// application could encounter.

--- a/kernel/random/src/lib.rs
+++ b/kernel/random/src/lib.rs
@@ -103,7 +103,7 @@ fn tsc_seed() -> [u8; 32] {
 
     for s in &mut seed {
         // The last byte is the _most_ random.
-        *s = u128::from(tsc::tsc_ticks()).to_be_bytes()[15];
+        *s = tsc::tsc_value().to_be_bytes().into_iter().last().unwrap();
     }
 
     // The TSC isn't a high quality source of randomness.

--- a/kernel/time/src/lib.rs
+++ b/kernel/time/src/lib.rs
@@ -2,10 +2,10 @@
 
 #![no_std]
 
-use core::ops;
-use crossbeam_utils::atomic::AtomicCell;
-
 mod dummy;
+
+use core::{fmt, ops};
+use crossbeam_utils::atomic::AtomicCell;
 
 pub use core::time::Duration;
 
@@ -144,6 +144,12 @@ impl From<u64> for Period {
     /// Creates a new period with the specified femtoseconds.
     fn from(period: u64) -> Self {
         Self(period)
+    }
+}
+
+impl fmt::Display for Period {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} fs", self.0)
     }
 }
 

--- a/kernel/tsc/Cargo.toml
+++ b/kernel/tsc/Cargo.toml
@@ -3,13 +3,10 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "tsc"
 description = "TSC (TimeStamp Counter) support for performance counters on x86. Basically a wrapper around rdtsc."
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 log = "0.4.8"
+pit_clock_basic = { path = "../pit_clock_basic" }
+time = { path = "../time" }
 
-[dependencies.pit_clock_basic]
-path = "../pit_clock_basic"
-
-
-[lib]
-crate-type = ["rlib"]

--- a/kernel/tsc/src/lib.rs
+++ b/kernel/tsc/src/lib.rs
@@ -1,78 +1,38 @@
 #![no_std]
 
-#[macro_use] extern crate log;
-extern crate pit_clock_basic;
+use log::info;
+use time::{Instant, Period};
 
-use core::sync::atomic::{AtomicUsize, Ordering};
+pub struct Tsc;
 
+impl time::ClockSource for Tsc {
+    type ClockType = time::Monotonic;
 
-#[derive(Debug)]
-pub struct TscTicks(u128);
-
-impl TscTicks {
-    /// Converts ticks to nanoseconds. 
-    ///
-    /// Returns `None` if the TSC tick frequency is unavailable 
-    /// or if overflow occured during the conversion.
-    pub fn to_ns(&self) -> Option<u128> {
-        get_tsc_frequency()
-            .ok()
-            .and_then(|freq| self.0.checked_mul(1000000000)
-                .map(|checked_tsc| checked_tsc / freq)
-            )
-    }
-
-    /// Checked subtraction. Computes `self - other`, 
-    /// returning `None` if underflow occurred.
-    pub fn sub(&self, other: &TscTicks) -> Option<TscTicks> {
-        let checked_sub = self.0.checked_sub(other.0);
-        checked_sub.map(TscTicks)
-    }
-    
-    /// Checked addition. Computes `self + other`, 
-    /// returning `None` if overflow occurred.
-    pub fn add(&self, other: &TscTicks) -> Option<TscTicks> {
-        let checked_add = self.0.checked_add(other.0);
-        checked_add.map(TscTicks)
+    fn now() -> Instant {
+        Instant::new(tsc_value())
     }
 }
 
-impl From<TscTicks> for u128 {
-    fn from(ticks: TscTicks) -> Self {
-        ticks.0
-    }
+/// Returns the frequency of the TSC for the system, currently measured using
+/// the PIT clock for calibration.
+pub fn get_tsc_period() -> Option<Period> {
+    const PIT_WAIT_MICROSECONDS: u32 = 10_000;
+    const PIT_WAIT_FEMTOSECONDS: u64 = PIT_WAIT_MICROSECONDS as u64 * 1_000_000_000;
+
+    let start = tsc_value();
+    pit_clock_basic::pit_wait(PIT_WAIT_MICROSECONDS).ok()?;
+    let end = tsc_value();
+
+    let increments = end.checked_sub(start)?;
+    let tsc_period = Period::new(PIT_WAIT_FEMTOSECONDS / increments);
+
+    info!("TSC period calculated by PIT is: {tsc_period}");
+
+    Some(tsc_period)
 }
 
-/// Returns the current number of ticks from the TSC, i.e., `rdtscp`. 
-pub fn tsc_ticks() -> TscTicks {
-    let mut val = 0;
-    // SAFE: just reading TSC value
-    let ticks = unsafe { core::arch::x86_64::__rdtscp(&mut val) as u128 };
-    TscTicks(ticks)
-}
-
-/// Returns the frequency of the TSC for the system, 
-/// currently measured using the PIT clock for calibration.
-pub fn get_tsc_frequency() -> Result<u128, &'static str> {
-    // this is a soft state, so it's not a form of state spill
-    static TSC_FREQUENCY: AtomicUsize = AtomicUsize::new(0);
-
-    let freq = TSC_FREQUENCY.load(Ordering::SeqCst) as u128;
-    
-    if freq != 0 {
-        Ok(freq)
-    }
-    else {
-        // a freq of zero means it hasn't yet been initialized.
-        let start = tsc_ticks();
-        // wait 10000 us (10 ms)
-        pit_clock_basic::pit_wait(10000)?;
-        let end = tsc_ticks(); 
-
-        let diff = end.sub(&start).ok_or("couldn't subtract end-start TSC tick values")?;
-        let tsc_freq = u128::from(diff) * 100; // multiplied by 100 because we measured a 10ms interval
-        info!("TSC frequency calculated by PIT is: {}", tsc_freq);
-        TSC_FREQUENCY.store(tsc_freq as usize, Ordering::Release);
-        Ok(tsc_freq)
-    }
+#[doc(hidden)]
+pub fn tsc_value() -> u64 {
+    let mut _aux = 0;
+    unsafe { core::arch::x86_64::__rdtscp(&mut _aux) }
 }

--- a/kernel/tsc/src/lib.rs
+++ b/kernel/tsc/src/lib.rs
@@ -34,5 +34,8 @@ pub fn get_tsc_period() -> Option<Period> {
 #[doc(hidden)]
 pub fn tsc_value() -> u64 {
     let mut _aux = 0;
+    // SAFETY: Reading the TSC value is a platform-specific intrinsic that has no
+    // side effects or dangerous behavior, and is supported on all modern x86_64
+    // hardware.
     unsafe { core::arch::x86_64::__rdtscp(&mut _aux) }
 }


### PR DESCRIPTION
Also removes `libterm`'s direct dependency on `tsc`.