### PR TITLE
Make use of `create_identity_mapping` in `multicore_bringup`

### DIFF
--- a/kernel/multicore_bringup/Cargo.toml
+++ b/kernel/multicore_bringup/Cargo.toml
@@ -20,10 +20,10 @@ kernel_config = { path = "../kernel_config" }
 psci = "0.1.1"
 memory_aarch64 = { path = "../memory_aarch64" }
 arm_boards = { path = "../arm_boards" }
+mod_mgmt = { path = "../mod_mgmt" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 pit_clock_basic = { path = "../pit_clock_basic" }
-mod_mgmt = { path = "../mod_mgmt" }
 acpi = { path = "../acpi" }
 apic = { path = "../apic" }
 madt = { path = "../acpi/madt" }

--- a/kernel/multicore_bringup/Cargo.toml
+++ b/kernel/multicore_bringup/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4.8"
 memory = { path = "../memory" }
 stack = { path = "../stack" }
 cpu = { path = "../cpu" }
+mod_mgmt = { path = "../mod_mgmt" }
 ap_start = { path = "../ap_start" }
 kernel_config = { path = "../kernel_config" }
 
@@ -20,7 +21,6 @@ kernel_config = { path = "../kernel_config" }
 psci = "0.1.1"
 memory_aarch64 = { path = "../memory_aarch64" }
 arm_boards = { path = "../arm_boards" }
-mod_mgmt = { path = "../mod_mgmt" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 pit_clock_basic = { path = "../pit_clock_basic" }

--- a/kernel/multicore_bringup/src/aarch64.rs
+++ b/kernel/multicore_bringup/src/aarch64.rs
@@ -97,7 +97,9 @@ pub fn handle_ap_cores(
         ap_data_phys_addr = page_table.translate(ap_data.ap_data_virt_addr.read()).unwrap();
 
         // get physical address of generated entry point
-        entry_point_phys_addr = page_table.translate(virt_addr).unwrap();
+        // this is identity mapped, so we can just cast from physical to virtual
+        // entry_point_phys_addr = page_table.translate(virt_addr).unwrap();
+        entry_point_phys_addr = PhysicalAddress::new_canonical(virt_addr.value());
     }
 
     let mut ap_stack = None;

--- a/kernel/multicore_bringup/src/aarch64.rs
+++ b/kernel/multicore_bringup/src/aarch64.rs
@@ -1,4 +1,4 @@
-use memory::{get_kernel_mmi_ref, create_identity_mapping, MmiRef, VirtualAddress, PhysicalAddress, PteFlags};
+use memory::{create_identity_mapping, MmiRef, VirtualAddress, PhysicalAddress, PteFlags};
 use memory_aarch64::{read_mmu_config, asm_set_mmu_config_x2_x3};
 use kernel_config::memory::{PAGE_SIZE, KERNEL_STACK_SIZE_IN_PAGES};
 use psci::{cpu_on, error::Error::*};
@@ -70,7 +70,7 @@ pub fn handle_ap_cores(
             .ok_or("BUG: the 'ap_entry_point' virtual address was not covered by the kernel's text pages")
             .and_then(|offset| kernel_text_pages.as_slice(offset, PAGE_SIZE))?;
 
-        let dst: &mut [u8] = ap_startup_mapped_pages.as_slice_mut(0, PAGE_SIZE).unwrap();
+        let dst: &mut [u8] = ap_startup_mapped_pages.as_slice_mut(0, PAGE_SIZE)?;
         dst.copy_from_slice(src);
 
         // After copying the content into the identity page, remap it to remove write permissions.
@@ -92,7 +92,7 @@ pub fn handle_ap_cores(
 
         // get physical address of the ApTrampolineData structure
         page_table.translate(ap_data.ap_data_virt_addr.read()).unwrap()
-    }
+    };
 
     let mut ap_stack = None;
     for def_mpidr in BOARD_CONFIG.cpu_ids {


### PR DESCRIPTION
`multicore_bringup` contained workarounds in aarch64 code because the main function needed a way to identity map any page/frame. Now that Kevin implemented that, this removes the temporary workarounds and makes use of the new `memory::create_identity_mapping` function.