### PR TITLE
aarch64: support FIQs and use them for TLB shootdown IPIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,7 +1660,7 @@ dependencies = [
 [[package]]
 name = "irq_safety"
 version = "0.1.1"
-source = "git+https://github.com/theseus-os/irq_safety#0e32fe775fdb93be1fc6f85b306d109aea5d920e"
+source = "git+https://github.com/theseus-os/irq_safety#11bfab9f410a898df1e42ad6213488612e20c926"
 dependencies = [
  "spin 0.9.4",
 ]

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -51,6 +51,7 @@ pub fn kstart_ap(
     nmi_lint: u8,
     nmi_flags: u16,
 ) -> ! {
+    irq_safety::disable_fast_interrupts();
     irq_safety::disable_interrupts();
 
     info!("Booted CPU {}, proc: {}, stack: {:#X} to {:#X}, nmi_lint: {}, nmi_flags: {:#X}",
@@ -100,6 +101,7 @@ pub fn kstart_ap(
 
     #[cfg(target_arch = "aarch64")] {
         interrupts::init_ap();
+        irq_safety::enable_fast_interrupts();
 
         // Register this CPU as online in the system
         // This is the equivalent of `LocalApic::init` on aarch64

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -51,8 +51,9 @@ pub fn kstart_ap(
     nmi_lint: u8,
     nmi_flags: u16,
 ) -> ! {
-    irq_safety::disable_fast_interrupts();
     irq_safety::disable_interrupts();
+    #[cfg(target_arch = "aarch64")]
+    irq_safety::disable_fast_interrupts();
 
     info!("Booted CPU {}, proc: {}, stack: {:#X} to {:#X}, nmi_lint: {}, nmi_flags: {:#X}",
         cpu_id, processor_id, _stack_start, _stack_end, nmi_lint, nmi_flags

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -123,6 +123,7 @@ pub fn init(
         interrupt_controller::init()?;
 
         interrupts::init()?;
+        irq_safety::enable_fast_interrupts();
 
         // register BSP CpuId
         cpu::register_cpu(true)?;

--- a/kernel/context_switch_regular/src/aarch64.rs
+++ b/kernel/context_switch_regular/src/aarch64.rs
@@ -22,6 +22,7 @@ pub struct ContextRegular {
 
     // only NZCV & DAIF bits are saved and restored
     pstate: usize,
+    padding: usize,
 }
 
 impl ContextRegular {
@@ -42,6 +43,7 @@ impl ContextRegular {
 
             // interrupts are initially unmasked/enabled
             pstate: 0,
+            padding: 0,
         }
     }
 

--- a/kernel/context_switch_regular/src/aarch64.rs
+++ b/kernel/context_switch_regular/src/aarch64.rs
@@ -22,7 +22,6 @@ pub struct ContextRegular {
 
     // only NZCV & DAIF bits are saved and restored
     pstate: usize,
-    padding: usize,
 }
 
 impl ContextRegular {
@@ -43,7 +42,6 @@ impl ContextRegular {
 
             // interrupts are initially unmasked/enabled
             pstate: 0,
-            padding: 0,
         }
     }
 
@@ -87,21 +85,21 @@ macro_rules! save_registers_regular {
         // Save all general purpose registers into the previous task.
         r#"
             // Make room on the stack for the registers.
-            sub sp,  sp,  #8 * 2 * 6
+            sub sp,  sp,  #8 * 13
 
             // Push registers on the stack, two at a time.
-            stp x19, x20, [sp, #8 * 2 * 0]
-            stp x21, x22, [sp, #8 * 2 * 1]
-            stp x23, x24, [sp, #8 * 2 * 2]
-            stp x25, x26, [sp, #8 * 2 * 3]
-            stp x27, x28, [sp, #8 * 2 * 4]
-            stp x29, x30, [sp, #8 * 2 * 5]
+            stp x19, x20, [sp, #8 * 0]
+            stp x21, x22, [sp, #8 * 2]
+            stp x23, x24, [sp, #8 * 4]
+            stp x25, x26, [sp, #8 * 6]
+            stp x27, x28, [sp, #8 * 8]
+            stp x29, x30, [sp, #8 * 10]
 
             // Push an OR of DAIF and NZCV flags of PSTATE
             mrs x29, DAIF
             mrs x30, NZCV
             orr x29, x29, x30
-            str x29, [sp, #8 * 2 * 6]
+            str x29, [sp, #8 * 12]
         "#
     );
 }
@@ -135,20 +133,20 @@ macro_rules! restore_registers_regular {
         r#"
             // Pop DAIF and NZCV flags of PSTATE
             // These MSRs discard irrelevant bits; no AND is required.
-            ldr x29, [sp, #8 * 2 * 6]
+            ldr x29, [sp, #8 * 12]
             msr DAIF, x29
             msr NZCV, x29
 
             // Pop registers from the stack, two at a time.
-            ldp x29, x30, [sp, #8 * 2 * 5]
-            ldp x27, x28, [sp, #8 * 2 * 4]
-            ldp x25, x26, [sp, #8 * 2 * 3]
-            ldp x23, x24, [sp, #8 * 2 * 2]
-            ldp x21, x22, [sp, #8 * 2 * 1]
-            ldp x19, x20, [sp, #8 * 2 * 0]
+            ldp x29, x30, [sp, #8 * 10]
+            ldp x27, x28, [sp, #8 * 8]
+            ldp x25, x26, [sp, #8 * 6]
+            ldp x23, x24, [sp, #8 * 4]
+            ldp x21, x22, [sp, #8 * 2]
+            ldp x19, x20, [sp, #8 * 0]
 
             // Move the stack pointer back up.
-            add sp,  sp,  #8 * 2 * 6
+            add sp,  sp,  #8 * 13
         "#
     );
 }

--- a/kernel/gic/src/gic/cpu_interface_gicv2.rs
+++ b/kernel/gic/src/gic/cpu_interface_gicv2.rs
@@ -8,6 +8,7 @@
 
 use super::Priority;
 use super::InterruptNumber;
+use super::SPURIOUS_INTERRUPT_NUM;
 
 use volatile::{Volatile, ReadOnly, WriteOnly};
 use zerocopy::FromBytes;
@@ -97,7 +98,7 @@ impl CpuRegsP1 {
         let priority = self.running_prio.read() as u8;
 
         match int_num {
-            1023 => None,
+            SPURIOUS_INTERRUPT_NUM => None,
             _ => Some((int_num, priority))
         }
     }

--- a/kernel/gic/src/gic/cpu_interface_gicv2.rs
+++ b/kernel/gic/src/gic/cpu_interface_gicv2.rs
@@ -42,7 +42,7 @@ pub struct CpuRegsP1 {            // base offset
 }
 
 // enable group 0
-// const CTLR_ENGRP0: u32 = 0b01;
+const CTLR_ENGRP0: u32 = 0b01;
 
 // enable group 1
 const CTLR_ENGRP1: u32 = 0b10;
@@ -51,6 +51,7 @@ impl CpuRegsP1 {
     /// Enables routing of group 1 interrupts for the current CPU.
     pub fn init(&mut self) {
         let mut reg = self.ctlr.read();
+        reg |= CTLR_ENGRP0;
         reg |= CTLR_ENGRP1;
         self.ctlr.write(reg);
     }
@@ -87,12 +88,17 @@ impl CpuRegsP1 {
     ///
     /// This tells the GIC that the requested interrupt is being
     /// handled by this CPU.
-    pub fn acknowledge_interrupt(&mut self) -> (InterruptNumber, Priority) {
+    ///
+    /// Returns None if a spurious interrupt is detected.
+    pub fn acknowledge_interrupt(&mut self) -> Option<(InterruptNumber, Priority)> {
         // Reading the interrupt number has the side effect
         // of acknowledging the interrupt.
         let int_num = self.acknowledge.read() as InterruptNumber;
         let priority = self.running_prio.read() as u8;
 
-        (int_num, priority)
+        match int_num {
+            1023 => None,
+            _ => Some((int_num, priority))
+        }
     }
 }

--- a/kernel/gic/src/gic/cpu_interface_gicv3.rs
+++ b/kernel/gic/src/gic/cpu_interface_gicv3.rs
@@ -12,6 +12,7 @@ use super::IpiTargetCpu;
 use super::Priority;
 use super::InterruptNumber;
 use super::InterruptGroup;
+use super::SPURIOUS_INTERRUPT_NUM;
 
 const SGIR_TARGET_ALL_OTHER_PE: u64 = 1 << 40;
 const IGRPEN_ENABLED: u64 = 1;
@@ -95,9 +96,9 @@ pub fn acknowledge_interrupt(group: InterruptGroup) -> Option<(InterruptNumber, 
 
     let int_num = int_num & 0xffffff;
     let priority = priority & 0xff;
-    match int_num {
-        1023 => None,
-        _ => Some((int_num as InterruptNumber, priority as u8))
+    match int_num as InterruptNumber {
+        SPURIOUS_INTERRUPT_NUM => None,
+        n => Some((n, priority as u8)),
     }
 }
 

--- a/kernel/gic/src/gic/cpu_interface_gicv3.rs
+++ b/kernel/gic/src/gic/cpu_interface_gicv3.rs
@@ -11,6 +11,7 @@ use core::arch::asm;
 use super::IpiTargetCpu;
 use super::Priority;
 use super::InterruptNumber;
+use super::InterruptGroup;
 
 const SGIR_TARGET_ALL_OTHER_PE: u64 = 1 << 40;
 const IGRPEN_ENABLED: u64 = 1;
@@ -28,7 +29,7 @@ pub fn init() {
 
     // Enable Group 0
     // bit 0 = group 0 enable
-    // unsafe { asm!("msr ICC_IGRPEN0_EL1, {}", in(reg) IGRPEN_ENABLED) };
+    unsafe { asm!("msr ICC_IGRPEN0_EL1, {}", in(reg) IGRPEN_ENABLED) };
 
     // Enable Groupe 1 (non-secure)
     // bit 0 = group 1 (non-secure) enable
@@ -61,9 +62,13 @@ pub fn set_minimum_priority(priority: Priority) {
 /// the current CPU.
 ///
 /// This implies that the CPU is ready to process interrupts again.
-pub fn end_of_interrupt(int: InterruptNumber) {
+pub fn end_of_interrupt(int: InterruptNumber, group: InterruptGroup) {
     let reg_value = int as u64;
-    unsafe { asm!("msr ICC_EOIR1_EL1, {}", in(reg) reg_value) };
+    
+    match group {
+        InterruptGroup::Group0 => unsafe { asm!("msr ICC_EOIR0_EL1, {}", in(reg) reg_value) },
+        InterruptGroup::Group1 => unsafe { asm!("msr ICC_EOIR1_EL1, {}", in(reg) reg_value) },
+    }
 }
 
 /// Acknowledge the currently serviced interrupt and fetches its
@@ -71,24 +76,33 @@ pub fn end_of_interrupt(int: InterruptNumber) {
 ///
 /// This tells the GIC that the requested interrupt is being
 /// handled by this CPU.
-pub fn acknowledge_interrupt() -> (InterruptNumber, Priority) {
+///
+/// Returns None if a spurious interrupt is detected.
+pub fn acknowledge_interrupt(group: InterruptGroup) -> Option<(InterruptNumber, Priority)> {
     let int_num: u64;
     let priority: u64;
 
     // Reading the interrupt number has the side effect
     // of acknowledging the interrupt.
+    match group {
+        InterruptGroup::Group0 => unsafe { asm!("mrs {}, ICC_IAR0_EL1", out(reg) int_num) },
+        InterruptGroup::Group1 => unsafe { asm!("mrs {}, ICC_IAR1_EL1", out(reg) int_num) },
+    }
+
     unsafe {
-        asm!("mrs {}, ICC_IAR1_EL1", out(reg) int_num);
         asm!("mrs {}, ICC_RPR_EL1", out(reg) priority);
     }
 
     let int_num = int_num & 0xffffff;
     let priority = priority & 0xff;
-    (int_num as InterruptNumber, priority as u8)
+    match int_num {
+        1023 => None,
+        _ => Some((int_num as InterruptNumber, priority as u8))
+    }
 }
 
 /// Generates an interrupt in CPU interfaces of the system
-pub fn send_ipi(int_num: InterruptNumber, target: IpiTargetCpu) {
+pub fn send_ipi(int_num: InterruptNumber, target: IpiTargetCpu, group: InterruptGroup) {
     let mut value = match target {
         IpiTargetCpu::Specific(cpu) => {
             let mpidr: cpu::MpidrValue = cpu.into();
@@ -118,5 +132,8 @@ pub fn send_ipi(int_num: InterruptNumber, target: IpiTargetCpu) {
     };
 
     value |= (int_num as u64) << 24;
-    unsafe { asm!("msr ICC_SGI1R_EL1, {}", in(reg) value) };
+    match group {
+        InterruptGroup::Group0 => unsafe { asm!("msr ICC_SGI0R_EL1, {}", in(reg) value) },
+        InterruptGroup::Group1 => unsafe { asm!("msr ICC_SGI1R_EL1, {}", in(reg) value) },
+    }
 }

--- a/kernel/gic/src/gic/dist_interface.rs
+++ b/kernel/gic/src/gic/dist_interface.rs
@@ -122,20 +122,19 @@ impl DistRegsP1 {
     }
 
     /// Returns whether the given SPI (shared peripheral interrupt) will be
-    /// forwarded by the distributor
+    /// forwarded by the distributor.
     pub fn get_spi_state(&self, int: InterruptNumber) -> Option<InterruptGroup> {
-        let enabled = read_array_volatile::<32>(&self.set_enable, int) == 1;
-        match enabled {
-            true => match read_array_volatile::<32>(&self.group, int) {
-                0 => Some(InterruptGroup::Group0),
-                1 => Some(InterruptGroup::Group1),
-                _ => unreachable!(),
-            },
-            false => None,
+        if read_array_volatile::<32>(&self.set_enable, int) == 1 {
+            match read_array_volatile::<32>(&self.group, int) {
+                0 => return Some(InterruptGroup::Group0),
+                1 => return Some(InterruptGroup::Group1),
+                _ => { }
+            }
         }
+        None
     }
 
-    /// Enables or disables the forwarding of a particular SPI (shared peripheral interrupt)
+    /// Enables or disables the forwarding of a particular SPI (shared peripheral interrupt).
     pub fn set_spi_state(&mut self, int: InterruptNumber, state: Option<InterruptGroup>) {
         if let Some(group) = state {
             write_array_volatile::<32>(&mut self.group, int, group as u32);

--- a/kernel/gic/src/gic/mod.rs
+++ b/kernel/gic/src/gic/mod.rs
@@ -250,10 +250,10 @@ impl ArmGicDistributor {
 
     /// Returns whether the given interrupt is forwarded by the distributor.
     ///
-    /// This returns:
-    /// - `None` if the interrupt is disabled.
-    /// - [`InterruptGroup::Group0`] if the interrupt is enabled and configured as a Group 0 interrupt.
-    /// - [`InterruptGroup::Group1`] if the interrupt is enabled and configured as a Group 1 interrupt.
+    /// # Return
+    /// * `None` if the interrupt is disabled.
+    /// * `Some(`[`InterruptGroup::Group0`]`)` if the interrupt is enabled and configured as a Group 0 interrupt.
+    /// * `Some(`[`InterruptGroup::Group1`]`)` if the interrupt is enabled and configured as a Group 1 interrupt.
     ///
     /// Panics if `int` is not in the SPI range (>= 32).
     pub fn get_spi_state(&self, int: InterruptNumber) -> Option<InterruptGroup> {
@@ -264,10 +264,10 @@ impl ArmGicDistributor {
     /// Enables or disables the forwarding of the given interrupt
     /// by the distributor.
     ///
-    /// If `state` is `None`, the interrupt will be disabled.
-    /// If it contains [`InterruptGroup::Group0`], the interrupt will be enabled and
-    /// configured as a Group 0 interrupt; if it contains [`InterruptGroup::Group1`],
-    /// the interrupt will be enabled and configured as a Group 1 interrupt.
+    /// # Arguments
+    /// * `int`: the interrupt number whose state we are modifying.
+    /// * `state`: whether the interrupt will be disabled (`None`),
+    ///   enabled as `Group0` (regular IRQs), or enabled as `Group1` (fast interrupts, FIQs).
     ///
     /// Panics if `int` is not in the SPI range (>= 32).
     pub fn set_spi_state(&mut self, int: InterruptNumber, state: Option<InterruptGroup>) {

--- a/kernel/gic/src/gic/redist_interface.rs
+++ b/kernel/gic/src/gic/redist_interface.rs
@@ -148,15 +148,14 @@ impl RedistRegsSgiPpi {
     /// Returns whether the given SGI (software generated interrupts) or
     /// PPI (private peripheral interrupts) will be forwarded by the redistributor
     pub fn get_sgippi_state(&self, int: InterruptNumber) -> Option<InterruptGroup> {
-        let enabled = read_array_volatile::<32>(&self.set_enable, int) == 1;
-        match enabled {
-            true => match read_array_volatile::<32>(&self.group, int) {
-                0 => Some(InterruptGroup::Group0),
-                1 => Some(InterruptGroup::Group1),
-                _ => unreachable!(),
-            },
-            false => None,
+        if read_array_volatile::<32>(&self.set_enable, int) == 1 {
+            match read_array_volatile::<32>(&self.group, int) {
+                0 => return Some(InterruptGroup::Group0),
+                1 => return Some(InterruptGroup::Group1),
+                _ => { }
+            }
         }
+        None
     }
 
     /// Enables or disables the forwarding of a particular

--- a/kernel/interrupt_controller/src/aarch64.rs
+++ b/kernel/interrupt_controller/src/aarch64.rs
@@ -145,11 +145,6 @@ impl LocalInterruptControllerApi for LocalInterruptController {
         &ctrls[index]
     }
 
-    fn init_secondary_cpu_interface(&self) {
-        let mut cpu_ctrl = self.0.lock();
-        cpu_ctrl.init_secondary_cpu_interface();
-    }
-
     fn id(&self) -> LocalInterruptControllerId {
         let cpu_ctrl = self.0.lock();
         LocalInterruptControllerId(cpu_ctrl.get_cpu_interface_id())
@@ -190,24 +185,31 @@ impl LocalInterruptControllerApi for LocalInterruptController {
         });
     }
 
-    fn get_minimum_priority(&self) -> Priority {
+    fn end_of_interrupt(&self, number: InterruptNumber) {
+        let mut cpu_ctrl = self.0.lock();
+        cpu_ctrl.end_of_interrupt(number as _)
+    }
+}
+
+impl LocalInterruptController {
+    pub fn get_minimum_priority(&self) -> Priority {
         let cpu_ctrl = self.0.lock();
         cpu_ctrl.get_minimum_priority()
     }
 
-    fn set_minimum_priority(&self, priority: Priority) {
+    pub fn set_minimum_priority(&self, priority: Priority) {
         let mut cpu_ctrl = self.0.lock();
         cpu_ctrl.set_minimum_priority(priority)
     }
 
-    fn acknowledge_interrupt(&self) -> (InterruptNumber, Priority) {
+    pub fn acknowledge_interrupt(&self) -> (InterruptNumber, Priority) {
         let mut cpu_ctrl = self.0.lock();
         let (num, prio) = cpu_ctrl.acknowledge_interrupt();
         (num as _, prio)
     }
 
-    fn end_of_interrupt(&self, number: InterruptNumber) {
+    pub fn init_secondary_cpu_interface(&self) {
         let mut cpu_ctrl = self.0.lock();
-        cpu_ctrl.end_of_interrupt(number as _)
+        cpu_ctrl.init_secondary_cpu_interface();
     }
 }

--- a/kernel/interrupt_controller/src/aarch64.rs
+++ b/kernel/interrupt_controller/src/aarch64.rs
@@ -1,7 +1,10 @@
 use {
-    gic::{ArmGicDistributor, ArmGicCpuComponents, SpiDestination, IpiTargetCpu, Version as GicVersion},
+    gic::{
+        ArmGicDistributor, ArmGicCpuComponents, SpiDestination, IpiTargetCpu,
+        Version as GicVersion, InterruptGroup,
+    },
     arm_boards::{NUM_CPUS, BOARD_CONFIG, InterruptControllerConfig},
-    core::array::try_from_fn,
+    core::{array::try_from_fn, cell::UnsafeCell},
     sync_irq::IrqSafeMutex,
     cpu::current_cpu,
     spin::Once,
@@ -49,9 +52,9 @@ pub fn init() -> Result<(), &'static str> {
                     ArmGicCpuComponents::init(cpu_id, &version)
                 })?;
 
-                Ok(cpu_ctlrs.map(|ctlr| {
+                Ok(cpu_ctlrs.map(|mut ctlr| {
                     let mutex = IrqSafeMutex::new(ctlr);
-                    LocalInterruptController(mutex)
+                    LocalInterruptController(UnsafeCell::new(mutex))
                 }))
             })?;
         },
@@ -69,7 +72,10 @@ pub struct SystemInterruptController(IrqSafeMutex<ArmGicDistributor>);
 /// Struct representing per-cpu-core interrupt controller chips.
 ///
 /// On aarch64 w/ GIC, this corresponds to a Redistributor & CPU interface.
-pub struct LocalInterruptController(IrqSafeMutex<ArmGicCpuComponents>);
+pub struct LocalInterruptController(UnsafeCell<IrqSafeMutex<ArmGicCpuComponents>>);
+
+unsafe impl Send for LocalInterruptController {}
+unsafe impl Sync for LocalInterruptController {}
 
 impl SystemInterruptControllerApi for SystemInterruptController {
     fn get() -> &'static Self {
@@ -112,17 +118,31 @@ impl SystemInterruptControllerApi for SystemInterruptController {
     fn set_destination(
         &self,
         sys_int_num: InterruptNumber,
-        destination: CpuId,
+        destination: Option<CpuId>,
         priority: Priority,
     ) -> Result<(), &'static str> {
         assert!(sys_int_num >= 32, "shared peripheral interrupts have a number >= 32");
+
+        let state = match destination.is_some() {
+            true => Some(InterruptGroup::Group1),
+            false => None,
+        };
+
         let mut dist = self.0.lock();
 
-        dist.set_spi_target(sys_int_num as _, SpiDestination::Specific(destination));
-        dist.set_spi_priority(sys_int_num as _, priority);
+        if let Some(destination) = destination {
+            dist.set_spi_target(sys_int_num as _, SpiDestination::Specific(destination));
+            dist.set_spi_priority(sys_int_num as _, priority);
+        }
+
+        dist.set_spi_state(sys_int_num as _, state);
 
         Ok(())
     }
+}
+
+macro_rules! lock {
+    ($this:ident) => (unsafe { $this.0.get().as_ref().unwrap().lock() })
 }
 
 impl LocalInterruptControllerApi for LocalInterruptController {
@@ -146,70 +166,127 @@ impl LocalInterruptControllerApi for LocalInterruptController {
     }
 
     fn id(&self) -> LocalInterruptControllerId {
-        let cpu_ctrl = self.0.lock();
+        let cpu_ctrl = lock!(self);
         LocalInterruptControllerId(cpu_ctrl.get_cpu_interface_id())
     }
 
     fn get_local_interrupt_priority(&self, num: InterruptNumber) -> Priority {
         assert!(num < 32, "local interrupts have a number < 32");
-        let cpu_ctrl = self.0.lock();
+        let cpu_ctrl = lock!(self);
         cpu_ctrl.get_interrupt_priority(num as _)
     }
 
     fn set_local_interrupt_priority(&self, num: InterruptNumber, priority: Priority) {
         assert!(num < 32, "local interrupts have a number < 32");
-        let mut cpu_ctrl = self.0.lock();
+        let mut cpu_ctrl = lock!(self);
         cpu_ctrl.set_interrupt_priority(num as _, priority);
     }
 
     fn is_local_interrupt_enabled(&self, num: InterruptNumber) -> bool {
         assert!(num < 32, "local interrupts have a number < 32");
-        let cpu_ctrl = self.0.lock();
-        cpu_ctrl.get_interrupt_state(num as _)
+        let cpu_ctrl = lock!(self);
+        match cpu_ctrl.get_interrupt_state(num as _) {
+            None => false,
+            Some(InterruptGroup::Group1) => true,
+            Some(InterruptGroup::Group0) => {
+                log::error!("Warning: found misconfigured local interrupt ({})", num);
+                true
+            },
+        }
     }
 
     fn enable_local_interrupt(&self, num: InterruptNumber, enabled: bool) {
         assert!(num < 32, "local interrupts have a number < 32");
-        let mut cpu_ctrl = self.0.lock();
-        cpu_ctrl.set_interrupt_state(num as _, enabled);
+        let state = match enabled {
+            true => Some(InterruptGroup::Group1),
+            false => None,
+        };
+        let mut cpu_ctrl = lock!(self);
+        cpu_ctrl.set_interrupt_state(num as _, state);
     }
 
     fn send_ipi(&self, num: InterruptNumber, dest: InterruptDestination) {
         use InterruptDestination::*;
         assert!(num < 16, "IPIs have a number < 16");
-        let mut cpu_ctrl = self.0.lock();
 
-        cpu_ctrl.send_ipi(num as _, match dest {
+        let dest = match dest {
             SpecificCpu(cpu) => IpiTargetCpu::Specific(cpu),
             AllOtherCpus => IpiTargetCpu::AllOtherCpus,
-        });
+        };
+
+        let mut cpu_ctrl = lock!(self);
+
+        cpu_ctrl.send_ipi(num as _, dest, InterruptGroup::Group1);
     }
 
     fn end_of_interrupt(&self, number: InterruptNumber) {
-        let mut cpu_ctrl = self.0.lock();
-        cpu_ctrl.end_of_interrupt(number as _)
+        let mut cpu_ctrl = lock!(self);
+        cpu_ctrl.end_of_interrupt(number as _, InterruptGroup::Group1)
     }
 }
 
 impl LocalInterruptController {
+    pub unsafe fn acknowledge_fast_interrupt(&self) -> Option<(InterruptNumber, Priority)> {
+        // we cannot lock here
+        // this has to be unsafe
+        let mut_mutex = self.0.get().as_mut().unwrap();
+        let mut cpu_ctrl = mut_mutex.get_mut();
+
+        let opt = cpu_ctrl.acknowledge_interrupt(InterruptGroup::Group0);
+        opt.map(|(num, prio)| (num as _, prio))
+    }
+
+    pub unsafe fn end_of_fast_interrupt(&self, number: InterruptNumber) {
+        // we cannot lock here
+        // this has to be unsafe
+        let mut_mutex = self.0.get().as_mut().unwrap();
+        let mut cpu_ctrl = mut_mutex.get_mut();
+
+        cpu_ctrl.end_of_interrupt(number as _, InterruptGroup::Group0)
+    }
+
+    pub fn enable_fast_local_interrupt(&self, num: InterruptNumber, enabled: bool) {
+        assert!(num < 32, "local interrupts have a number < 32");
+        let state = match enabled {
+            true => Some(InterruptGroup::Group0),
+            false => None,
+        };
+        let mut cpu_ctrl = lock!(self);
+        cpu_ctrl.set_interrupt_state(num as _, state);
+    }
+
+    pub fn send_fast_ipi(&self, num: InterruptNumber, dest: InterruptDestination) {
+        use InterruptDestination::*;
+        assert!(num < 16, "IPIs have a number < 16");
+
+        let dest = match dest {
+            SpecificCpu(cpu) => IpiTargetCpu::Specific(cpu),
+            AllOtherCpus => IpiTargetCpu::AllOtherCpus,
+        };
+
+        let mut cpu_ctrl = lock!(self);
+
+        cpu_ctrl.send_ipi(num as _, dest, InterruptGroup::Group0);
+    }
+
     pub fn get_minimum_priority(&self) -> Priority {
-        let cpu_ctrl = self.0.lock();
+        let cpu_ctrl = lock!(self);
         cpu_ctrl.get_minimum_priority()
     }
 
     pub fn set_minimum_priority(&self, priority: Priority) {
-        let mut cpu_ctrl = self.0.lock();
+        let mut cpu_ctrl = lock!(self);
         cpu_ctrl.set_minimum_priority(priority)
     }
 
-    pub fn acknowledge_interrupt(&self) -> (InterruptNumber, Priority) {
-        let mut cpu_ctrl = self.0.lock();
-        let (num, prio) = cpu_ctrl.acknowledge_interrupt();
-        (num as _, prio)
+    pub fn acknowledge_interrupt(&self) -> Option<(InterruptNumber, Priority)> {
+        let mut cpu_ctrl = lock!(self);
+        let opt = cpu_ctrl.acknowledge_interrupt(InterruptGroup::Group1);
+        opt.map(|(num, prio)| (num as _, prio))
     }
 
     pub fn init_secondary_cpu_interface(&self) {
-        let mut cpu_ctrl = self.0.lock();
+        let mut cpu_ctrl = lock!(self);
         cpu_ctrl.init_secondary_cpu_interface();
     }
 }

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -52,7 +52,7 @@ pub trait SystemInterruptControllerApi {
     fn set_destination(
         &self,
         sys_int_num: InterruptNumber,
-        destination: CpuId,
+        destination: Option<CpuId>,
         priority: Priority,
     ) -> Result<(), &'static str>;
 }

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -75,3 +75,42 @@ pub trait LocalInterruptControllerApi {
     /// Tell the interrupt controller that the current interrupt has been handled.
     fn end_of_interrupt(&self, number: InterruptNumber);
 }
+
+/// AArch64-specific methods of a local interrupt controller
+pub trait AArch64LocalInterruptControllerApi {
+    /// Same as [`LocalInterruptControllerApi::enable_local_interrupt`] but for fast interrupts (FIQs).
+    fn enable_fast_local_interrupt(&self, num: InterruptNumber, enabled: bool);
+
+    /// Same as [`LocalInterruptControllerApi::send_ipi`] but for fast interrupts (FIQs).
+    fn send_fast_ipi(&self, num: InterruptNumber, dest: InterruptDestination);
+
+    /// Reads the minimum priority for an interrupt to reach this CPU.
+    fn get_minimum_priority(&self) -> Priority;
+
+    /// Changes the minimum priority for an interrupt to reach this CPU.
+    fn set_minimum_priority(&self, priority: Priority);
+
+    /// Aarch64-specific way to read the current pending interrupt number & priority.
+    fn acknowledge_interrupt(&self) -> Option<(InterruptNumber, Priority)>;
+
+    /// Aarch64-specific way to initialize the secondary CPU interfaces.
+    ///
+    /// Must be called once from every secondary CPU.
+    fn init_secondary_cpu_interface(&self);
+
+    /// Same as [`Self::acknowledge_interrupt`] but for fast interrupts (FIQs)
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe because it circumvents the internal Mutex.
+    /// It must only be used by the `interrupts` crate when handling an FIQ.
+    unsafe fn acknowledge_fast_interrupt(&self) -> Option<(InterruptNumber, Priority)>;
+
+    /// Same as [`LocalInterruptControllerApi::end_of_interrupt`] but for fast interrupts (FIQs)
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe because it circumvents the internal Mutex.
+    /// It must only be used by the `interrupts` crate when handling an FIQ.
+    unsafe fn end_of_fast_interrupt(&self, number: InterruptNumber);
+}

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -60,13 +60,6 @@ pub trait SystemInterruptControllerApi {
 pub trait LocalInterruptControllerApi {
     fn get() -> &'static Self;
 
-    /// Aarch64-specific way to initialize the secondary CPU interfaces.
-    ///
-    /// Must be called once from every secondary CPU.
-    ///
-    /// Always panics on x86_64.
-    fn init_secondary_cpu_interface(&self);
-
     fn id(&self) -> LocalInterruptControllerId;
     fn get_local_interrupt_priority(&self, num: InterruptNumber) -> Priority;
     fn set_local_interrupt_priority(&self, num: InterruptNumber, priority: Priority);
@@ -78,21 +71,6 @@ pub trait LocalInterruptControllerApi {
     /// If `dest` is Some, the interrupt is sent to a specific CPU.
     /// If it's None, all CPUs except the sender receive the interrupt.
     fn send_ipi(&self, num: InterruptNumber, dest: InterruptDestination);
-
-    /// Reads the minimum priority for an interrupt to reach this CPU.
-    ///
-    /// Note: aarch64-only, at the moment.
-    fn get_minimum_priority(&self) -> Priority;
-
-    /// Changes the minimum priority for an interrupt to reach this CPU.
-    ///
-    /// Note: aarch64-only, at the moment.
-    fn set_minimum_priority(&self, priority: Priority);
-
-    /// Aarch64-specific way to read the current pending interrupt number & priority.
-    ///
-    /// Always panics on x86_64.
-    fn acknowledge_interrupt(&self) -> (InterruptNumber, Priority);
 
     /// Tell the interrupt controller that the current interrupt has been handled.
     fn end_of_interrupt(&self, number: InterruptNumber);

--- a/kernel/interrupt_controller/src/x86_64.rs
+++ b/kernel/interrupt_controller/src/x86_64.rs
@@ -73,10 +73,6 @@ impl LocalInterruptControllerApi for LocalInterruptController {
         unimplemented!()
     }
 
-    fn init_secondary_cpu_interface(&self) {
-        panic!("This must not be used on x86_64")
-    }
-
     fn id(&self) -> LocalInterruptControllerId {
         let int_ctlr = get_my_apic().expect("BUG: id(): get_my_apic() returned None");
         let int_ctlr = int_ctlr.read();
@@ -110,20 +106,6 @@ impl LocalInterruptControllerApi for LocalInterruptController {
             SpecificCpu(cpu) => LapicIpiDestination::One(cpu.into()),
             AllOtherCpus => LapicIpiDestination::AllButMe,
         });
-    }
-
-    fn get_minimum_priority(&self) -> Priority {
-        // No priority support on x86_64
-        Priority
-    }
-
-    fn set_minimum_priority(&self, priority: Priority) {
-        // No priority support on x86_64
-        let _ = priority;
-    }
-
-    fn acknowledge_interrupt(&self) -> (InterruptNumber, Priority) {
-        panic!("This must not be used on x86_64")
     }
 
     fn end_of_interrupt(&self, _number: InterruptNumber) {

--- a/kernel/interrupt_controller/src/x86_64.rs
+++ b/kernel/interrupt_controller/src/x86_64.rs
@@ -55,7 +55,7 @@ impl SystemInterruptControllerApi for SystemInterruptController {
     fn set_destination(
         &self,
         sys_int_num: InterruptNumber,
-        destination: CpuId,
+        destination: Option<CpuId>,
         priority: Priority,
     ) -> Result<(), &'static str> {
         let mut int_ctlr = get_ioapic(self.id).expect("BUG: set_destination(): get_ioapic() returned None");
@@ -63,7 +63,11 @@ impl SystemInterruptControllerApi for SystemInterruptController {
         // no support for priority on x86_64
         let _ = priority;
 
-        int_ctlr.set_irq(sys_int_num, destination.into(), sys_int_num /* <- is this correct? */)
+        if let Some(destination) = destination {
+            int_ctlr.set_irq(sys_int_num, destination.into(), sys_int_num /* <- is this correct? */)
+        } else {
+            Err("SystemInterruptController::set_destination: todo on x86")
+        }
     }
 }
 

--- a/kernel/interrupt_controller/src/x86_64.rs
+++ b/kernel/interrupt_controller/src/x86_64.rs
@@ -64,9 +64,9 @@ impl SystemInterruptControllerApi for SystemInterruptController {
         let _ = priority;
 
         if let Some(destination) = destination {
-            int_ctlr.set_irq(sys_int_num, destination.into(), sys_int_num /* <- is this correct? */)
+            int_ctlr.set_irq(sys_int_num, destination.into(), sys_int_num)
         } else {
-            Err("SystemInterruptController::set_destination: todo on x86")
+            Err("SystemInterruptController::set_destination: todo on x86: set the IOREDTBL MASK bit")
         }
     }
 }

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -438,6 +438,11 @@ extern "C" fn current_elx_synchronous(e: &mut ExceptionContext) {
     default_exception_handler(e, "current_elx_synchronous");
 }
 
+// When this is entered, FIQs are enabled / unmasked, because we use
+// them as an NMI alternative, so they must be allowed at all times.
+//
+// Spurious interrupts are often the result of an FIQ being handled
+// after we started handling an IRQ but before we acknowledged it.
 #[no_mangle]
 extern "C" fn current_elx_irq(exc: &mut ExceptionContext) {
     let (irq_num, _priority) = {
@@ -463,6 +468,10 @@ extern "C" fn current_elx_irq(exc: &mut ExceptionContext) {
     }
 }
 
+// When this is entered, FIQs are disabled / masked: there must be
+// only one FIQ (that we use as an NMI alternative) at a time.
+//
+// Currently, FIQs are only used for TLB shootdown.
 #[no_mangle]
 extern "C" fn current_elx_fiq(exc: &mut ExceptionContext) {
     let (irq_num, _priority) = {

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -308,8 +308,16 @@ pub fn deregister_interrupt(int_num: InterruptNumber, func: InterruptHandler) ->
     }
 }
 
+/// Broadcast an Inter-Processor Interrupt to all other CPU cores in the system
+pub fn broadcast_ipi(ipi_num: InterruptNumber) {
+    let int_ctrl = LocalInterruptController::get();
+    int_ctrl.send_ipi(ipi_num, InterruptDestination::AllOtherCpus);
+}
+
 /// Broadcast the TLB Shootdown Inter-Processor Interrupt to all other
 /// CPU cores in the system
+///
+/// This IPI uses fast interrupts (FIQs) as an NMI alternative.
 pub fn broadcast_tlb_shootdown_ipi() {
     let int_ctrl = LocalInterruptController::get();
     int_ctrl.send_fast_ipi(TLB_SHOOTDOWN_IPI, InterruptDestination::AllOtherCpus);

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -204,7 +204,7 @@ pub fn setup_tlb_shootdown_handler(handler: InterruptHandler) -> Result<(), &'st
 /// Enables the PL011 "RX" SPI and routes it to the current CPU.
 pub fn init_pl011_rx_interrupt() -> Result<(), &'static str> {
     let int_ctrl = SystemInterruptController::get();
-    int_ctrl.set_destination(PL011_RX_SPI, current_cpu(), u8::MAX)
+    int_ctrl.set_destination(PL011_RX_SPI, Some(current_cpu()), u8::MAX)
 }
 
 /// Disables the timer, schedules its next tick, and re-enables it

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -11,7 +11,7 @@ use tock_registers::registers::InMemoryRegister;
 
 use interrupt_controller::{
     LocalInterruptController, SystemInterruptController, InterruptDestination,
-    LocalInterruptControllerApi, SystemInterruptControllerApi,
+    LocalInterruptControllerApi, AArch64LocalInterruptControllerApi, SystemInterruptControllerApi,
 };
 use kernel_config::time::CONFIG_TIMESLICE_PERIOD_MICROSECONDS;
 use arm_boards::BOARD_CONFIG;

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -424,7 +424,6 @@ extern "C" fn current_elx_irq(exc: &mut ExceptionContext) {
             // will use LocalInterruptController
             eoi(irq_num);
         }
-        return;
     } else {
         log::error!("Unhandled IRQ: {}\r\n{:?}\r\n[looping forever now]", irq_num, exc);
         loop { core::hint::spin_loop() }
@@ -450,7 +449,6 @@ extern "C" fn current_elx_fiq(exc: &mut ExceptionContext) {
             let int_ctrl = LocalInterruptController::get();
             unsafe { int_ctrl.end_of_fast_interrupt(irq_num) };
         }
-        return;
     } else {
         log::error!("Unhandled FIQ: {}\r\n{:?}\r\n[looping forever now]", irq_num, exc);
         loop { core::hint::spin_loop() }

--- a/kernel/interrupts/src/aarch64/table.s
+++ b/kernel/interrupts/src/aarch64/table.s
@@ -77,6 +77,7 @@ __exception_vector_start:
 .org 0x200
     CALL_WITH_CONTEXT current_elx_synchronous
 .org 0x280
+    // this first instruction re-enables (unmasks) fast interrupts so that IRQs can be interrupted by FIQs.
     msr daifclr, #1
     CALL_WITH_CONTEXT current_elx_irq
 .org 0x300

--- a/kernel/interrupts/src/aarch64/table.s
+++ b/kernel/interrupts/src/aarch64/table.s
@@ -77,9 +77,10 @@ __exception_vector_start:
 .org 0x200
     CALL_WITH_CONTEXT current_elx_synchronous
 .org 0x280
+    msr daifclr, #1
     CALL_WITH_CONTEXT current_elx_irq
 .org 0x300
-    FIQ_SUSPEND
+    CALL_WITH_CONTEXT current_elx_fiq
 .org 0x380
     CALL_WITH_CONTEXT current_elx_serror
 

--- a/kernel/memory_aarch64/src/lib.rs
+++ b/kernel/memory_aarch64/src/lib.rs
@@ -16,24 +16,50 @@ use pte_flags::PteFlags;
 use boot_info::{BootInformation, ElfSection};
 use kernel_config::memory::KERNEL_OFFSET;
 
-#[cfg(any(target_arch = "aarch64", doc))]
+#[cfg(target_arch = "aarch64")]
 use core::arch::asm;
 
 const THESEUS_ASID: u16 = 0;
 
-#[cfg(any(target_arch = "aarch64", doc))]
 /// Flushes the specific virtual address in TLB.
 ///
 /// TLBI => tlb invalidate instruction
-/// "va" => all translations at execution level
-///         using the supplied address
+/// "va" => all translations at execution level using the supplied address
 /// "e1" => execution level
 pub fn tlb_flush_virt_addr(vaddr: VirtualAddress) {
     #[cfg(target_arch = "aarch64")]
-    unsafe { asm!("tlbi vae1, {}", in(reg) vaddr.value()) };
+    unsafe {
+        // unsure here: where should the original address ASID go?
+        // it's zero in theseus so it's not important for us
+
+        // about the 48 bit shift:
+        // If the implementation supports 16 bits of ASID, then the
+        // upper 8 bits of the ASID must be written to 0 by software
+        // when the context being invalidated only uses 8 bits
+        let value = ((THESEUS_ASID as usize) << 48) | (vaddr.value() >> 12);
+        asm!("tlbi vae1, {}", in(reg) value)
+    };
 }
 
-#[cfg(any(target_arch = "aarch64", doc))]
+/* NO SUPPORT IN QEMU
+
+/// Flushes the specific virtual address in the TLB of any CPU
+/// in the outer shareable domain.
+///
+/// TLBI => tlb invalidate instruction
+/// "va" => all translations at execution level using the supplied address
+/// "e1" => execution level
+/// "os" => outer shareable domain
+pub fn tlb_flush_virt_addr_all_cpus(vaddr: VirtualAddress) {
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        let value = ((THESEUS_ASID as usize) << 48) | (vaddr.value() >> 12);
+        asm!(".arch armv8.4-a\ntlbi vae1os, {}", in(reg) value)
+    };
+}
+
+*/
+
 /// Flushes all TLB entries with Theseus' ASID (=0).
 ///
 /// TLBI => tlb invalidate instruction
@@ -44,7 +70,6 @@ pub fn tlb_flush_by_theseus_asid() {
     unsafe { asm!("tlbi aside1, {:x}", in(reg) THESEUS_ASID) };
 }
 
-#[cfg(any(target_arch = "aarch64", doc))]
 pub use tlb_flush_by_theseus_asid as tlb_flush_all;
 
 /// Returns the current top-level page table address.

--- a/kernel/memory_aarch64/src/lib.rs
+++ b/kernel/memory_aarch64/src/lib.rs
@@ -21,11 +21,13 @@ use core::arch::asm;
 
 const THESEUS_ASID: u16 = 0;
 
+/* allow attribute is there for cross-platform doc building */
 /// Flushes the specific virtual address in TLB.
 ///
 /// TLBI => tlb invalidate instruction
 /// "va" => all translations at execution level using the supplied address
 /// "e1" => execution level
+#[allow(unused_variables)]
 pub fn tlb_flush_virt_addr(vaddr: VirtualAddress) {
     #[cfg(target_arch = "aarch64")]
     unsafe {

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -87,6 +87,7 @@ fn nano_core<B>(
 where
     B: boot_info::BootInformation
 {
+    irq_safety::disable_fast_interrupts();
     irq_safety::disable_interrupts();
     println!("nano_core(): Entered early setup. Interrupts disabled.");
 
@@ -131,7 +132,7 @@ where
         let logger_ports = [take_serial_port(SerialPortAddress::COM1)];
         logger::early_init(None, IntoIterator::into_iter(logger_ports).flatten());
         log::info!("initialized early logger with aarch64 serial ports.");
-        println!("nano_core(): initialized early logger  with aarch64 serial ports.");
+        println!("nano_core(): initialized early logger with aarch64 serial ports.");
     }
 
     println!("nano_core(): initialized memory subsystem.");

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -87,8 +87,10 @@ fn nano_core<B>(
 where
     B: boot_info::BootInformation
 {
-    irq_safety::disable_fast_interrupts();
     irq_safety::disable_interrupts();
+    #[cfg(target_arch = "aarch64")]
+    irq_safety::disable_fast_interrupts();
+
     println!("nano_core(): Entered early setup. Interrupts disabled.");
 
     #[cfg(target_arch = "x86_64")]

--- a/kernel/tlb_shootdown/src/lib.rs
+++ b/kernel/tlb_shootdown/src/lib.rs
@@ -40,7 +40,8 @@ pub fn init() {
 pub fn handle_tlb_shootdown_ipi() -> bool {
     let pages_to_invalidate = TLB_SHOOTDOWN_IPI_PAGES.read().clone();
     if let Some(pages) = pages_to_invalidate {
-        // THIS LOG USAGE CAN CAUSE A DEADLOCK ON AARCH64
+        // Note: logging in a NMI (x86_64) or FIQ (aarch64) context can cause deadlock,
+        // so this should only be used sparingly to help debug problems with TLB shootdowns.
         // log::trace!("handle_tlb_shootdown_ipi(): CPU {}, pages: {:?}", apic::current_cpu(), pages);
         for page in pages {
             tlb_flush_virt_addr(page.start_address());

--- a/kernel/tlb_shootdown/src/lib.rs
+++ b/kernel/tlb_shootdown/src/lib.rs
@@ -28,7 +28,7 @@ pub fn init() {
     memory::set_broadcast_tlb_shootdown_cb(broadcast_tlb_shootdown);
 
     #[cfg(target_arch = "aarch64")]
-    interrupts::setup_ipi_handler(tlb_shootdown_ipi_handler, interrupts::TLB_SHOOTDOWN_IPI).unwrap();
+    interrupts::setup_tlb_shootdown_handler(tlb_shootdown_ipi_handler).unwrap();
 }
 
 /// Handles a TLB shootdown IPI requested by another CPU.
@@ -40,6 +40,7 @@ pub fn init() {
 pub fn handle_tlb_shootdown_ipi() -> bool {
     let pages_to_invalidate = TLB_SHOOTDOWN_IPI_PAGES.read().clone();
     if let Some(pages) = pages_to_invalidate {
+        // THIS LOG USAGE CAN CAUSE A DEADLOCK ON AARCH64
         // log::trace!("handle_tlb_shootdown_ipi(): CPU {}, pages: {:?}", apic::current_cpu(), pages);
         for page in pages {
             tlb_flush_virt_addr(page.start_address());
@@ -97,7 +98,7 @@ fn broadcast_tlb_shootdown(pages_to_invalidate: PageRange) {
     }
 
     #[cfg(target_arch = "aarch64")]
-    interrupts::send_ipi_to_all_other_cpus(interrupts::TLB_SHOOTDOWN_IPI);
+    interrupts::broadcast_tlb_shootdown_ipi();
 
     // wait for all other cores to handle this IPI
     // it must be a blocking, synchronous operation to ensure stale TLB entries don't cause problems
@@ -111,6 +112,10 @@ fn broadcast_tlb_shootdown(pages_to_invalidate: PageRange) {
 
     // release lock
     TLB_SHOOTDOWN_IPI_LOCK.store(false, Ordering::Release); 
+
+    if false {
+        log::warn!("send_tlb_shootdown_ipi(): from CPU {:?}, complete", cpu::current_cpu());
+    }
 }
 
 /// Interrupt Handler for TLB Shootdowns on aarch64


### PR DESCRIPTION
Sometimes when we tried spawning an interactive console in theseus on aarch64, by sending keystrokes through the UART port, theseus hanged.

We then found out that a complicated scenario was taking place:
- the console task was spawned and scheduled but the sub-tasks it spawned in turn were not running
- in fact two of the four cores were stopped, so they were ghosting the tasks randomly assigned to them...
- they were stopped because they tried to broadcast an interrupt to other cores, which is an NMI on x86 but I had implemented it as a regular interrupt on aarch64, early in the port process, without leaving a clear TODO/warning... big mistake: the two missing cores were silently clashing on this
- I reimplemented this using fast interrupts, which highlighted some other bugs but ultimately fixed the issue

This brings the following changes:
- The interrupt controller API only contains cross-platform features, other features are not part of the trait. This made it easier to support FIQs on aarch64, but it could become a separate trait: Aarch64LocalInterruptController.
- Aarch64-specific methods of the LocalInterruptController allow configuring/handling fast interrupts (FIQs).
- The interrupt controller now allows enabling/disabling SPIs too (this was missing).
- The GIC driver was updated with Group 0 (used by FIQs) interrupt support.
- A bug in memory_aarch64 was fixed (a shift operation was missing).
- A silent bug recently introduced in context_switch_regular was fixed (incorrect structure size assumption, fixed by padding the structure, which makes the assembly and memory layout easier to understand).
- The `interrupts` crate was modified to handle FIQs.
- The TLB Shootdown crate now uses FIQs on aarch64 as an NMI alternative.
- nano_core, captain and ap_start were modified to set FIQ masks correctly.

This depend on [a PR in irq_safety](https://github.com/theseus-os/irq_safety/pull/10), so it doesn't build at this moment.