### PR TITLE
Allow page allocation requests to specify a desired alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3759,6 +3759,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_aligned_page_allocation"
+version = "0.1.0"
+dependencies = [
+ "app_io",
+ "log",
+ "memory",
+]
+
+[[package]]
 name = "test_async"
 version = "0.1.0"
 dependencies = [
@@ -4048,6 +4057,7 @@ dependencies = [
  "seconds_counter",
  "shell",
  "swap",
+ "test_aligned_page_allocation",
  "test_async",
  "test_backtrace",
  "test_block_io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ exclude = [
 
 	## Exclude application crates used for testing specific Theseus functionality.
 	## TODO: move these to a specific "tests" folder so we can exclude that entire folder.
+	"applications/test_aligned_page_allocation",
 	"applications/test_backtrace",
 	"applications/test_block_io",
 	"applications/test_channel",

--- a/applications/test_aligned_page_allocation/Cargo.toml
+++ b/applications/test_aligned_page_allocation/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test_aligned_page_allocation"
+version = "0.1.0"
+description = "Tests the `AllocationRequest::AlignedTo` variant, which is needed for huge pages"
+authors = ["Kevin Boos <kevinaboos@gmail.com>"]
+edition = "2021"
+
+[dependencies]
+log = "0.4.8"
+
+[dependencies.memory]
+path = "../../kernel/memory"
+
+[dependencies.app_io]
+path = "../../kernel/app_io"

--- a/applications/test_aligned_page_allocation/src/lib.rs
+++ b/applications/test_aligned_page_allocation/src/lib.rs
@@ -1,0 +1,45 @@
+//! A set of basic tests for the [`AllocationRequest::AlignedTo`] variant.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{
+    vec::Vec,
+    string::String,
+};
+use app_io::println;
+use memory::AllocationRequest;
+
+static TEST_SET: [usize; 9] = [1, 2, 4, 8, 27, 48, 256, 512, 1024];
+
+pub fn main(_args: Vec<String>) -> isize {    
+    match rmain() {
+        Ok(_) => 0,
+        Err(e) => {
+            println!("Error: {}", e); 
+            -1
+        }
+    }
+}
+
+fn rmain() -> Result<(), &'static str> {
+    for num_pages in TEST_SET.into_iter() {
+        for alignment in TEST_SET.into_iter() {
+            println!("Attempting to allocate {num_pages} pages with alignment of {alignment} 4K pages...");
+            match memory::allocate_pages_deferred(
+                AllocationRequest::AlignedTo { alignment_4k_pages: alignment },
+                num_pages,
+            ) {
+                Ok((ap, _action)) => {
+                    assert_eq!(ap.start().number() % alignment, 0);
+                    assert_eq!(ap.size_in_pages(), num_pages);
+                    println!("    Success: {ap:?}");
+                }
+                Err(e) => println!("    !! FAILURE: {e:?}"),
+            }
+        }
+    }
+    
+    Ok(())
+}

--- a/kernel/memory/src/lib.rs
+++ b/kernel/memory/src/lib.rs
@@ -26,6 +26,8 @@ pub use memory_structs::*;
 pub use page_allocator::{
     AllocatedPages,
     AllocationRequest,
+    allocate_pages_deferred,
+    allocate_pages_by_bytes_deferred,
     allocate_pages,
     allocate_pages_at,
     allocate_pages_by_bytes,
@@ -37,6 +39,8 @@ pub use page_allocator::{
 pub use frame_allocator::{
     AllocatedFrames,
     UnmappedFrames,
+    allocate_frames_deferred,
+    allocate_frames_by_bytes_deferred,
     allocate_frames,
     allocate_frames_at,
     allocate_frames_by_bytes,

--- a/kernel/memory_structs/src/lib.rs
+++ b/kernel/memory_structs/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![no_std]
 #![feature(step_trait)]
+#![feature(int_roundings)]
 #![allow(incomplete_features)]
 #![feature(adt_const_params)]
 
@@ -285,6 +286,15 @@ macro_rules! implement_page_frame {
                 pub const fn containing_address(addr: $address) -> $TypeName {
                     $TypeName {
                         number: addr.value() / PAGE_SIZE,
+                    }
+                }
+
+                #[doc = "Returns a new `" $TypeName "` that is aligned up from this \
+                    `" $TypeName "` to the nearest multiple of `alignment_4k_pages`."]
+                #[doc(alias = "next_multiple_of")]
+                pub const fn align_up(&self, alignment_4k_pages: usize) -> $TypeName {
+                    $TypeName {
+                        number: self.number.next_multiple_of(alignment_4k_pages)
                     }
                 }
             }

--- a/theseus_features/Cargo.toml
+++ b/theseus_features/Cargo.toml
@@ -47,6 +47,7 @@ hello = { path = "../applications/hello", optional = true }
 raw_mode = { path = "../applications/raw_mode", optional = true }
 print_fault_log = { path = "../applications/print_fault_log", optional = true }
 seconds_counter = { path = "../applications/seconds_counter", optional = true }
+test_aligned_page_allocation = { path = "../applications/test_aligned_page_allocation", optional = true }
 test_async = { path = "../applications/test_async", optional = true }
 test_backtrace = { path = "../applications/test_backtrace", optional = true }
 test_block_io = { path = "../applications/test_block_io", optional = true }
@@ -146,6 +147,7 @@ theseus_tests = [
     "hello",
     "raw_mode",
     "seconds_counter",
+    "test_aligned_page_allocation",
     "test_async",
     "test_backtrace",
     "test_block_io",


### PR DESCRIPTION
The new `AllocationRequest::AlignedAt` variant can accept an alignment value, specified in number of 4K pages (not bytes).

This is needed to support easier allocation of huge pages, which have a large alignment requirement, e.g., 512 4K pages.
See #1016.