### PR TITLE
Implement identity mapping convenience function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3806,6 +3806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_identity_mapping"
+version = "0.1.0"
+dependencies = [
+ "app_io",
+ "log",
+ "memory",
+]
+
+[[package]]
 name = "test_ixgbe"
 version = "0.1.0"
 dependencies = [
@@ -4033,6 +4042,7 @@ dependencies = [
  "test_block_io",
  "test_channel",
  "test_filerw",
+ "test_identity_mapping",
  "test_ixgbe",
  "test_libc",
  "test_mlx5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ exclude = [
 	"applications/test_block_io",
 	"applications/test_channel",
 	"applications/test_filerw",
+	"applications/test_identity_mapping",
 	"applications/test_ixgbe",
 	"applications/test_libc",
 	"applications/test_mlx5",

--- a/applications/test_identity_mapping/Cargo.toml
+++ b/applications/test_identity_mapping/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test_identity_mapping"
+version = "0.1.0"
+description = "Tests the `memory::create_identity_mapping()` function"
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+edition = "2021"
+
+[dependencies]
+log = "0.4.8"
+
+[dependencies.memory]
+path = "../../kernel/memory"
+
+[dependencies.app_io]
+path = "../../kernel/app_io"

--- a/applications/test_identity_mapping/src/lib.rs
+++ b/applications/test_identity_mapping/src/lib.rs
@@ -1,0 +1,39 @@
+//! A set of basic tests for [`memory::create_identity_mapping()`].
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{
+    vec::Vec,
+    string::String,
+};
+use app_io::println;
+
+static TEST_SET: [usize; 8] = [1, 2, 4, 8, 25, 48, 256, 1024];
+
+pub fn main(_args: Vec<String>) -> isize {    
+    match rmain() {
+        Ok(_) => 0,
+        Err(e) => {
+            println!("Error: {}", e); 
+            -1
+        }
+    }
+}
+
+fn rmain() -> Result<(), &'static str> {
+    let flags = memory::PteFlags::new().valid(true);
+    for num_pages in TEST_SET.into_iter() {
+        println!("Attempting to create identity mapping of {num_pages} pages...");
+        match memory::create_identity_mapping(num_pages, flags) {
+            Ok(mp) => {
+                assert_eq!(mp.size_in_pages(), num_pages);
+                println!("    Success: {mp:?}");
+            }
+            Err(e) => println!("    !! FAILURE: {e:?}"),
+        }
+    }
+    
+    Ok(())
+}

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -163,8 +163,8 @@ pub fn create_mapping<F: Into<PteFlagsArch>>(
 
 /// Creates an identity mapping at a random available virtual and physical address.
 ///
-/// The returned `MappedPages` is guaranteed to have the same virtual and physical addresses
-/// 
+/// The returned `MappedPages` is guaranteed to have virtual pages mapped to physical frames
+/// with the same virtual addresses as physical addresses.
 pub fn create_identity_mapping<F: Into<PteFlagsArch>>(
     num_pages: usize,
     flags: F,
@@ -216,6 +216,7 @@ pub fn create_identity_mapping<F: Into<PteFlagsArch>>(
 
     match (allocated_pages, allocated_frames) {
         (Some(ap), Ok(Some(af))) => {
+            assert!(ap.start_address().value() == af.start_address().value()); // sanity check
             kernel_mmi_ref.lock().page_table.map_allocated_pages_to(ap, af, flags)
         }
         _ => Err("Couldn't allocate frames or pages for an identity mapping"),

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -181,15 +181,15 @@ pub fn create_identity_mapping<F: Into<PteFlagsArch>>(
     // with allocating the range of frames that matches those pages.
     let allocated_frames = frame_allocator::inspect_then_allocate_free_frames(&mut |frames| {
         if frames.size_in_frames() < num_pages {
-            log::trace!("Skipping too small {:?}", frames);
+            // log::trace!("[{num_pages} pages] Skipping too small {:?}", frames);
             return FramesIteratorRequest::Next;
         }
         let Some(start_vaddr) = VirtualAddress::new(frames.start_address().value()) else {
-            log::trace!("Skipping {:?} with invalid starting vaddr", frames);
+            // log::trace!("[{num_pages} pages] Skipping {:?} with invalid starting vaddr", frames);
             return FramesIteratorRequest::Next;
         };
         let Some(end_vaddr) = VirtualAddress::new(frames.end().start_address().value()) else {
-            log::trace!("Skipping {:?} with invalid ending vaddr", frames);
+            // log::trace!("[{num_pages} pages] Skipping {:?} with invalid ending vaddr", frames);
             return FramesIteratorRequest::Next;
         };
         let ap_result = allocate_pages_in_range(
@@ -209,7 +209,7 @@ pub fn create_identity_mapping<F: Into<PteFlagsArch>>(
                 num_frames: num_pages,
             }
         } else {
-            log::trace!("Skipping {:?}, identity pages couldn't be allocated", frames);
+            // log::trace!("[{num_pages} pages] Skipping {:?}, identity pages couldn't be allocated", frames);
             FramesIteratorRequest::Next
         }
     });

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -57,7 +57,7 @@ use log::debug;
 use spin::Once;
 use sync_irq::IrqSafeMutex;
 use alloc::{sync::Arc, vec::Vec};
-use frame_allocator::{PhysicalMemoryRegion, MemoryRegionType};
+use frame_allocator::{PhysicalMemoryRegion, MemoryRegionType, FramesIteratorRequest};
 use no_drop::NoDrop;
 pub use kernel_config::memory::PAGE_SIZE;
 
@@ -158,6 +158,68 @@ pub fn create_mapping<F: Into<PteFlagsArch>>(
     let kernel_mmi_ref = get_kernel_mmi_ref().ok_or("create_contiguous_mapping(): KERNEL_MMI was not yet initialized!")?;
     let allocated_pages = allocate_pages_by_bytes(size_in_bytes).ok_or("memory::create_mapping(): couldn't allocate pages!")?;
     kernel_mmi_ref.lock().page_table.map_allocated_pages(allocated_pages, flags)
+}
+
+
+/// Creates an identity mapping at a random available virtual and physical address.
+///
+/// The returned `MappedPages` is guaranteed to have the same virtual and physical addresses
+/// 
+pub fn create_identity_mapping<F: Into<PteFlagsArch>>(
+    num_pages: usize,
+    flags: F,
+) -> Result<MappedPages, &'static str> {
+    let kernel_mmi_ref = get_kernel_mmi_ref()
+        .ok_or("create_identity_mapping(): KERNEL_MMI was not yet initialized!")?;
+
+    let mut allocated_pages = None;
+    // We first iterate over all free general-purpose frames,
+    // as there are far fewer available frames than available pages.
+    // Once we find a suitable free chunk of frames,
+    // we then attempt to allocate the corresponding identity pages,
+    // and if that succeeds, we allow the frame allocator to proceed
+    // with allocating the range of frames that matches those pages.
+    let allocated_frames = frame_allocator::inspect_then_allocate_free_frames(&mut |frames| {
+        if frames.size_in_frames() < num_pages {
+            log::trace!("Skipping too small {:?}", frames);
+            return FramesIteratorRequest::Next;
+        }
+        let Some(start_vaddr) = VirtualAddress::new(frames.start_address().value()) else {
+            log::trace!("Skipping {:?} with invalid starting vaddr", frames);
+            return FramesIteratorRequest::Next;
+        };
+        let Some(end_vaddr) = VirtualAddress::new(frames.end().start_address().value()) else {
+            log::trace!("Skipping {:?} with invalid ending vaddr", frames);
+            return FramesIteratorRequest::Next;
+        };
+        let ap_result = allocate_pages_in_range(
+            num_pages,
+            &PageRange::new(
+                Page::containing_address(start_vaddr),
+                Page::containing_address(end_vaddr),
+            )
+        );
+        if let Ok(ap) = ap_result {
+            let start_addr = PhysicalAddress::new_canonical(ap.start_address().value());
+            allocated_pages = Some(ap);
+            // Tell the `inspect_then_allocate_free_frames` function that we want to proceed
+            // with allocating the identity frames corresponding to the pages allocated above.
+            FramesIteratorRequest::AllocateAt {
+                requested_frame: Frame::containing_address(start_addr),
+                num_frames: num_pages,
+            }
+        } else {
+            log::trace!("Skipping {:?}, identity pages couldn't be allocated", frames);
+            FramesIteratorRequest::Next
+        }
+    });
+
+    match (allocated_pages, allocated_frames) {
+        (Some(ap), Ok(Some(af))) => {
+            kernel_mmi_ref.lock().page_table.map_allocated_pages_to(ap, af, flags)
+        }
+        _ => Err("Couldn't allocate frames or pages for an identity mapping"),
+    }
 }
 
 

--- a/theseus_features/Cargo.toml
+++ b/theseus_features/Cargo.toml
@@ -52,6 +52,7 @@ test_backtrace = { path = "../applications/test_backtrace", optional = true }
 test_block_io = { path = "../applications/test_block_io", optional = true }
 test_channel = { path = "../applications/test_channel", optional = true }
 test_filerw = { path = "../applications/test_filerw", optional = true }
+test_identity_mapping = { path = "../applications/test_identity_mapping", optional = true }
 test_ixgbe = { path = "../applications/test_ixgbe", optional = true }
 test_libc = { path = "../applications/test_libc", optional = true }
 test_mlx5 = { path = "../applications/test_mlx5", optional = true }
@@ -150,6 +151,7 @@ theseus_tests = [
     "test_block_io",
     "test_channel",
     "test_filerw",
+    "test_identity_mapping",
     "test_ixgbe",
     "test_libc",
     "test_mlx5",


### PR DESCRIPTION
The new `create_identity_mapping()` function chooses random virtual and physical addresses (that are obviously the same) and maps the allocated virtual pages to the corresponding allocated physical frames.

The procedure is as follows:
> We first iterate over all free general-purpose frames,
> as there are far fewer available frames than available pages.
> Once we find a suitable free chunk of frames,
> we then attempt to allocate the corresponding identity pages,
> and if that succeeds, we allow the frame allocator to proceed
> with allocating the range of frames that matches those pages.

This is needed for proper/easier multicore CPU bringup on arrch64. 