### PR TITLE
Minor FIQ improvements (follow-up for issue #1047)

### DIFF
--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -10,7 +10,7 @@ use tock_registers::interfaces::Readable;
 use tock_registers::registers::InMemoryRegister;
 
 use interrupt_controller::{
-    LocalInterruptController, SystemInterruptController, InterruptDestination, Priority,
+    LocalInterruptController, SystemInterruptController, InterruptDestination,
     LocalInterruptControllerApi, AArch64LocalInterruptControllerApi, SystemInterruptControllerApi,
 };
 use kernel_config::time::CONFIG_TIMESLICE_PERIOD_MICROSECONDS;
@@ -87,27 +87,6 @@ pub struct ExceptionContext {
 
     /// Exception syndrome register.
     esr_el1: EsrEL1,
-}
-
-/// Special exception context that is only available to `current_elx_fiq`.
-///
-/// This has two methods which are only safe to be executed in the context of FIQ handling.
-#[repr(transparent)]
-#[non_exhaustive]
-pub struct ExceptionContextFiq(ExceptionContext);
-
-impl ExceptionContextFiq {
-    fn acknowledge_fast_interrupt(&self) -> Option<(InterruptNumber, Priority)> {
-        let int_ctrl = LocalInterruptController::get()
-            .expect("LocalInterruptController was not yet initialized");
-        unsafe { int_ctrl.acknowledge_fast_interrupt() }
-    }
-
-    fn end_of_fast_interrupt(&self, number: InterruptNumber) {
-        let int_ctrl = LocalInterruptController::get()
-            .expect("LocalInterruptController was not yet initialized");
-        unsafe { int_ctrl.end_of_fast_interrupt(number) }
-    }
 }
 
 pub type InterruptHandler = extern "C" fn(&InterruptStackFrame) -> EoiBehaviour;
@@ -502,21 +481,28 @@ extern "C" fn current_elx_irq(exc: &mut ExceptionContext) {
 //
 // Currently, FIQs are only used for TLB shootdown.
 #[no_mangle]
-extern "C" fn current_elx_fiq(exc_fiq: &mut ExceptionContextFiq) {
-    let (irq_num, _priority) = match exc_fiq.acknowledge_fast_interrupt() {
-        Some(irq_prio_tuple) => irq_prio_tuple,
-        None /* spurious interrupt */ => return,
+extern "C" fn current_elx_fiq(exc: &mut ExceptionContext) {
+    let (irq_num, _priority) = {
+        let int_ctrl = LocalInterruptController::get()
+            .expect("LocalInterruptController was not yet initialized");
+        let ack = unsafe { int_ctrl.acknowledge_fast_interrupt() };
+        match ack {
+            Some(irq_prio_tuple) => irq_prio_tuple,
+            None /* spurious interrupt */ => return,
+        }
     };
 
     let handler = IRQ_HANDLERS.read().get(irq_num as usize).copied().flatten();
-    let result = handler.map(|handler| handler(&exc_fiq.0));
+    let result = handler.map(|handler| handler(exc));
 
     if let Some(result) = result {
         if result == EoiBehaviour::HandlerDidNotSendEoi {
-            exc_fiq.end_of_fast_interrupt(irq_num);
+            let int_ctrl = LocalInterruptController::get()
+                .expect("LocalInterruptController was not yet initialized");
+            unsafe { int_ctrl.end_of_fast_interrupt(irq_num) };
         }
     } else {
-        log::error!("Unhandled FIQ: {}\r\n{:?}\r\n[looping forever now]", irq_num, exc_fiq.0);
+        log::error!("Unhandled FIQ: {}\r\n{:?}\r\n[looping forever now]", irq_num, exc);
         loop { core::hint::spin_loop() }
     }
 }


### PR DESCRIPTION
#### `InterruptDestination` seems redundant with `IpiTargetCpu`...?

As discussed on discord, it makes sense to keep both types:
- `InterruptDestination`: the cross-platform public type that can be used everywhere in theseus. Has two variants: "All But Me" / "One Specific CPU core"
- `IpiTargetCpu` / `SpiDestination`: GIC-specific structures that must only be used in GIC-specific code. These have a `GICv2TargetList` variant.

-----

#### We can use type wrappers to ensure that the `acknowledge_fast_interrupt` and `end_of_fast_interrupt` functions are only invokable by `current_elx_fiq`.

Yes. I implemented a safe wrapper, but I'm not entirely sure I did what you had in mind: As `ExceptionContext` is defined in the `interrupts` crate, everything had to be done inside of it. `interrupt_controller` wasn't modified.

The relevant commit is the second one.

-----

#### It's a little bit odd to use the type `*const InterruptHandler`, since `InterruptHandler` is already a function pointer.

Yes. That's now fixed.