### PR TITLE
Redesign the interrupt controller crate; support x86_64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,12 +1573,14 @@ dependencies = [
 name = "interrupt_controller"
 version = "0.1.0"
 dependencies = [
+ "acpi",
  "apic",
  "arm_boards",
  "cpu",
  "gic",
  "ioapic",
  "log",
+ "madt",
  "memory",
  "spin 0.9.4",
  "sync_irq",

--- a/kernel/acpi/madt/src/lib.rs
+++ b/kernel/acpi/madt/src/lib.rs
@@ -355,7 +355,7 @@ fn handle_bsp_lapic_entry(madt_iter: MadtIter, page_table: &mut PageTable) -> Re
 
             // Redirect every IoApic's interrupts to the one BSP.
             // TODO: long-term, we should distribute interrupts across CPUs more evenly.
-            for (_ioapic_id, ioapic) in ioapic::get_ioapics().iter() {
+            for (_ioapic_id, ioapic) in ioapic::get_ioapics() {
                 let mut ioapic_ref = ioapic.lock();
 
                 // Set the BSP to receive regular PIC interrupts routed through the IoApic.
@@ -380,7 +380,7 @@ fn handle_bsp_lapic_entry(madt_iter: MadtIter, page_table: &mut PageTable) -> Re
             let mut handled = false;
 
             // find the IoApic that should handle this interrupt source override entry
-            for (_id, ioapic) in ioapic::get_ioapics().iter() {
+            for (_id, ioapic) in ioapic::get_ioapics() {
                 let mut ioapic_ref = ioapic.lock();
                 if ioapic_ref.handles_irq(int_src.gsi) {
                     // using BSP for now, but later we could redirect the IRQ to more (or all) cores

--- a/kernel/acpi/src/lib.rs
+++ b/kernel/acpi/src/lib.rs
@@ -86,13 +86,6 @@ pub fn init(rsdp_address: Option<PhysicalAddress>, page_table: &mut PageTable) -
             warn!("This machine has no HPET.");
         }
     };
-    
-    // MADT is mandatory
-    {
-        let acpi_tables = ACPI_TABLES.lock();
-        let madt = madt::Madt::get(&acpi_tables).ok_or("The required MADT ACPI table wasn't found (signature 'APIC')")?;
-        madt.bsp_init(page_table)?;
-    }
 
     // If we have a DMAR table, use it to obtain IOMMU info. 
     {

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -93,19 +93,17 @@ pub fn init(
         log::warn!("Couldn't get TSC period");
     }
 
-    // now we initialize early driver stuff, like APIC/ACPI
-    // arch-gate: device_manager currently detects PCI & PS2 devices,
-    // which are unsupported on aarch64 at this point
+    // Initialize early devices, which currently only includes ACPI (x86-specific).
     #[cfg(target_arch = "x86_64")]
     device_manager::early_init(rsdp_address, kernel_mmi_ref.lock().deref_mut())?;
 
-    // initialize the rest of the BSP's interrupt stuff, including TSS & GDT
+    // Initialize local and system-wide interrupt controllers.
+    interrupt_controller::init(&kernel_mmi_ref)?;
+    
+    // Initialize other arch-specific interrupt stuff, e.g., basic interrupt handlers.
     // arch-gate: the IDT & special stacks are x86_64 specific
     #[cfg(target_arch = "x86_64")]
     let idt = {
-        // does nothing at the moment on x86_64
-        interrupt_controller::init()?;
-
         let (double_fault_stack, privilege_stack) = {
             let mut kernel_mmi = kernel_mmi_ref.lock();
             (
@@ -119,9 +117,6 @@ pub fn init(
     };
 
     #[cfg(target_arch = "aarch64")] {
-        // Initialize the GIC
-        interrupt_controller::init()?;
-
         interrupts::init()?;
         irq_safety::enable_fast_interrupts();
 

--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -21,18 +21,13 @@ use {
 /// Performs early-stage initialization for simple devices needed during early boot.
 ///
 /// This includes:
-/// * local APICs ([`apic`]),
 /// * [`acpi`] tables for system configuration info, including the IOAPIC.
 #[cfg(target_arch = "x86_64")]
 pub fn early_init(
     rsdp_address: Option<PhysicalAddress>,
     kernel_mmi: &mut MemoryManagementInfo
 ) -> Result<(), &'static str> {
-    // First, initialize the local APIC hardware such that we can populate
-    // and initialize each LocalAPIC discovered in the ACPI table initialization routine below.
-    apic::init();
-    
-    // Then, parse the ACPI tables to acquire system configuration info.
+    // Parse the ACPI tables to acquire system configuration info.
     acpi::init(rsdp_address, &mut kernel_mmi.page_table)?;
 
     Ok(())

--- a/kernel/interrupt_controller/Cargo.toml
+++ b/kernel/interrupt_controller/Cargo.toml
@@ -17,7 +17,6 @@ sync_irq = { path = "../../libs/sync_irq" }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 arm_boards = { path = "../arm_boards" }
-memory = { path = "../memory" }
 gic = { path = "../gic" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/kernel/interrupt_controller/Cargo.toml
+++ b/kernel/interrupt_controller/Cargo.toml
@@ -1,21 +1,27 @@
 [package]
-authors = ["Nathan Royer <nathan.royer.pro@gmail.com>"]
-description = "Cross-platform abstraction over interrupt controllers"
-version = "0.1.0"
-edition = "2021"
 name = "interrupt_controller"
+version = "0.1.0"
+authors = [
+    "Nathan Royer <nathan.royer.pro@gmail.com>",
+    "Kevin Boos <kevinaboos@gmail.com>",
+]
+description = "Cross-platform abstraction over interrupt controllers"
+edition = "2021"
 
 [dependencies]
 log = "0.4.8"
 cpu = { path = "../cpu" }
+memory = { path = "../memory" }
+spin = "0.9.4"
+sync_irq = { path = "../../libs/sync_irq" }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-sync_irq = { path = "../../libs/sync_irq" }
 arm_boards = { path = "../arm_boards" }
 memory = { path = "../memory" }
 gic = { path = "../gic" }
-spin = "0.9.4"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
+acpi = { path = "../acpi" }
 apic = { path = "../apic" }
 ioapic = { path = "../ioapic" }
+madt = { path = "../acpi/madt" }

--- a/kernel/interrupt_controller/src/aarch64.rs
+++ b/kernel/interrupt_controller/src/aarch64.rs
@@ -140,7 +140,7 @@ impl SystemInterruptControllerApi for SystemInterruptController {
 }
 
 
-/// Struct representing per-CPU interrupt controller chips.
+/// Struct representing a per-CPU interrupt controller chip.
 ///
 /// On aarch64 w/ GIC, this corresponds to a Redistributor & CPU interface.
 ///

--- a/kernel/interrupt_controller/src/lib.rs
+++ b/kernel/interrupt_controller/src/lib.rs
@@ -1,3 +1,5 @@
+//! Support for accessing interupt controllers across multiple architectures.
+
 #![no_std]
 #![allow(unused_variables, unused_mut)]
 #![feature(array_try_from_fn)]
@@ -6,14 +8,11 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use cpu::CpuId;
+use memory::MmiRef;
 
-#[cfg(target_arch = "aarch64")]
-#[path = "aarch64.rs"]
-pub mod arch;
-
-#[cfg(target_arch = "x86_64")]
-#[path = "x86_64.rs"]
-pub mod arch;
+#[cfg_attr(target_arch = "x86_64", path = "x86_64.rs")]
+#[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
+mod arch;
 
 pub use arch::{
     SystemInterruptControllerVersion,
@@ -22,12 +21,30 @@ pub use arch::{
     Priority,
     SystemInterruptController,
     LocalInterruptController,
-    init,
 };
+
+#[cfg(target_arch = "aarch64")]
+pub use arch::AArch64LocalInterruptControllerApi;
 
 pub type InterruptNumber = u8;
 
-/// The Cpu where this interrupt should be handled, as well as
+
+/// Initializes the interrupt controller(s) on this system.
+///
+/// Depending on the architecture, this includes both the system-wide
+/// interrupt controller(s) and one or more local (per-CPU) interrupt controllers.
+/// * On x86_64 systems, this initializes the I/O APIC(s) (there may be more than one)
+///   as the system-wide interrupt controller(s), and the Local APIC for the BSP
+///   (bootstrap processor) only as the first local interrupt controller.
+///   * Other Local APICs are initialized by those CPUs when they are brought online.
+/// * On aarch64 systems with GIC, this initializes both the system-wide
+///   interrupt controller (the GIC Distributor) as well as the local controllers
+///   for all CPUs (their Redistributors and CPU interfaces).
+pub fn init(kernel_mmi: &MmiRef) -> Result<(), &'static str> {
+    arch::init(kernel_mmi)
+}
+
+/// The CPU where an interrupt should be handled, as well as
 /// the local interrupt number this gets translated to.
 ///
 /// On aarch64, there is no `local_number` field as the system interrupt
@@ -38,79 +55,52 @@ pub enum InterruptDestination {
     AllOtherCpus,
 }
 
+/// Functionality provided by system-wide interrupt controllers.
+///
+/// Note that a system may actually have *multiple* system-wide interrupt controllers.
+///
+/// * On x86_64, this corresponds to an I/O APIC (IOAPIC).
+/// * On aarch64 (with GIC), this corresponds to the Distributor.
 pub trait SystemInterruptControllerApi {
-    fn get() -> &'static Self;
-
+    /// Returns the unique ID of this system-wide interrupt controller.
     fn id(&self) -> SystemInterruptControllerId;
+
+    /// Returns the version ID of this system-wide interrupt controller.
     fn version(&self) -> SystemInterruptControllerVersion;
 
+    /// Returns the destination(s) that the given `interrupt` is routed to
+    /// by this system-wide interrupt controller.
     fn get_destination(
         &self,
-        interrupt_num: InterruptNumber,
+        interrupt: InterruptNumber,
     ) -> Result<(Vec<CpuId>, Priority), &'static str>;
-
+    
+    /// Routes the given `interrupt` to the given `destination` with the given `priority`. 
     fn set_destination(
         &self,
-        sys_int_num: InterruptNumber,
+        interrupt: InterruptNumber,
         destination: Option<CpuId>,
         priority: Priority,
     ) -> Result<(), &'static str>;
 }
 
+/// Functionality provided by local interrupt controllers,
+/// which exist on a per-CPU basis.
+///
+/// * On x86_64, this corresponds to a Local APIC.
+/// * On aarch64 (with GIC), this corresponds to the GIC Redistributor + CPU interface.
 pub trait LocalInterruptControllerApi {
-    fn get() -> &'static Self;
-
+    /// Returns the unique ID of this local interrupt controller.
     fn id(&self) -> LocalInterruptControllerId;
-    fn get_local_interrupt_priority(&self, num: InterruptNumber) -> Priority;
-    fn set_local_interrupt_priority(&self, num: InterruptNumber, priority: Priority);
-    fn is_local_interrupt_enabled(&self, num: InterruptNumber) -> bool;
-    fn enable_local_interrupt(&self, num: InterruptNumber, enabled: bool);
+    
+    /// Enables or disables the local timer interrupt for this local interrupt controller.
+    fn enable_local_timer_interrupt(&self, enable: bool);
 
-    /// Sends an inter-processor interrupt.
-    ///
-    /// If `dest` is Some, the interrupt is sent to a specific CPU.
-    /// If it's None, all CPUs except the sender receive the interrupt.
+    /// Sends an inter-processor interrupt from this local interrupt controller
+    /// to the given destination.
     fn send_ipi(&self, num: InterruptNumber, dest: InterruptDestination);
 
-    /// Tell the interrupt controller that the current interrupt has been handled.
+    /// Tells this local interrupt controller that the interrupt being currently serviced
+    /// has been completely handled.
     fn end_of_interrupt(&self, number: InterruptNumber);
-}
-
-/// AArch64-specific methods of a local interrupt controller
-pub trait AArch64LocalInterruptControllerApi {
-    /// Same as [`LocalInterruptControllerApi::enable_local_interrupt`] but for fast interrupts (FIQs).
-    fn enable_fast_local_interrupt(&self, num: InterruptNumber, enabled: bool);
-
-    /// Same as [`LocalInterruptControllerApi::send_ipi`] but for fast interrupts (FIQs).
-    fn send_fast_ipi(&self, num: InterruptNumber, dest: InterruptDestination);
-
-    /// Reads the minimum priority for an interrupt to reach this CPU.
-    fn get_minimum_priority(&self) -> Priority;
-
-    /// Changes the minimum priority for an interrupt to reach this CPU.
-    fn set_minimum_priority(&self, priority: Priority);
-
-    /// Aarch64-specific way to read the current pending interrupt number & priority.
-    fn acknowledge_interrupt(&self) -> Option<(InterruptNumber, Priority)>;
-
-    /// Aarch64-specific way to initialize the secondary CPU interfaces.
-    ///
-    /// Must be called once from every secondary CPU.
-    fn init_secondary_cpu_interface(&self);
-
-    /// Same as [`Self::acknowledge_interrupt`] but for fast interrupts (FIQs)
-    ///
-    /// # Safety
-    ///
-    /// This is unsafe because it circumvents the internal Mutex.
-    /// It must only be used by the `interrupts` crate when handling an FIQ.
-    unsafe fn acknowledge_fast_interrupt(&self) -> Option<(InterruptNumber, Priority)>;
-
-    /// Same as [`LocalInterruptControllerApi::end_of_interrupt`] but for fast interrupts (FIQs)
-    ///
-    /// # Safety
-    ///
-    /// This is unsafe because it circumvents the internal Mutex.
-    /// It must only be used by the `interrupts` crate when handling an FIQ.
-    unsafe fn end_of_fast_interrupt(&self, number: InterruptNumber);
 }

--- a/kernel/interrupt_controller/src/x86_64.rs
+++ b/kernel/interrupt_controller/src/x86_64.rs
@@ -1,9 +1,10 @@
 use super::*;
 
-use {
-    apic::{get_my_apic, LapicIpiDestination},
-    ioapic::get_ioapic,
-};
+use apic::{LocalApic, LapicIpiDestination};
+use ioapic::IoApic;
+use madt::Madt;
+use spin::Mutex;
+use sync_irq::IrqSafeRwLock;
 
 #[derive(Debug, Copy, Clone)]
 pub struct SystemInterruptControllerVersion(pub u32);
@@ -14,35 +15,38 @@ pub struct LocalInterruptControllerId(pub u32);
 #[derive(Debug, Copy, Clone)]
 pub struct Priority;
 
-/// Initializes the interrupt controller (not yet used on x86)
-pub fn init() -> Result<(), &'static str> { Ok(()) }
+/// Initializes the interrupt controller(s), including the Local APIC for the BSP
+/// (bootstrap processor) and the system-wide IOAPIC(s).
+pub fn init(kernel_mmi: &memory::MmiRef) -> Result<(), &'static str> {
+    apic::init();
+
+    // Use the MADT ACPI table to initialize more interrupt controller details.
+    {
+        let acpi_tables = acpi::get_acpi_tables().lock();
+        let madt = Madt::get(&acpi_tables)
+            .ok_or("The required MADT ACPI table wasn't found (signature 'APIC')")?;
+        madt.bsp_init(&mut kernel_mmi.lock().page_table)?;
+    }
+
+    Ok(())
+}
 
 /// Structure representing a top-level/system-wide interrupt controller chip,
 /// responsible for routing interrupts between peripherals and CPU cores.
 ///
 /// On x86_64, this corresponds to an IoApic.
-pub struct SystemInterruptController {
-    id: u8,
-}
+pub struct SystemInterruptController(&'static Mutex<IoApic>);
 
-/// Struct representing per-cpu-core interrupt controller chips.
-///
-/// On x86_64, this corresponds to a LocalApic.
-pub struct LocalInterruptController;
+// TODO: implement `SystemInterruptController::get()` for IOAPIC,
+//       but it needs to be able to handle multiple IOAPICs.
 
 impl SystemInterruptControllerApi for SystemInterruptController {
-    fn get() -> &'static Self {
-        unimplemented!()
-    }
-
     fn id(&self) -> SystemInterruptControllerId {
-        let mut int_ctlr = get_ioapic(self.id).expect("BUG: id(): get_ioapic() returned None");
-        SystemInterruptControllerId(int_ctlr.id())
+        SystemInterruptControllerId(self.0.lock().id())
     }
 
     fn version(&self) -> SystemInterruptControllerVersion {
-        let mut int_ctlr = get_ioapic(self.id).expect("BUG: version(): get_ioapic() returned None");
-        SystemInterruptControllerVersion(int_ctlr.version())
+        SystemInterruptControllerVersion(self.0.lock().version())
     }
 
     fn get_destination(
@@ -58,65 +62,50 @@ impl SystemInterruptControllerApi for SystemInterruptController {
         destination: Option<CpuId>,
         priority: Priority,
     ) -> Result<(), &'static str> {
-        let mut int_ctlr = get_ioapic(self.id).expect("BUG: set_destination(): get_ioapic() returned None");
-
         // no support for priority on x86_64
         let _ = priority;
 
         if let Some(destination) = destination {
-            int_ctlr.set_irq(sys_int_num, destination.into(), sys_int_num)
+            self.0.lock().set_irq(sys_int_num, destination.into(), sys_int_num)
         } else {
-            Err("SystemInterruptController::set_destination: todo on x86: set the IOREDTBL MASK bit")
+            todo!("SystemInterruptController::set_destination: todo on x86: set the IOREDTBL MASK bit")
         }
     }
 }
 
 
+/// Struct representing per-cpu-core interrupt controller chips.
+///
+/// On x86_64, this corresponds to a LocalApic.
+pub struct LocalInterruptController(&'static IrqSafeRwLock<LocalApic>);
+impl LocalInterruptController {
+    /// Returns a reference to the current CPU's local interrupt controller,
+    /// if it has been initialized.
+    pub fn get() -> Option<Self> {
+        apic::get_my_apic().map(Self)
+    }
+}
+
 impl LocalInterruptControllerApi for LocalInterruptController {
-    fn get() -> &'static Self {
-        unimplemented!()
-    }
-
     fn id(&self) -> LocalInterruptControllerId {
-        let int_ctlr = get_my_apic().expect("BUG: id(): get_my_apic() returned None");
-        let int_ctlr = int_ctlr.read();
-        LocalInterruptControllerId(int_ctlr.processor_id())
+        LocalInterruptControllerId(self.0.read().apic_id().value())
     }
 
-    fn get_local_interrupt_priority(&self, num: InterruptNumber) -> Priority {
-        // No priority support on x86_64
-        Priority
-    }
-
-    fn set_local_interrupt_priority(&self, num: InterruptNumber, priority: Priority) {
-        // No priority support on x86_64
-        let _ = priority;
-    }
-
-    fn is_local_interrupt_enabled(&self, num: InterruptNumber) -> bool {
-        todo!()
-    }
-
-    fn enable_local_interrupt(&self, num: InterruptNumber, enabled: bool) {
-        todo!()
+    fn enable_local_timer_interrupt(&self, enable: bool) {
+        self.0.write().enable_lvt_timer(enable)
     }
 
     fn send_ipi(&self, num: InterruptNumber, dest: InterruptDestination) {
         use InterruptDestination::*;
 
-        let mut int_ctlr = get_my_apic().expect("BUG: send_ipi(): get_my_apic() returned None");
-        let mut int_ctlr = int_ctlr.write();
-        int_ctlr.send_ipi(num, match dest {
+        self.0.write().send_ipi(num, match dest {
             SpecificCpu(cpu) => LapicIpiDestination::One(cpu.into()),
             AllOtherCpus => LapicIpiDestination::AllButMe,
         });
     }
 
     fn end_of_interrupt(&self, _number: InterruptNumber) {
-        let mut int_ctlr = get_my_apic().expect("BUG: end_of_interrupt(): get_my_apic() returned None");
-        let mut int_ctlr = int_ctlr.write();
-
-        // On x86, passing the number isn't required.
-        int_ctlr.eoi();
+        // When using APIC, we don't need to pass in an IRQ number.
+        self.0.write().eoi();
     }
 }

--- a/kernel/interrupt_controller/src/x86_64.rs
+++ b/kernel/interrupt_controller/src/x86_64.rs
@@ -74,7 +74,7 @@ impl SystemInterruptControllerApi for SystemInterruptController {
 }
 
 
-/// Struct representing per-cpu-core interrupt controller chips.
+/// Struct representing a per-CPU interrupt controller chip.
 ///
 /// On x86_64, this corresponds to a LocalApic.
 pub struct LocalInterruptController(&'static IrqSafeRwLock<LocalApic>);

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -178,7 +178,7 @@ pub fn init_timer(timer_tick_handler: InterruptHandler) -> Result<(), &'static s
     // Route the IRQ to this core (implicit as IRQ < 32) & Enable the interrupt.
     {
         let int_ctrl = LocalInterruptController::get()
-    .expect("LocalInterruptController was not yet initialized");
+            .expect("LocalInterruptController was not yet initialized");
 
         // enable routing of this interrupt
         int_ctrl.enable_local_interrupt(CPU_LOCAL_TIMER_IRQ, true);
@@ -201,7 +201,7 @@ pub fn setup_ipi_handler(handler: InterruptHandler, local_num: InterruptNumber) 
 
     {
         let int_ctrl = LocalInterruptController::get()
-    .expect("LocalInterruptController was not yet initialized");
+            .expect("LocalInterruptController was not yet initialized");
 
         // enable routing of this interrupt
         int_ctrl.enable_local_interrupt(local_num, true);
@@ -224,7 +224,7 @@ pub fn setup_tlb_shootdown_handler(handler: InterruptHandler) -> Result<(), &'st
     {
         // enable this interrupt as a Fast interrupt (FIQ / Group 0 interrupt)
         let int_ctrl = LocalInterruptController::get()
-    .expect("LocalInterruptController was not yet initialized");
+            .expect("LocalInterruptController was not yet initialized");
         int_ctrl.enable_fast_local_interrupt(TLB_SHOOTDOWN_IPI, true);
     }
 
@@ -315,7 +315,7 @@ pub fn deregister_interrupt(int_num: InterruptNumber, func: InterruptHandler) ->
 /// Broadcast an Inter-Processor Interrupt to all other CPU cores in the system
 pub fn broadcast_ipi(ipi_num: InterruptNumber) {
     let int_ctrl = LocalInterruptController::get()
-    .expect("LocalInterruptController was not yet initialized");
+        .expect("LocalInterruptController was not yet initialized");
     int_ctrl.send_ipi(ipi_num, InterruptDestination::AllOtherCpus);
 }
 
@@ -325,7 +325,7 @@ pub fn broadcast_ipi(ipi_num: InterruptNumber) {
 /// This IPI uses fast interrupts (FIQs) as an NMI alternative.
 pub fn broadcast_tlb_shootdown_ipi() {
     let int_ctrl = LocalInterruptController::get()
-    .expect("LocalInterruptController was not yet initialized");
+        .expect("LocalInterruptController was not yet initialized");
     int_ctrl.send_fast_ipi(TLB_SHOOTDOWN_IPI, InterruptDestination::AllOtherCpus);
 }
 
@@ -333,7 +333,7 @@ pub fn broadcast_tlb_shootdown_ipi() {
 /// the given interrupt request `irq` has been serviced.
 pub fn eoi(irq_num: InterruptNumber) {
     let int_ctrl = LocalInterruptController::get()
-    .expect("LocalInterruptController was not yet initialized");
+        .expect("LocalInterruptController was not yet initialized");
     int_ctrl.end_of_interrupt(irq_num);
 }
 
@@ -454,7 +454,7 @@ extern "C" fn current_elx_synchronous(e: &mut ExceptionContext) {
 extern "C" fn current_elx_irq(exc: &mut ExceptionContext) {
     let (irq_num, _priority) = {
         let int_ctrl = LocalInterruptController::get()
-    .expect("LocalInterruptController was not yet initialized");
+            .expect("LocalInterruptController was not yet initialized");
         match int_ctrl.acknowledge_interrupt() {
             Some(irq_prio_tuple) => irq_prio_tuple,
             None /* spurious interrupt */ => return,
@@ -484,7 +484,7 @@ extern "C" fn current_elx_irq(exc: &mut ExceptionContext) {
 extern "C" fn current_elx_fiq(exc: &mut ExceptionContext) {
     let (irq_num, _priority) = {
         let int_ctrl = LocalInterruptController::get()
-    .expect("LocalInterruptController was not yet initialized");
+            .expect("LocalInterruptController was not yet initialized");
         let ack = unsafe { int_ctrl.acknowledge_fast_interrupt() };
         match ack {
             Some(irq_prio_tuple) => irq_prio_tuple,
@@ -498,7 +498,7 @@ extern "C" fn current_elx_fiq(exc: &mut ExceptionContext) {
     if let Some(result) = result {
         if result == EoiBehaviour::HandlerDidNotSendEoi {
             let int_ctrl = LocalInterruptController::get()
-    .expect("LocalInterruptController was not yet initialized");
+                .expect("LocalInterruptController was not yet initialized");
             unsafe { int_ctrl.end_of_fast_interrupt(irq_num) };
         }
     } else {

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -20,7 +20,7 @@ extern crate alloc;
 use log::{info, error, warn};
 use alloc::format;
 
-use deferred_interrupt_tasks::{InterruptRegistrationError};
+use deferred_interrupt_tasks::InterruptRegistrationError;
 pub use serial_port_basic::{
     SerialPortAddress,
     SerialPortInterruptEvent,
@@ -384,7 +384,10 @@ static INTERRUPT_ACTION_COM1_COM3: Once<Box<dyn Fn() + Send + Sync>> = Once::new
 static INTERRUPT_ACTION_COM2_COM4: Once<Box<dyn Fn() + Send + Sync>> = Once::new();
 
 
-// Cross-platform interrupt handler for COM1 and COM3 (IRQ 0x24 on x86_64).
+// Cross-platform interrupt handler for the primary serial port.
+//
+// * On x86_64, this is IRQ 0x24, used for COM1 and COM3 serial ports.
+// * On aarch64, we also use interrupt 0x24, used for the 
 interrupt_handler!(com1_com3_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x4), _stack_frame, {
     // log::trace!("COM1/COM3 serial handler");
 
@@ -401,7 +404,7 @@ interrupt_handler!(com1_com3_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET
     EoiBehaviour::HandlerDidNotSendEoi
 });
 
-// Cross-platform interrupt handler for COM2 and COM4 (IRQ 0x24 on 0x23).
+// Cross-platform interrupt handler, only used on x86_64 for COM2 and COM4 (IRQ 0x23).
 interrupt_handler!(com2_com4_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x3), _stack_frame, {
     // trace!("COM2/COM4 serial handler");
     if let Some(func) = INTERRUPT_ACTION_COM2_COM4.get() {

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -96,7 +96,7 @@ pub fn init_serial_port(
         let (int_num, int_handler) = interrupt_number_handler(&serial_port_address);
 
         #[cfg(target_arch = "aarch64")]
-        let (int_num, int_handler) = (PL011_RX_SPI, com1_com3_interrupt_handler);
+        let (int_num, int_handler) = (PL011_RX_SPI, primary_serial_port_interrupt_handler);
 
         SerialPort::register_interrupt_handler(sp.clone(), int_num, int_handler).unwrap();
 
@@ -127,8 +127,8 @@ fn interrupt_number_handler(
 ) -> (InterruptNumber, InterruptHandler) {
     use interrupts::IRQ_BASE_OFFSET;
     match serial_port_address {
-        SerialPortAddress::COM1 | SerialPortAddress::COM3 => (IRQ_BASE_OFFSET + 0x04, com1_com3_interrupt_handler),
-        SerialPortAddress::COM2 | SerialPortAddress::COM4 => (IRQ_BASE_OFFSET + 0x03, com2_com4_interrupt_handler),
+        SerialPortAddress::COM1 | SerialPortAddress::COM3 => (IRQ_BASE_OFFSET + 0x04, primary_serial_port_interrupt_handler),
+        SerialPortAddress::COM2 | SerialPortAddress::COM4 => (IRQ_BASE_OFFSET + 0x03, secondary_serial_port_interrupt_handler),
     }
 }
 
@@ -387,8 +387,8 @@ static INTERRUPT_ACTION_COM2_COM4: Once<Box<dyn Fn() + Send + Sync>> = Once::new
 // Cross-platform interrupt handler for the primary serial port.
 //
 // * On x86_64, this is IRQ 0x24, used for COM1 and COM3 serial ports.
-// * On aarch64, we also use interrupt 0x24, used for the 
-interrupt_handler!(com1_com3_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x4), _stack_frame, {
+// * On aarch64, this is interrupt 0x21, used for the PL011 UART serial port.
+interrupt_handler!(primary_serial_port_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x4), _stack_frame, {
     // log::trace!("COM1/COM3 serial handler");
 
     #[cfg(target_arch = "aarch64")] {
@@ -405,7 +405,7 @@ interrupt_handler!(com1_com3_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET
 });
 
 // Cross-platform interrupt handler, only used on x86_64 for COM2 and COM4 (IRQ 0x23).
-interrupt_handler!(com2_com4_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x3), _stack_frame, {
+interrupt_handler!(secondary_serial_port_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x3), _stack_frame, {
     // trace!("COM2/COM4 serial handler");
     if let Some(func) = INTERRUPT_ACTION_COM2_COM4.get() {
         func()


### PR DESCRIPTION
* The `interrupt_controller` crate still is not used on x86_64.
* Move initialization of x86-specific interrupt controllers (i.e., APIC)
  into the x86-specific module of `interrupt_controller`,
  which makes more sense than doing it from the `device_manager`.
  * As such, the `captain` can now unconditionally initialize
    the interrupt controller crate, which works on all architectures.

Two remaining TODOs:
1. Implement `enable_local_timer_interrupt()` for aarch64
   * This requires moving some aarch64-specific functionality for setting up the system's per-CPU timer out of the  `interrupts` crate and into another crate.
2. Implement `SystemInterruptController::get()` for x86_64.
   * This is a bit challenging because there can be _multiple_ system-wide interrupt controllers (I/O APICs) on x86_64, so we can't simply implement a basic getter function.
   * We may need to offer an iterator interface, or perhaps a getter that takes the current CPU or NUMA domain or some kind of other identifier into account.

In the future, we'll move each `LocalInterruptController` instance into CPU-local storage to allow for very fast access.