### PR TITLE
Fix build of `wasmtime-runtime` on macOS hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,9 +426,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cd"


### PR DESCRIPTION
... for real this time.

The key modifications are found in the `build.rs` script in `wasmtime-runtime`:
<https://github.com/theseus-os/wasmtime/commit/2e651271303b812a1d18f2e2e6029ce56749e56c>

Also updated to the latest version of `cc`, which is needed
for our custom invocation of `cc` in that build script.