### PR TITLE
fix: set `inner.pinned_cpu` for pinned tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3487,6 +3487,7 @@ dependencies = [
  "spin 0.9.4",
  "stack",
  "task",
+ "task_struct",
  "thread_local_macro",
 ]
 

--- a/kernel/spawn/Cargo.toml
+++ b/kernel/spawn/Cargo.toml
@@ -18,6 +18,7 @@ stack = { path = "../stack" }
 cpu = { path = "../cpu" }
 preemption = { path = "../preemption" }
 task = { path = "../task" }
+task_struct = { path = "../task_struct" }
 runqueue = { path = "../runqueue" }
 scheduler = { path = "../scheduler" }
 mod_mgmt = { path = "../mod_mgmt" }

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -31,6 +31,7 @@ use spin::Mutex;
 use memory::{get_kernel_mmi_ref, MmiRef};
 use stack::Stack;
 use task::{Task, TaskRef, RestartInfo, RunState, JoinableTaskRef, ExitableTaskRef, FailureCleanupFunction};
+use task_struct::ExposedTask;
 use mod_mgmt::{CrateNamespace, SectionType, SECTION_HASH_DELIMITER};
 use path::Path;
 use fs_node::FileOrDir;
@@ -381,7 +382,11 @@ impl<F, A, R> TaskBuilder<F, A, R>
         )?;
         // If a Task name wasn't provided, then just use the function's name.
         new_task.name = self.name.unwrap_or_else(|| String::from(core::any::type_name::<F>()));
-    
+
+        let exposed = ExposedTask { task: new_task };
+        exposed.inner().lock().pinned_cpu = self.pin_on_cpu;
+        let ExposedTask { task: mut new_task } = exposed;    
+
         #[cfg(simd_personality)] {  
             new_task.simd = self.simd;
         }


### PR DESCRIPTION
When spawning a pinned task, `spawn` didn't previously set `inner.pinned_cpu`. This created problems in #1042 because the scheduler didn't know that tasks were pinned and freely migrated them across cores.