### PR TITLE
Fix section order on x86_64 when using older versions of `ld`

### DIFF
--- a/kernel/nano_core/linker_higher_half-aarch64.ld
+++ b/kernel/nano_core/linker_higher_half-aarch64.ld
@@ -122,7 +122,7 @@ SECTIONS {
     }
 }
 
-/* This definition must be placed at the end of the file so that the .cls,
-section is placed in the correct order. */
+/* This definition must be placed at the end of the file so that the .tdata, and
+.tbss sections are placed in the correct order. */
 __THESEUS_TLS_SIZE = SIZEOF(.tdata) + SIZEOF(.tbss);
 /* We don't need the CLS size on AArch64. */

--- a/kernel/nano_core/linker_higher_half-x86_64.ld
+++ b/kernel/nano_core/linker_higher_half-x86_64.ld
@@ -8,9 +8,6 @@ OUTPUT_FORMAT(elf64-x86-64)
  */
 KERNEL_OFFSET = 0xFFFFFFFF80000000;
 
-__THESEUS_CLS_SIZE = SIZEOF(.cls);
-__THESEUS_TLS_SIZE = SIZEOF(.tdata) + SIZEOF(.tbss);
-
 SECTIONS {
 
 	/*
@@ -115,3 +112,8 @@ SECTIONS {
 		*(.data.rel.ro.local*) *(.data.rel.ro .data.rel.ro.*)
 	}
 }
+
+/* These definitions must be placed at the end of the file so that the .cls,
+.tdata, and .tbss sections are placed in the correct order. */
+__THESEUS_CLS_SIZE = SIZEOF(.cls);
+__THESEUS_TLS_SIZE = SIZEOF(.tdata) + SIZEOF(.tbss);


### PR DESCRIPTION
Older versions of `ld` place the `.cls`, `.tdata`, and `.tbss` sections first because they are used in linker script variable definitions. This creates problems because `memory_x86_64` assumes a specific order of the sections. The fix is the same as for AArch64 --- move the definitions to the end of the file.