### PR TITLE
Update the GIC driver and interrupt controller for owned + per-CPU memory mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,6 +1581,7 @@ dependencies = [
  "ioapic",
  "log",
  "memory",
+ "spin 0.9.4",
  "sync_irq",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ dependencies = [
  "cpu",
  "log",
  "memory",
- "static_assertions",
+ "volatile 0.2.7",
  "zerocopy",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "cpu",
  "log",
  "memory",
+ "spin 0.9.4",
  "volatile 0.2.7",
  "zerocopy",
 ]

--- a/kernel/arm_boards/src/lib.rs
+++ b/kernel/arm_boards/src/lib.rs
@@ -20,6 +20,8 @@ pub struct GicV3InterruptControllerConfig {
 }
 
 #[derive(Debug, Copy, Clone)]
+/// This excludes GICv2 because there's no way to send IPIs
+/// with GICv2 via the current driver API.
 pub enum InterruptControllerConfig {
     GicV3(GicV3InterruptControllerConfig),
 }

--- a/kernel/gic/Cargo.toml
+++ b/kernel/gic/Cargo.toml
@@ -8,6 +8,7 @@ name = "gic"
 [dependencies]
 zerocopy = "0.5.0"
 volatile = "0.2.7"
+spin = "0.9.4"
 log = "0.4.8"
 
 memory = { path = "../memory" }

--- a/kernel/gic/Cargo.toml
+++ b/kernel/gic/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 name = "gic"
 
 [dependencies]
-static_assertions = "1.1.0"
 zerocopy = "0.5.0"
+volatile = "0.2.7"
 log = "0.4.8"
 
 memory = { path = "../memory" }

--- a/kernel/gic/src/gic/cpu_interface_gicv2.rs
+++ b/kernel/gic/src/gic/cpu_interface_gicv2.rs
@@ -12,14 +12,13 @@ use super::InterruptNumber;
 use volatile::{Volatile, ReadOnly, WriteOnly};
 use zerocopy::FromBytes;
 
-/// Registers of a CPU interface of the GIC, pertaining
-/// to a specific CPU in the system.
+/// The GICv2 MMIO registers for interfacing with a specific CPU.
 ///
-/// Methods refer to that specific CPU by "current CPU".
+/// Methods herein apply to the "current" CPU only, i.e., the CPU
+/// on which the code that accesses these registers is currently running.
 ///
-/// Caution: Even though the physical address for this
-/// structure is the same for each CPU, the actual backing
-/// memory is per-CPU (different for each CPU).
+/// Note: the physical address for this structure is the same for all CPUs,
+/// but the actual backing memory refers to physically separate registers.
 #[derive(FromBytes)]
 #[repr(C)]
 pub struct CpuRegsP1 {            // base offset

--- a/kernel/gic/src/gic/cpu_interface_gicv2.rs
+++ b/kernel/gic/src/gic/cpu_interface_gicv2.rs
@@ -16,6 +16,10 @@ use zerocopy::FromBytes;
 /// to a specific CPU in the system.
 ///
 /// Methods refer to that specific CPU by "current CPU".
+///
+/// Caution: Even though the physical address for this
+/// structure is the same for each CPU, the actual backing
+/// memory is per-CPU (different for each CPU).
 #[derive(FromBytes)]
 #[repr(C)]
 pub struct CpuRegsP1 {            // base offset

--- a/kernel/gic/src/gic/cpu_interface_gicv2.rs
+++ b/kernel/gic/src/gic/cpu_interface_gicv2.rs
@@ -29,45 +29,47 @@ pub struct CpuRegsP1 {            // base offset
 // enable group 1
 const CTLR_ENGRP1: u32 = 0b10;
 
-/// Enables routing of group 1 interrupts for the current CPU
-pub fn init(registers: &mut CpuRegsP1) {
-    let mut reg = registers.ctlr.read();
-    reg |= CTLR_ENGRP1;
-    registers.ctlr.write(reg);
-}
+impl CpuRegsP1 {
+    /// Enables routing of group 1 interrupts for the current CPU
+    pub fn init(&mut self) {
+        let mut reg = self.ctlr.read();
+        reg |= CTLR_ENGRP1;
+        self.ctlr.write(reg);
+    }
 
-/// Interrupts have a priority; if their priority
-/// is lower or equal to this one, they're queued
-/// until this CPU or another one is ready to handle
-/// them
-pub fn get_minimum_priority(registers: &CpuRegsP1) -> Priority {
-    u8::MAX - (registers.prio_mask.read() as u8)
-}
+    /// Interrupts have a priority; if their priority
+    /// is lower or equal to this one, they're queued
+    /// until this CPU or another one is ready to handle
+    /// them
+    pub fn get_minimum_priority(&self) -> Priority {
+        u8::MAX - (self.prio_mask.read() as u8)
+    }
 
-/// Interrupts have a priority; if their priority
-/// is lower or equal to this one, they're queued
-/// until this CPU or another one is ready to handle
-/// them
-pub fn set_minimum_priority(registers: &mut CpuRegsP1, priority: Priority) {
-    registers.prio_mask.write((u8::MAX - priority) as u32);
-}
+    /// Interrupts have a priority; if their priority
+    /// is lower or equal to this one, they're queued
+    /// until this CPU or another one is ready to handle
+    /// them
+    pub fn set_minimum_priority(&mut self, priority: Priority) {
+        self.prio_mask.write((u8::MAX - priority) as u32);
+    }
 
-/// Signals to the controller that the currently processed interrupt has
-/// been fully handled, by zeroing the current priority level of this CPU.
-/// This implies that the CPU is ready to process interrupts again.
-pub fn end_of_interrupt(registers: &mut CpuRegsP1, int: InterruptNumber) {
-    registers.eoi.write(int);
-}
+    /// Signals to the controller that the currently processed interrupt has
+    /// been fully handled, by zeroing the current priority level of this CPU.
+    /// This implies that the CPU is ready to process interrupts again.
+    pub fn end_of_interrupt(&mut self, int: InterruptNumber) {
+        self.eoi.write(int);
+    }
 
-/// Acknowledge the currently serviced interrupt
-/// and fetches its number; this tells the GIC that
-/// the requested interrupt is being handled by
-/// this CPU.
-pub fn acknowledge_interrupt(registers: &mut CpuRegsP1) -> (InterruptNumber, Priority) {
-    // Reading the interrupt number has the side effect
-    // of acknowledging the interrupt.
-    let int_num = registers.acknowledge.read() as InterruptNumber;
-    let priority = registers.running_prio.read() as u8;
+    /// Acknowledge the currently serviced interrupt
+    /// and fetches its number; this tells the GIC that
+    /// the requested interrupt is being handled by
+    /// this CPU.
+    pub fn acknowledge_interrupt(&mut self) -> (InterruptNumber, Priority) {
+        // Reading the interrupt number has the side effect
+        // of acknowledging the interrupt.
+        let int_num = self.acknowledge.read() as InterruptNumber;
+        let priority = self.running_prio.read() as u8;
 
-    (int_num, priority)
+        (int_num, priority)
+    }
 }

--- a/kernel/gic/src/gic/dist_interface.rs
+++ b/kernel/gic/src/gic/dist_interface.rs
@@ -26,32 +26,51 @@ use volatile::{Volatile, ReadOnly};
 use zerocopy::FromBytes;
 use cpu::MpidrValue;
 
+/// First page of distributor registers
 #[derive(FromBytes)]
 #[repr(C)]
 pub struct DistRegsP1 {                   // base offset
+    /// Distributor Control Register
     ctlr:          Volatile<u32>,         // 0x000
+
+    /// Interrupt Controller Type Register
     typer:         ReadOnly<u32>,         // 0x004
+
+    /// Distributor Implementer Identification Register
     ident:         ReadOnly<u32>,         // 0x008
+
     _unused0:     [u8;            0x074],
 
+    /// Interrupt Group Registers
     group:        [Volatile<u32>; 0x020], // 0x080
+
+    /// Interrupt Set-Enable Registers
     set_enable:   [Volatile<u32>; 0x020], // 0x100
+
+    /// Interrupt Clear-Enable Registers
     clear_enable: [Volatile<u32>; 0x020], // 0x180
 
     _unused1:     [u8;            0x200],
 
+    /// Interrupt Priority Registers
     priority:     [Volatile<u32>; 0x100], // 0x400
+
+    /// Interrupt Processor Targets Registers
     target:       [Volatile<u32>; 0x100], // 0x800
 
     _unused2:     [u8;            0x300],
 
+    /// Software Generated Interrupt Register
     sgir:          Volatile<u32>,         // 0xf00
 }
 
+/// Sixth page of distributor registers
 #[derive(FromBytes)]
 #[repr(C)]
 pub struct DistRegsP6 {     // base offset
     _unused: [u8; 0x100],
+
+    /// Interrupt Routing Registers
     route:   Volatile<u64>, // 0x100
 }
 

--- a/kernel/gic/src/gic/dist_interface.rs
+++ b/kernel/gic/src/gic/dist_interface.rs
@@ -150,8 +150,8 @@ pub struct Implementer {
 impl super::ArmGicDistributor {
     pub(crate) fn distributor(&self) -> &GicRegisters {
         match self {
-            Self::V2 { registers } => &registers,
-            Self::V3 { v2_regs, .. } => &v2_regs,
+            Self::V2 { registers } => registers,
+            Self::V3 { v2_regs, .. } => v2_regs,
         }
     }
 

--- a/kernel/gic/src/gic/mod.rs
+++ b/kernel/gic/src/gic/mod.rs
@@ -436,7 +436,7 @@ impl ArmGicCpuComponents {
     /// Panics if `int` is greater than or equal to 32, which is beyond the range
     /// of local interrupt numbers.
     pub fn set_interrupt_state(&mut self, int: InterruptNumber, enabled: Enabled) {
-        assert!(int < 32, "get_interrupt_state: `int` doesn't lie in the SGI/PPI (local interrupt) range");
+        assert!(int < 32, "set_interrupt_state: `int` doesn't lie in the SGI/PPI (local interrupt) range");
 
         if let Self::V3 { redist_regs } = self {
             redist_regs.redist_sgippi.enable_sgippi(int, enabled);
@@ -451,7 +451,7 @@ impl ArmGicCpuComponents {
     /// Panics if `int` is greater than or equal to 32, which is beyond the range
     /// of local interrupt numbers.
     pub fn get_interrupt_priority(&self, int: InterruptNumber) -> Priority {
-        assert!(int < 32, "get_interrupt_state: `int` doesn't lie in the SGI/PPI (local interrupt) range");
+        assert!(int < 32, "get_interrupt_priority: `int` doesn't lie in the SGI/PPI (local interrupt) range");
 
         if let Self::V3 { redist_regs } = self {
             redist_regs.redist_sgippi.get_sgippi_priority(int)
@@ -469,7 +469,7 @@ impl ArmGicCpuComponents {
     /// Panics if `int` is greater than or equal to 32, which is beyond the range
     /// of local interrupt numbers.
     pub fn set_interrupt_priority(&mut self, int: InterruptNumber, enabled: Priority) {
-        assert!(int < 32, "get_interrupt_state: `int` doesn't lie in the SGI/PPI (local interrupt) range");
+        assert!(int < 32, "set_interrupt_priority: `int` doesn't lie in the SGI/PPI (local interrupt) range");
 
         if let Self::V3 { redist_regs } = self {
             redist_regs.redist_sgippi.set_sgippi_priority(int, enabled);

--- a/kernel/gic/src/gic/mod.rs
+++ b/kernel/gic/src/gic/mod.rs
@@ -467,7 +467,7 @@ impl ArmGicCpuComponents {
     /// them
     pub fn get_minimum_priority(&self) -> Priority {
         match self {
-            Self::V2 { registers, .. } => cpu_interface_gicv2::get_minimum_priority(&registers),
+            Self::V2 { registers, .. } => cpu_interface_gicv2::get_minimum_priority(registers),
             Self::V3 { .. } => cpu_interface_gicv3::get_minimum_priority(),
         }
     }

--- a/kernel/gic/src/gic/mod.rs
+++ b/kernel/gic/src/gic/mod.rs
@@ -130,7 +130,6 @@ const U32BITS: usize = u32::BITS as usize;
 // items in a single u32.
 //
 // - `int` is the index
-// - `offset` tells the beginning of the array
 // - `INTS_PER_U32` = how many array slots per u32 in this array
 fn read_array_volatile<const INTS_PER_U32: usize>(slice: &[Volatile<u32>], int: InterruptNumber) -> u32 {
     let int = int as usize;
@@ -153,7 +152,6 @@ fn read_array_volatile<const INTS_PER_U32: usize>(slice: &[Volatile<u32>], int: 
 // items in a single u32.
 //
 // - `int` is the index
-// - `offset` tells the beginning of the array
 // - `INTS_PER_U32` = how many array slots per u32 in this array
 // - `value` is the value to write
 fn write_array_volatile<const INTS_PER_U32: usize>(slice: &mut [Volatile<u32>], int: InterruptNumber, value: u32) {
@@ -173,7 +171,6 @@ fn write_array_volatile<const INTS_PER_U32: usize>(slice: &mut [Volatile<u32>], 
 
 const REDIST_SGIPPI_OFFSET: usize = 0x10000;
 const DIST_P6_OFFSET: usize = 0x6000;
-
 
 pub struct ArmGicV3RedistPages {
     pub redistributor: BorrowedMappedPages<RedistRegsP1, Mutable>,

--- a/kernel/gic/src/gic/mod.rs
+++ b/kernel/gic/src/gic/mod.rs
@@ -3,8 +3,8 @@ use core::convert::AsMut;
 use cpu::{CpuId, MpidrValue};
 use arm_boards::{BOARD_CONFIG, NUM_CPUS};
 use memory::{
-    PageTable, BorrowedMappedPages, Mutable, PhysicalAddress,
-    allocate_pages, allocate_frames_at, MMIO_FLAGS,
+    BorrowedMappedPages, Mutable, PhysicalAddress,
+    MMIO_FLAGS, map_frame_range, PAGE_SIZE,
 };
 
 use static_assertions::const_assert_eq;
@@ -211,46 +211,13 @@ impl GicRegisters {
 
 const_assert_eq!(core::mem::size_of::<GicRegisters>(), 0x1000);
 
-/// Returns the index to the redistributor base address for this CPU
-/// in the array of register base addresses.
-///
-/// This is defined in `arm_boards::INTERRUPT_CONTROLLER_CONFIG`.
-fn get_current_cpu_redist_index() -> usize {
-    let cpu_id = cpu::current_cpu();
-    BOARD_CONFIG.cpu_ids.iter()
-          .position(|mpidr| CpuId::from(*mpidr) == cpu_id)
-          .expect("BUG: get_current_cpu_redist_index: unexpected CpuId for current CPU")
-}
-
 const REDIST_SGIPPI_OFFSET: usize = 0x10000;
 const DIST_P6_OFFSET: usize = 0x6000;
 
-pub struct ArmGicV2 {
-    pub distributor: BorrowedMappedPages<GicRegisters, Mutable>,
-    pub processor: BorrowedMappedPages<GicRegisters, Mutable>,
-}
 
 pub struct ArmGicV3RedistPages {
     pub redistributor: BorrowedMappedPages<GicRegisters, Mutable>,
     pub redist_sgippi: BorrowedMappedPages<GicRegisters, Mutable>,
-}
-
-pub struct ArmGicV3 {
-    pub affinity_routing: Enabled,
-    pub distributor: BorrowedMappedPages<GicRegisters, Mutable>,
-    pub dist_extended: BorrowedMappedPages<GicRegisters, Mutable>,
-    pub redistributors: [ArmGicV3RedistPages; NUM_CPUS],
-}
-
-/// Arm Generic Interrupt Controller
-///
-/// The GIC is an extension to ARMv8 which
-/// allows routing and filtering interrupts
-/// in a single or multi-core system.
-#[allow(clippy::large_enum_variant)]
-pub enum ArmGic {
-    V2(ArmGicV2),
-    V3(ArmGicV3),
 }
 
 pub enum Version {
@@ -264,81 +231,142 @@ pub enum Version {
     }
 }
 
-impl ArmGic {
-    pub fn init(page_table: &mut PageTable, version: Version) -> Result<Self, &'static str> {
-        let mut map_dist = |gicd_base| -> Result<BorrowedMappedPages<GicRegisters, Mutable>, &'static str>  {
-            let pages = allocate_pages(1).ok_or("couldn't allocate pages for the distributor interface")?;
-            let frames = allocate_frames_at(gicd_base, 1)?;
-            let mapped = page_table.map_allocated_pages_to(pages, frames, MMIO_FLAGS)?;
-            mapped.into_borrowed_mut(0).map_err(|(_, e)| e)
-        };
+pub enum ArmGicDistributor {
+    V2 {
+        registers: BorrowedMappedPages<GicRegisters, Mutable>,
+    },
+    V3 {
+        affinity_routing: Enabled,
+        v2_regs: BorrowedMappedPages<GicRegisters, Mutable>,
+        v3_regs: BorrowedMappedPages<GicRegisters, Mutable>,
+    },
+}
+
+impl ArmGicDistributor {
+    pub fn init(version: &Version) -> Result<Self, &'static str> {
+        match version {
+            Version::InitV2 { dist, .. } => {
+                let mapped = map_frame_range(*dist, PAGE_SIZE, MMIO_FLAGS)?;
+                let mut registers = mapped
+                    .into_borrowed_mut::<GicRegisters>(0)
+                    .map_err(|(_, e)| e)?;
+
+                dist_interface::init(registers.as_mut());
+
+                Ok(Self::V2 {
+                    registers,
+                })
+            },
+            Version::InitV3 { dist, .. } => {
+                let mapped = map_frame_range(*dist, PAGE_SIZE, MMIO_FLAGS)?;
+                let mut v2_regs = mapped
+                    .into_borrowed_mut::<GicRegisters>(0)
+                    .map_err(|(_, e)| e)?;
+
+                let v3_regs: BorrowedMappedPages<GicRegisters, Mutable> = {
+                    let paddr = *dist + DIST_P6_OFFSET;
+                    let mapped = map_frame_range(paddr, PAGE_SIZE, MMIO_FLAGS)?;
+                    mapped.into_borrowed_mut(0).map_err(|(_, e)| e)?
+                };
+
+                let affinity_routing = dist_interface::init(v2_regs.as_mut());
+
+                Ok(Self::V3 {
+                    affinity_routing,
+                    v2_regs,
+                    v3_regs,
+                })
+            },
+        }
+    }
+
+    /// Will that interrupt be forwarded by the distributor?
+    pub fn get_spi_state(&self, int: InterruptNumber) -> Enabled {
+        assert!(int >= 32);
+        dist_interface::is_spi_enabled(self.distributor(), int)
+    }
+
+    /// Enables or disables the forwarding of
+    /// a particular interrupt in the distributor
+    pub fn set_spi_state(&mut self, int: InterruptNumber, enabled: Enabled) {
+        assert!(int >= 32);
+        dist_interface::enable_spi(self.distributor_mut(), int, enabled)
+    }
+
+    /// Returns the priority of an interrupt
+    pub fn get_spi_priority(&self, int: InterruptNumber) -> Priority {
+        assert!(int >= 32);
+        dist_interface::get_spi_priority(self.distributor(), int)
+    }
+
+    /// Sets the priority of an interrupt (0-255)
+    pub fn set_spi_priority(&mut self, int: InterruptNumber, enabled: Priority) {
+        assert!(int >= 32);
+        dist_interface::set_spi_priority(self.distributor_mut(), int, enabled)
+    }
+}
+
+pub enum ArmGicCpuComponents {
+    V2 {
+        registers: BorrowedMappedPages<GicRegisters, Mutable>,
+        cpu_index: u16,
+    },
+    V3 {
+        redist_regs: ArmGicV3RedistPages,
+    },
+}
+
+impl ArmGicCpuComponents {
+    pub fn init(cpu_id: CpuId, version: &Version) -> Result<Self, &'static str> {
+        let cpu_index = BOARD_CONFIG.cpu_ids.iter()
+            .position(|mpidr| CpuId::from(*mpidr) == cpu_id)
+            .expect("BUG: invalid CpuId in ArmGicCpuComponents::init");
 
         match version {
-            Version::InitV2 { dist, cpu } => {
-                let mut distributor = map_dist(dist)?;
-
-                let mut processor: BorrowedMappedPages<GicRegisters, Mutable> = {
-                    let pages = allocate_pages(1).ok_or("couldn't allocate pages for the CPU interface")?;
-                    let frames = allocate_frames_at(cpu, 1)?;
-                    let mapped = page_table.map_allocated_pages_to(pages, frames, MMIO_FLAGS)?;
+            Version::InitV2 { cpu, .. } => {
+                let mut registers: BorrowedMappedPages<GicRegisters, Mutable> = {
+                    let mapped = map_frame_range(*cpu, PAGE_SIZE, MMIO_FLAGS)?;
                     mapped.into_borrowed_mut(0).map_err(|(_, e)| e)?
                 };
 
-                cpu_interface_gicv2::init(processor.as_mut());
-                dist_interface::init(distributor.as_mut());
+                cpu_interface_gicv2::init(registers.as_mut());
 
-                Ok(Self::V2(ArmGicV2 { distributor, processor }))
+                Ok(Self::V2 {
+                    registers,
+                    cpu_index: cpu_index as u16,
+                })
             },
-            Version::InitV3 { dist, redist } => {
-                let mut distributor = map_dist(dist)?;
+            Version::InitV3 { redist, .. } => {
+                let phys_addr = redist[cpu_index];
 
-                let dist_extended: BorrowedMappedPages<GicRegisters, Mutable> = {
-                    let pages = allocate_pages(1).ok_or("couldn't allocate pages for the extended distributor interface")?;
-                    let frames = allocate_frames_at(dist + DIST_P6_OFFSET, 1)?;
-                    let mapped = page_table.map_allocated_pages_to(pages, frames, MMIO_FLAGS)?;
+                let mut redistributor: BorrowedMappedPages<GicRegisters, Mutable> = {
+                    let mapped = map_frame_range(phys_addr, PAGE_SIZE, MMIO_FLAGS)?;
                     mapped.into_borrowed_mut(0).map_err(|(_, e)| e)?
                 };
 
-                let redistributors: [ArmGicV3RedistPages; NUM_CPUS] = core::array::try_from_fn(|i| {
-                    let phys_addr = redist[i];
+                let redist_sgippi = {
+                    let rso_paddr = phys_addr + REDIST_SGIPPI_OFFSET;
+                    let mapped = map_frame_range(rso_paddr, PAGE_SIZE, MMIO_FLAGS)?;
+                    mapped.into_borrowed_mut(0).map_err(|(_, e)| e)?
+                };
 
-                    let mut redistributor: BorrowedMappedPages<GicRegisters, Mutable> = {
-                        let pages = allocate_pages(1).ok_or("couldn't allocate pages for the redistributor interface")?;
-                        let frames = allocate_frames_at(phys_addr, 1)?;
-                        let mapped = page_table.map_allocated_pages_to(pages, frames, MMIO_FLAGS)?;
-                        mapped.into_borrowed_mut(0).map_err(|(_, e)| e)?
-                    };
+                redist_interface::init(redistributor.as_mut())?;
+                cpu_interface_gicv3::init();
 
-                    redist_interface::init(redistributor.as_mut())?;
-
-                    let redist_sgippi = {
-                        let pages = allocate_pages(1).ok_or("couldn't allocate pages for the extended redistributor interface")?;
-                        let frames = allocate_frames_at(phys_addr + REDIST_SGIPPI_OFFSET, 1)?;
-                        let mapped = page_table.map_allocated_pages_to(pages, frames, MMIO_FLAGS)?;
-                        mapped.into_borrowed_mut(0).map_err(|(_, e)| e)?
-                    };
-
-                    Ok::<ArmGicV3RedistPages, &'static str>(ArmGicV3RedistPages {
+                Ok(Self::V3 {
+                    redist_regs: ArmGicV3RedistPages {
                         redistributor,
                         redist_sgippi,
-                    })
-                })?;
-
-                // this cannot fail as we pushed exactly `arm_boards::CPUS` items
-                // let redistributors = redistributors.into_inner().unwrap();
-
-                cpu_interface_gicv3::init();
-                let affinity_routing = dist_interface::init(distributor.as_mut());
-
-                Ok(Self::V3(ArmGicV3 { distributor, dist_extended, redistributors, affinity_routing }))
+                    },
+                })
             },
         }
     }
 
     pub fn init_secondary_cpu_interface(&mut self) {
         match self {
-            Self::V2(v2) => cpu_interface_gicv2::init(v2.processor.as_mut()),
-            Self::V3( _) => cpu_interface_gicv3::init(),
+            Self::V2 { registers, .. } => cpu_interface_gicv2::init(registers.as_mut()),
+            Self::V3 { .. } => cpu_interface_gicv3::init(),
         }
     }
 
@@ -349,9 +377,16 @@ impl ArmGic {
     pub fn send_ipi(&mut self, int_num: InterruptNumber, target: IpiTargetCpu) {
         assert!(int_num < 16, "IPIs must have a number below 16 on ARMv8");
 
-        match self {
-            Self::V2(v2) => dist_interface::send_ipi_gicv2(&mut v2.distributor, int_num, target),
-            Self::V3( _) => cpu_interface_gicv3::send_ipi(int_num, target),
+        if let Self::V3 { .. } = self {
+            cpu_interface_gicv3::send_ipi(int_num, target)
+        } else {
+            // we don't have access to the distributor... code would be:
+            // dist_interface::send_ipi_gicv2(&mut dist_regs, int_num, target)
+            // workaround: caller could check is this must be done in the dist
+            // and then get the SystemInterruptController and call a dedicated
+            // method on it, like `sys_ctlr.send_ipi_gicv2()`
+
+            panic!("GICv2 doesn't support sending IPIs (need distributor)");
         }
     }
 
@@ -359,62 +394,71 @@ impl ArmGic {
     /// and fetches its number
     pub fn acknowledge_interrupt(&mut self) -> (InterruptNumber, Priority) {
         match self {
-            Self::V2(v2) => cpu_interface_gicv2::acknowledge_interrupt(&mut v2.processor),
-            Self::V3( _) => cpu_interface_gicv3::acknowledge_interrupt(),
+            Self::V2 { registers, .. } => cpu_interface_gicv2::acknowledge_interrupt(registers),
+            Self::V3 { .. } => cpu_interface_gicv3::acknowledge_interrupt(),
         }
     }
 
     /// Performs priority drop for the specified interrupt
     pub fn end_of_interrupt(&mut self, int: InterruptNumber) {
         match self {
-            Self::V2(v2) => cpu_interface_gicv2::end_of_interrupt(&mut v2.processor, int),
-            Self::V3( _) => cpu_interface_gicv3::end_of_interrupt(int),
+            Self::V2 { registers, .. } => cpu_interface_gicv2::end_of_interrupt(registers, int),
+            Self::V3 { .. } => cpu_interface_gicv3::end_of_interrupt(int),
         }
     }
 
-    /// Will that interrupt be forwarded by the distributor?
+    /// Will that interrupt be received by this CPU?
     pub fn get_interrupt_state(&self, int: InterruptNumber) -> Enabled {
-        match (int, self) {
-            (0..=31, Self::V3(v3)) => {
-                let i = get_current_cpu_redist_index();
-                redist_interface::is_sgippi_enabled(&v3.redistributors[i].redist_sgippi, int)
-            },
-            (_, this) => dist_interface::is_spi_enabled(this.distributor(), int),
+        assert!(int < 32);
+
+        if let Self::V3 { redist_regs } = self {
+            redist_interface::is_sgippi_enabled(&redist_regs.redist_sgippi, int)
+        } else {
+            // there is no redistributor and we don't have access to the distributor
+            log::error!("GICv2 doesn't support enabling/disabling local interrupt");
+
+            // should we panic?
+            true
         }
     }
 
-    /// Enables or disables the forwarding of
-    /// a particular interrupt in the distributor
+    /// Enables or disables the receiving of a local interrupt in the distributor
     pub fn set_interrupt_state(&mut self, int: InterruptNumber, enabled: Enabled) {
-        match (int, self) {
-            (0..=31, Self::V3(v3)) => {
-                let i = get_current_cpu_redist_index();
-                redist_interface::enable_sgippi(&mut v3.redistributors[i].redist_sgippi, int, enabled);
-            },
-            (_, this) => dist_interface::enable_spi(this.distributor_mut(), int, enabled),
-        };
-    }
+        assert!(int < 32);
 
-    /// Returns the priority of an interrupt
-    pub fn get_interrupt_priority(&self, int: InterruptNumber) -> Priority {
-        match (int, self) {
-            (0..=31, Self::V3(v3)) => {
-                let i = get_current_cpu_redist_index();
-                redist_interface::get_sgippi_priority(&v3.redistributors[i].redist_sgippi, int)
-            },
-            (_, this) => dist_interface::get_spi_priority(this.distributor(), int),
+        if let Self::V3 { redist_regs } = self {
+            redist_interface::enable_sgippi(&mut redist_regs.redist_sgippi, int, enabled);
+        } else {
+            // there is no redistributor and we don't have access to the distributor
+            log::error!("GICv2 doesn't support enabling/disabling local interrupt");
         }
     }
 
-    /// Sets the priority of an interrupt (0-255)
+    /// Returns the priority of a local interrupt
+    pub fn get_interrupt_priority(&self, int: InterruptNumber) -> Priority {
+        assert!(int < 32);
+
+        if let Self::V3 { redist_regs } = self {
+            redist_interface::get_sgippi_priority(&redist_regs.redist_sgippi, int)
+        } else {
+            // there is no redistributor and we don't have access to the distributor
+            log::error!("GICv2 doesn't support setting local interrupt priority");
+
+            // should we panic?
+            128
+        }
+    }
+
+    /// Sets the priority of a local interrupt (prio: 0-255)
     pub fn set_interrupt_priority(&mut self, int: InterruptNumber, enabled: Priority) {
-        match (int, self) {
-            (0..=31, Self::V3(v3)) => {
-                let i = get_current_cpu_redist_index();
-                redist_interface::set_sgippi_priority(&mut v3.redistributors[i].redist_sgippi, int, enabled);
-            },
-            (_, this) => dist_interface::set_spi_priority(this.distributor_mut(), int, enabled),
-        };
+        assert!(int < 32);
+
+        if let Self::V3 { redist_regs } = self {
+            redist_interface::set_sgippi_priority(&mut redist_regs.redist_sgippi, int, enabled);
+        } else {
+            // there is no redistributor and we don't have access to the distributor
+            log::error!("GICv2 doesn't support setting local interrupt priority");
+        }
     }
 
     /// Interrupts have a priority; if their priority
@@ -423,8 +467,8 @@ impl ArmGic {
     /// them
     pub fn get_minimum_priority(&self) -> Priority {
         match self {
-            Self::V2(v2) => cpu_interface_gicv2::get_minimum_priority(&v2.processor),
-            Self::V3( _) => cpu_interface_gicv3::get_minimum_priority(),
+            Self::V2 { registers, .. } => cpu_interface_gicv2::get_minimum_priority(&registers),
+            Self::V3 { .. } => cpu_interface_gicv3::get_minimum_priority(),
         }
     }
 
@@ -434,20 +478,19 @@ impl ArmGic {
     /// them
     pub fn set_minimum_priority(&mut self, priority: Priority) {
         match self {
-            Self::V2(v2) => cpu_interface_gicv2::set_minimum_priority(&mut v2.processor, priority),
-            Self::V3( _) => cpu_interface_gicv3::set_minimum_priority(priority),
+            Self::V2 { registers, .. } => cpu_interface_gicv2::set_minimum_priority(registers, priority),
+            Self::V3 { .. } => cpu_interface_gicv3::set_minimum_priority(priority),
         }
     }
 
     /// Returns the internal ID of the redistributor (GICv3)
     ///
-    /// Note #2: this is only provided for debugging purposes
     /// Note #1: as a compatibility feature, on GICv2, the CPU index is returned.
+    /// Note #2: this is only provided for debugging purposes
     pub fn get_cpu_interface_id(&self) -> u16 {
-        let i = get_current_cpu_redist_index();
         match self {
-            Self::V3(v3) => redist_interface::get_internal_id(&v3.redistributors[i].redistributor),
-            _ => i as _,
+            Self::V3 { redist_regs } => redist_interface::get_internal_id(&redist_regs.redistributor),
+            Self::V2 { cpu_index, .. } => *cpu_index,
         }
     }
 }

--- a/kernel/gic/src/gic/mod.rs
+++ b/kernel/gic/src/gic/mod.rs
@@ -236,27 +236,35 @@ impl ArmGicDistributor {
     }
 
     /// Will that interrupt be forwarded by the distributor?
+    ///
+    /// Panics: will panic if `int` is not in the SPI range (>= 32)
     pub fn get_spi_state(&self, int: InterruptNumber) -> Enabled {
-        assert!(int >= 32);
+        assert!(int >= 32, "get_spi_state: `int` must be >= 32");
         self.distributor().is_spi_enabled(int)
     }
 
     /// Enables or disables the forwarding of
     /// a particular interrupt in the distributor
+    ///
+    /// Panics: will panic if `int` is not in the SPI range (>= 32)
     pub fn set_spi_state(&mut self, int: InterruptNumber, enabled: Enabled) {
-        assert!(int >= 32);
+        assert!(int >= 32, "set_spi_state: `int` must be >= 32");
         self.distributor_mut().enable_spi(int, enabled)
     }
 
     /// Returns the priority of an interrupt
+    ///
+    /// Panics: will panic if `int` is not in the SPI range (>= 32)
     pub fn get_spi_priority(&self, int: InterruptNumber) -> Priority {
-        assert!(int >= 32);
+        assert!(int >= 32, "get_spi_priority: `int` must be >= 32");
         self.distributor().get_spi_priority(int)
     }
 
     /// Sets the priority of an interrupt (0-255)
+    ///
+    /// Panics: will panic if `int` is not in the SPI range (>= 32)
     pub fn set_spi_priority(&mut self, int: InterruptNumber, enabled: Priority) {
-        assert!(int >= 32);
+        assert!(int >= 32, "set_spi_priority: `int` must be >= 32");
         self.distributor_mut().set_spi_priority(int, enabled)
     }
 }
@@ -325,10 +333,11 @@ impl ArmGicCpuComponents {
         }
     }
 
-    /// Sends an inter processor interrupt (IPI),
-    /// also called software generated interrupt (SGI).
+    /// Sends an inter processor interrupt (IPI), also called software
+    /// generated interrupt (SGI).
     ///
-    /// note: on Aarch64, IPIs must have a number below 16 on ARMv8
+    /// Panics: on Aarch64, IPIs must have a number below 16. This function
+    /// panics if `int_num` is equal to or greater than 16.
     pub fn send_ipi(&mut self, int_num: InterruptNumber, target: IpiTargetCpu) {
         assert!(int_num < 16, "IPIs must have a number below 16 on ARMv8");
 
@@ -362,9 +371,11 @@ impl ArmGicCpuComponents {
         }
     }
 
-    /// Will that interrupt be received by this CPU?
+    /// Will that local interrupt be received by this CPU?
+    ///
+    /// Panics: will panic if `int` is not in the local range (< 32)
     pub fn get_interrupt_state(&self, int: InterruptNumber) -> Enabled {
-        assert!(int < 32);
+        assert!(int < 32, "get_interrupt_state: `int` doesn't lie in the SGI/PPI (local interrupt) range");
 
         if let Self::V3 { redist_regs } = self {
             redist_regs.redist_sgippi.is_sgippi_enabled(int)
@@ -378,8 +389,10 @@ impl ArmGicCpuComponents {
     }
 
     /// Enables or disables the receiving of a local interrupt in the distributor
+    ///
+    /// Panics: will panic if `int` is not in the local range (< 32)
     pub fn set_interrupt_state(&mut self, int: InterruptNumber, enabled: Enabled) {
-        assert!(int < 32);
+        assert!(int < 32, "get_interrupt_state: `int` doesn't lie in the SGI/PPI (local interrupt) range");
 
         if let Self::V3 { redist_regs } = self {
             redist_regs.redist_sgippi.enable_sgippi(int, enabled);
@@ -390,8 +403,10 @@ impl ArmGicCpuComponents {
     }
 
     /// Returns the priority of a local interrupt
+    ///
+    /// Panics: will panic if `int` is not in the local range (< 32)
     pub fn get_interrupt_priority(&self, int: InterruptNumber) -> Priority {
-        assert!(int < 32);
+        assert!(int < 32, "get_interrupt_state: `int` doesn't lie in the SGI/PPI (local interrupt) range");
 
         if let Self::V3 { redist_regs } = self {
             redist_regs.redist_sgippi.get_sgippi_priority(int)
@@ -405,8 +420,10 @@ impl ArmGicCpuComponents {
     }
 
     /// Sets the priority of a local interrupt (prio: 0-255)
+    ///
+    /// Panics: will panic if `int` is not in the local range (< 32)
     pub fn set_interrupt_priority(&mut self, int: InterruptNumber, enabled: Priority) {
-        assert!(int < 32);
+        assert!(int < 32, "get_interrupt_state: `int` doesn't lie in the SGI/PPI (local interrupt) range");
 
         if let Self::V3 { redist_regs } = self {
             redist_regs.redist_sgippi.set_sgippi_priority(int, enabled);
@@ -416,10 +433,11 @@ impl ArmGicCpuComponents {
         }
     }
 
-    /// Interrupts have a priority; if their priority
-    /// is lower or equal to this one, they're queued
-    /// until this CPU or another one is ready to handle
-    /// them
+    /// Retrieves the current priority threshold for the current CPU.
+    ///
+    /// Interrupts have a priority; if their priority is lower or
+    /// equal to this threshold, they're queued until the current CPU
+    /// is ready to handle them.
     pub fn get_minimum_priority(&self) -> Priority {
         match self {
             Self::V2 { registers, .. } => registers.get_minimum_priority(),
@@ -427,10 +445,11 @@ impl ArmGicCpuComponents {
         }
     }
 
-    /// Interrupts have a priority; if their priority
-    /// is lower or equal to this one, they're queued
-    /// until this CPU or another one is ready to handle
-    /// them
+    /// Sets the current priority threshold for the current CPU.
+    ///
+    /// Interrupts have a priority; if their priority is lower or
+    /// equal to this threshold, they're queued until the current CPU
+    /// is ready to handle them.
     pub fn set_minimum_priority(&mut self, priority: Priority) {
         match self {
             Self::V2 { registers, .. } => registers.set_minimum_priority(priority),

--- a/kernel/gic/src/gic/redist_interface.rs
+++ b/kernel/gic/src/gic/redist_interface.rs
@@ -18,32 +18,48 @@ use super::write_array_volatile;
 use volatile::{Volatile, ReadOnly};
 use zerocopy::FromBytes;
 
+/// General redistributor registers
 #[derive(FromBytes)]
 #[repr(C)]
-pub struct RedistRegsP1 {        // base offset
-    ctlr:         Volatile<u32>, // 0x00
+pub struct RedistRegsP1 {                          // base offset
+    /// Redistributor Control Register
+    ctlr:         Volatile<u32>,                   // 0x00
+
+    /// Implementer Identification Register
     _unused0:     u32,
-    ident:        ReadOnly<u64>, // 0x08
+
+    /// Redistributor Type Register
+    ident:        ReadOnly<u64>,                   // 0x08
+
+    /// Error Reporting Status Register, optional
     _unused1:     u32,
-    waker:        Volatile<u32>, // 0x14
+
+    /// Redistributor Wake Register
+    waker:        Volatile<u32>,                   // 0x14
 }
 
+/// Redistributor registers for SGIs & PPIs
 #[derive(FromBytes)]
 #[repr(C)]
 pub struct RedistRegsSgiPpi {            // base offset
     _reserved0:   [u8;            0x80],
 
+    /// Interrupt Group Register 0
     group:        [Volatile<u32>; 0x01], // 0x080
     _reserved1:   [u32;           0x1f],
 
+    /// Interrupt Set-Enable Registers
     set_enable:   [Volatile<u32>; 0x01], // 0x100
     _reserved2:   [u32;           0x1f],
 
+    /// Interrupt Clear-Enable Registers
     clear_enable: [Volatile<u32>; 0x01], // 0x180
     _reserved3:   [u32;           0x1f],
 
+    /// Interrupt Set & Clear Pending / Active Registers
     _unused0:     [u32;           0x80],
 
+    /// Interrupt Priority Registers
     priority:     [Volatile<u32>; 0x08], // 0x400
 }
 

--- a/kernel/gic/src/lib.rs
+++ b/kernel/gic/src/lib.rs
@@ -1,4 +1,7 @@
-//! Allows configuring the Generic Interrupt Controller
+//! Arm Generic Interrupt Controller Support
+//!
+//! The GIC is an extension to ARMv8 which allows routing and
+//! filtering interrupts in a single or multi-core system.
 //!
 //! The term "Forwarding" is sometimes used in this crate.
 //! This is because the Distributor, Redistributor and CPU interface are
@@ -8,7 +11,6 @@
 
 #![no_std]
 #![feature(doc_cfg)]
-#![feature(array_try_from_fn)]
 
 #[cfg(target_arch = "aarch64")]
 mod gic;

--- a/kernel/interrupt_controller/Cargo.toml
+++ b/kernel/interrupt_controller/Cargo.toml
@@ -14,6 +14,7 @@ sync_irq = { path = "../../libs/sync_irq" }
 arm_boards = { path = "../arm_boards" }
 memory = { path = "../memory" }
 gic = { path = "../gic" }
+spin = "0.9.4"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 apic = { path = "../apic" }

--- a/kernel/interrupt_controller/src/aarch64.rs
+++ b/kernel/interrupt_controller/src/aarch64.rs
@@ -1,9 +1,9 @@
 use {
-    gic::{ArmGic, SpiDestination, IpiTargetCpu, Version as GicVersion},
-    arm_boards::{BOARD_CONFIG, InterruptControllerConfig},
-    sync_irq::IrqSafeMutex,
+    gic::{ArmGicDistributor, ArmGicCpuComponents, SpiDestination, IpiTargetCpu, Version as GicVersion},
+    arm_boards::{NUM_CPUS, BOARD_CONFIG, InterruptControllerConfig},
+    core::{ops::DerefMut, array::try_from_fn},
     memory::get_kernel_mmi_ref,
-    core::ops::DerefMut,
+    sync_irq::IrqSafeMutex,
 };
 
 use super::*;
@@ -17,65 +17,54 @@ pub struct SystemInterruptControllerId(pub u8);
 #[derive(Debug, Copy, Clone)]
 pub struct LocalInterruptControllerId(pub u16);
 
-/// The private global Generic Interrupt Controller singleton
-pub(crate) static INTERRUPT_CONTROLLER: IrqSafeMutex<Option<ArmGic>> = IrqSafeMutex::new(None);
-
 /// Initializes the interrupt controller, on aarch64
 pub fn init() -> Result<(), &'static str> {
-    let mut int_ctrl = INTERRUPT_CONTROLLER.lock();
-    if int_ctrl.is_some() {
-        Err("The interrupt controller has already been initialized!")
-    } else {
-        match BOARD_CONFIG.interrupt_controller {
-            InterruptControllerConfig::GicV3(gicv3_cfg) => {
-                let kernel_mmi_ref = get_kernel_mmi_ref()
-                    .ok_or("interrupts::aarch64::init: couldn't get kernel MMI ref")?;
+    match BOARD_CONFIG.interrupt_controller {
+        InterruptControllerConfig::GicV3(gicv3_cfg) => {
+            let kernel_mmi_ref = get_kernel_mmi_ref()
+                .ok_or("interrupts::aarch64::init: couldn't get kernel MMI ref")?;
 
-                let mut mmi = kernel_mmi_ref.lock();
-                let page_table = &mut mmi.deref_mut().page_table;
+            let mut mmi = kernel_mmi_ref.lock();
+            let page_table = &mut mmi.deref_mut().page_table;
 
-                *int_ctrl = Some(ArmGic::init(
-                    page_table,
-                    GicVersion::InitV3 {
-                        dist: gicv3_cfg.distributor_base_address,
-                        redist: gicv3_cfg.redistributor_base_addresses,
-                    },
-                )?);
-            },
-        }
+            let version = GicVersion::InitV3 {
+                dist: gicv3_cfg.distributor_base_address,
+                redist: gicv3_cfg.redistributor_base_addresses,
+            };
 
-        Ok(())
+            let distrib = ArmGicDistributor::init(&version)?;
+            let cpu_ctlrs: [ArmGicCpuComponents; NUM_CPUS] = try_from_fn(|i| {
+                let cpu_id = BOARD_CONFIG.cpu_ids[i].into();
+                ArmGicCpuComponents::init(cpu_id, &version)
+            })?;
+
+            // TODO: store these somewhere
+        },
     }
+
+    Ok(())
 }
 
 /// Structure representing a top-level/system-wide interrupt controller chip,
 /// responsible for routing interrupts between peripherals and CPU cores.
 ///
 /// On aarch64 w/ GIC, this corresponds to the Distributor.
-pub struct SystemInterruptController;
+pub struct SystemInterruptController(IrqSafeMutex<ArmGicDistributor>);
 
 /// Struct representing per-cpu-core interrupt controller chips.
 ///
 /// On aarch64 w/ GIC, this corresponds to a Redistributor & CPU interface.
-pub struct LocalInterruptController;
+pub struct LocalInterruptController(IrqSafeMutex<ArmGicCpuComponents>);
 
 impl SystemInterruptControllerApi for SystemInterruptController {
     fn id(&self) -> SystemInterruptControllerId {
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_ref()
-            .expect("BUG: id(): INTERRUPT_CONTROLLER was uninitialized");
-
-        SystemInterruptControllerId(int_ctlr.implementer().product_id)
+        let dist = self.0.lock();
+        SystemInterruptControllerId(dist.implementer().product_id)
     }
 
     fn version(&self) -> SystemInterruptControllerVersion {
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_ref()
-            .expect("BUG: version(): INTERRUPT_CONTROLLER was uninitialized");
-
-        SystemInterruptControllerVersion(int_ctlr.implementer().version)
+        let dist = self.0.lock();
+        SystemInterruptControllerVersion(dist.implementer().version)
     }
 
     fn get_destination(
@@ -83,13 +72,10 @@ impl SystemInterruptControllerApi for SystemInterruptController {
         interrupt_num: InterruptNumber,
     ) -> Result<(Vec<CpuId>, Priority), &'static str> {
         assert!(interrupt_num >= 32, "shared peripheral interrupts have a number >= 32");
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_ref()
-            .expect("BUG: get_destination(): INTERRUPT_CONTROLLER was uninitialized");
+        let dist = self.0.lock();
 
-        let priority = int_ctlr.get_interrupt_priority(interrupt_num as _);
-        let vec = match int_ctlr.get_spi_target(interrupt_num as _)?.canonicalize() {
+        let priority = dist.get_spi_priority(interrupt_num as _);
+        let vec = match dist.get_spi_target(interrupt_num as _)?.canonicalize() {
             SpiDestination::Specific(cpu) => [cpu].to_vec(),
             SpiDestination::AnyCpuAvailable => BOARD_CONFIG.cpu_ids.map(|mpidr| mpidr.into()).to_vec(),
             SpiDestination::GICv2TargetList(list) => {
@@ -111,13 +97,10 @@ impl SystemInterruptControllerApi for SystemInterruptController {
         priority: Priority,
     ) -> Result<(), &'static str> {
         assert!(sys_int_num >= 32, "shared peripheral interrupts have a number >= 32");
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_mut()
-            .expect("BUG: set_destination(): INTERRUPT_CONTROLLER was uninitialized");
+        let mut dist = self.0.lock();
 
-        int_ctlr.set_spi_target(sys_int_num as _, SpiDestination::Specific(destination));
-        int_ctlr.set_interrupt_priority(sys_int_num as _, priority);
+        dist.set_spi_target(sys_int_num as _, SpiDestination::Specific(destination));
+        dist.set_spi_priority(sys_int_num as _, priority);
 
         Ok(())
     }
@@ -125,112 +108,68 @@ impl SystemInterruptControllerApi for SystemInterruptController {
 
 impl LocalInterruptControllerApi for LocalInterruptController {
     fn init_secondary_cpu_interface(&self) {
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_mut()
-            .expect("BUG: init_secondary_cpu_interface(): INTERRUPT_CONTROLLER was uninitialized");
-
-        int_ctlr.init_secondary_cpu_interface();
+        let mut cpu = self.0.lock();
+        cpu.init_secondary_cpu_interface();
     }
 
     fn id(&self) -> LocalInterruptControllerId {
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_ref()
-            .expect("BUG: id(): INTERRUPT_CONTROLLER was uninitialized");
-
-        LocalInterruptControllerId(int_ctlr.get_cpu_interface_id())
+        let cpu = self.0.lock();
+        LocalInterruptControllerId(cpu.get_cpu_interface_id())
     }
 
     fn get_local_interrupt_priority(&self, num: InterruptNumber) -> Priority {
         assert!(num < 32, "local interrupts have a number < 32");
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_ref()
-            .expect("BUG: get_local_interrupt_priority(): INTERRUPT_CONTROLLER was uninitialized");
-
-        int_ctlr.get_interrupt_priority(num as _)
+        let cpu = self.0.lock();
+        cpu.get_interrupt_priority(num as _)
     }
 
     fn set_local_interrupt_priority(&self, num: InterruptNumber, priority: Priority) {
         assert!(num < 32, "local interrupts have a number < 32");
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_mut()
-            .expect("BUG: set_local_interrupt_priority(): INTERRUPT_CONTROLLER was uninitialized");
-
-        int_ctlr.set_interrupt_priority(num as _, priority);
+        let mut cpu = self.0.lock();
+        cpu.set_interrupt_priority(num as _, priority);
     }
 
     fn is_local_interrupt_enabled(&self, num: InterruptNumber) -> bool {
         assert!(num < 32, "local interrupts have a number < 32");
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_ref()
-            .expect("BUG: is_local_interrupt_enabled(): INTERRUPT_CONTROLLER was uninitialized");
-
-        int_ctlr.get_interrupt_state(num as _)
+        let cpu = self.0.lock();
+        cpu.get_interrupt_state(num as _)
     }
 
     fn enable_local_interrupt(&self, num: InterruptNumber, enabled: bool) {
         assert!(num < 32, "local interrupts have a number < 32");
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_mut()
-            .expect("BUG: enable_local_interrupt(): INTERRUPT_CONTROLLER was uninitialized");
-
-        int_ctlr.set_interrupt_state(num as _, enabled);
+        let mut cpu = self.0.lock();
+        cpu.set_interrupt_state(num as _, enabled);
     }
 
     fn send_ipi(&self, num: InterruptNumber, dest: InterruptDestination) {
         use InterruptDestination::*;
         assert!(num < 16, "IPIs have a number < 16");
+        let mut cpu = self.0.lock();
 
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_mut()
-            .expect("BUG: send_ipi(): INTERRUPT_CONTROLLER was uninitialized");
-
-        int_ctlr.send_ipi(num as _, match dest {
+        cpu.send_ipi(num as _, match dest {
             SpecificCpu(cpu) => IpiTargetCpu::Specific(cpu),
             AllOtherCpus => IpiTargetCpu::AllOtherCpus,
         });
     }
 
     fn get_minimum_priority(&self) -> Priority {
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_ref()
-            .expect("BUG: get_minimum_priority(): INTERRUPT_CONTROLLER was uninitialized");
-
-        int_ctlr.get_minimum_priority()
+        let cpu = self.0.lock();
+        cpu.get_minimum_priority()
     }
 
     fn set_minimum_priority(&self, priority: Priority) {
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_mut()
-            .expect("BUG: set_minimum_priority(): INTERRUPT_CONTROLLER was uninitialized");
-
-        int_ctlr.set_minimum_priority(priority)
+        let mut cpu = self.0.lock();
+        cpu.set_minimum_priority(priority)
     }
 
     fn acknowledge_interrupt(&self) -> (InterruptNumber, Priority) {
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_mut()
-            .expect("BUG: acknowledge_interrupt(): INTERRUPT_CONTROLLER was uninitialized");
-
-        let (num, prio) = int_ctlr.acknowledge_interrupt();
+        let mut cpu = self.0.lock();
+        let (num, prio) = cpu.acknowledge_interrupt();
         (num as _, prio)
     }
 
     fn end_of_interrupt(&self, number: InterruptNumber) {
-        let mut int_ctlr = INTERRUPT_CONTROLLER.lock();
-        let int_ctlr = int_ctlr
-            .as_mut()
-            .expect("BUG: end_of_interrupt(): INTERRUPT_CONTROLLER was uninitialized");
-
-        int_ctlr.end_of_interrupt(number as _)
+        let mut cpu = self.0.lock();
+        cpu.end_of_interrupt(number as _)
     }
 }

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![allow(unused_variables, unused_mut)]
+#![feature(array_try_from_fn)]
 
 extern crate alloc;
 

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -39,6 +39,8 @@ pub enum InterruptDestination {
 }
 
 pub trait SystemInterruptControllerApi {
+    fn get() -> &'static Self;
+
     fn id(&self) -> SystemInterruptControllerId;
     fn version(&self) -> SystemInterruptControllerVersion;
 
@@ -56,6 +58,8 @@ pub trait SystemInterruptControllerApi {
 }
 
 pub trait LocalInterruptControllerApi {
+    fn get() -> &'static Self;
+
     /// Aarch64-specific way to initialize the secondary CPU interfaces.
     ///
     /// Must be called once from every secondary CPU.

--- a/kernel/interrupt_controller/src/x86_64.rs
+++ b/kernel/interrupt_controller/src/x86_64.rs
@@ -31,6 +31,10 @@ pub struct SystemInterruptController {
 pub struct LocalInterruptController;
 
 impl SystemInterruptControllerApi for SystemInterruptController {
+    fn get() -> &'static Self {
+        unimplemented!()
+    }
+
     fn id(&self) -> SystemInterruptControllerId {
         let mut int_ctlr = get_ioapic(self.id).expect("BUG: id(): get_ioapic() returned None");
         SystemInterruptControllerId(int_ctlr.id())
@@ -65,6 +69,10 @@ impl SystemInterruptControllerApi for SystemInterruptController {
 
 
 impl LocalInterruptControllerApi for LocalInterruptController {
+    fn get() -> &'static Self {
+        unimplemented!()
+    }
+
     fn init_secondary_cpu_interface(&self) {
         panic!("This must not be used on x86_64")
     }

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -140,7 +140,7 @@ pub fn init_ap() {
     set_vbar_el1();
 
     // Enable the CPU-local timer
-    let int_ctrl = LocalInterruptController;
+    let int_ctrl = LocalInterruptController::get();
     int_ctrl.init_secondary_cpu_interface();
     int_ctrl.set_minimum_priority(0);
 
@@ -160,7 +160,7 @@ pub fn init() -> Result<(), &'static str> {
 
     set_vbar_el1();
 
-    let int_ctrl = LocalInterruptController;
+    let int_ctrl = LocalInterruptController::get();
     int_ctrl.set_minimum_priority(0);
 
     Ok(())
@@ -178,7 +178,7 @@ pub fn init_timer(timer_tick_handler: InterruptHandler) -> Result<(), &'static s
 
     // Route the IRQ to this core (implicit as IRQ < 32) & Enable the interrupt.
     {
-        let int_ctrl = LocalInterruptController;
+        let int_ctrl = LocalInterruptController::get();
 
         // enable routing of this interrupt
         int_ctrl.enable_local_interrupt(CPU_LOCAL_TIMER_IRQ, true);
@@ -198,7 +198,7 @@ pub fn setup_ipi_handler(handler: InterruptHandler, local_num: InterruptNumber) 
     }
 
     {
-        let int_ctrl = LocalInterruptController;
+        let int_ctrl = LocalInterruptController::get();
 
         // enable routing of this interrupt
         int_ctrl.enable_local_interrupt(local_num, true);
@@ -209,7 +209,7 @@ pub fn setup_ipi_handler(handler: InterruptHandler, local_num: InterruptNumber) 
 
 /// Enables the PL011 "RX" SPI and routes it to the current CPU.
 pub fn init_pl011_rx_interrupt() -> Result<(), &'static str> {
-    let int_ctrl = SystemInterruptController;
+    let int_ctrl = SystemInterruptController::get();
     int_ctrl.set_destination(PL011_RX_SPI, current_cpu(), u8::MAX)
 }
 
@@ -295,14 +295,14 @@ pub fn deregister_interrupt(int_num: InterruptNumber, func: InterruptHandler) ->
 /// Broadcast an Inter-Processor Interrupt to all other
 /// cores in the system
 pub fn send_ipi_to_all_other_cpus(irq_num: InterruptNumber) {
-    let int_ctrl = LocalInterruptController;
+    let int_ctrl = LocalInterruptController::get();
     int_ctrl.send_ipi(irq_num, InterruptDestination::AllOtherCpus);
 }
 
 /// Send an "end of interrupt" signal, notifying the interrupt chip that
 /// the given interrupt request `irq` has been serviced.
 pub fn eoi(irq_num: InterruptNumber) {
-    let int_ctrl = LocalInterruptController;
+    let int_ctrl = LocalInterruptController::get();
     int_ctrl.end_of_interrupt(irq_num);
 }
 
@@ -417,7 +417,7 @@ extern "C" fn current_elx_synchronous(e: &mut ExceptionContext) {
 #[no_mangle]
 extern "C" fn current_elx_irq(exc: &mut ExceptionContext) {
     let (irq_num, _priority) = {
-        let int_ctrl = LocalInterruptController;
+        let int_ctrl = LocalInterruptController::get();
         int_ctrl.acknowledge_interrupt()
     };
 


### PR DESCRIPTION
Changes:
- The GIC driver has two main structures: `ArmGicDistributor` & `ArmGicCpuComponents` which map to `SystemInterruptController` & `LocalInterruptController`. There's one `ArmGicCpuComponents` per CPU. This is a cleaner ownership distribution.
- I had to comment out some GICv2 support for this unfortunately, because IPIs are sent via the distributor in this version, whereas on GICv3 it's done on the CPU interface. I left a big comment on the affected code and in arm_boards; this code now panics.
- The `aarch64` part of `interrupt_controller` initializes these properly and implements `SystemInterruptControllerApi` & `LocalInterruptControllerApi` on top of them.

However, this is a draft PR because I'm not sure where to store these, since there have been work on cpu-local-storage recently and I'm not sure if it's ready or not.