### PR TITLE
aarch64: move generic system timer to its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,8 +1361,12 @@ dependencies = [
 name = "generic_timer_aarch64"
 version = "0.1.0"
 dependencies = [
+ "cortex-a",
  "derive_more",
+ "log",
  "memory_structs",
+ "time",
+ "tock-registers",
 ]
 
 [[package]]
@@ -1585,6 +1589,7 @@ dependencies = [
  "apic",
  "arm_boards",
  "cpu",
+ "generic_timer_aarch64",
  "gic",
  "ioapic",
  "log",
@@ -1605,6 +1610,7 @@ dependencies = [
  "early_printer",
  "exceptions_early",
  "gdt",
+ "generic_timer_aarch64",
  "gic",
  "interrupt_controller",
  "kernel_config",
@@ -1614,7 +1620,6 @@ dependencies = [
  "pic",
  "spin 0.9.4",
  "sync_irq",
- "time",
  "tock-registers",
  "tss",
  "x86_64",
@@ -3123,9 +3128,12 @@ version = "0.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpu",
+ "generic_timer_aarch64",
  "interrupts",
+ "kernel_config",
  "log",
  "sleep",
+ "spin 0.9.4",
  "task",
  "x86_64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic_timer_aarch64"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "memory_structs",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "git+https://github.com/theseus-os/getopts#da1e04828d3ecd6adc90e2da61e2e3cccc7ca97c"

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -98,6 +98,7 @@ pub fn init(
     device_manager::early_init(rsdp_address, kernel_mmi_ref.lock().deref_mut())?;
 
     // Initialize local and system-wide interrupt controllers.
+    // TODO: move this into `interrupts::init()`.
     interrupt_controller::init(&kernel_mmi_ref)?;
     
     // Initialize other arch-specific interrupt stuff, e.g., basic interrupt handlers.

--- a/kernel/generic_timer_aarch64/Cargo.toml
+++ b/kernel/generic_timer_aarch64/Cargo.toml
@@ -8,11 +8,10 @@ description = "Support for aarch64's generic timer and system counter"
 version = "0.1.0"
 edition = "2021"
 
-
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-memory_structs = { path = "../memory_structs" }
+cortex-a = "7.5.0"
 derive_more = "0.99.0"
-
-[features]
-default = [ "qemu_virt" ]
-qemu_virt = []
+log = "0.4.8"
+tock-registers = "0.7.0"
+memory_structs = { path = "../memory_structs" }
+time = { path = "../time" }

--- a/kernel/generic_timer_aarch64/Cargo.toml
+++ b/kernel/generic_timer_aarch64/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+authors = [
+    "Nathan Royer <nathan.royer.pro@gmail.com>",
+    "Kevin Boos <kevinaboos@gmail.com",
+]
+name = "generic_timer_aarch64"
+description = "Support for aarch64's generic timer and system counter"
+version = "0.1.0"
+edition = "2021"
+
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+memory_structs = { path = "../memory_structs" }
+derive_more = "0.99.0"
+
+[features]
+default = [ "qemu_virt" ]
+qemu_virt = []

--- a/kernel/generic_timer_aarch64/src/lib.rs
+++ b/kernel/generic_timer_aarch64/src/lib.rs
@@ -75,11 +75,8 @@ pub fn set_next_timer_interrupt(ticks_to_elapse: u64) {
 pub fn enable_timer_interrupt(enable: bool) {
     // Unmask the interrupt (to enable it), and enable the timer.
     CNTP_CTL_EL0.write(
-          CNTP_CTL_EL0::IMASK.val(0)
-        + CNTP_CTL_EL0::ENABLE.val(match enable {
-            true => 1,
-            false => 0,
-        })
+          CNTP_CTL_EL0::IMASK.val(!enable as u64)
+        + CNTP_CTL_EL0::ENABLE.val(enable as u64)
     );
 
     if false {

--- a/kernel/generic_timer_aarch64/src/lib.rs
+++ b/kernel/generic_timer_aarch64/src/lib.rs
@@ -1,6 +1,9 @@
 //! Support for aarch64's generic timer and system counter.
+//!
+//! Docs: <https://developer.arm.com/documentation/102379/latest/>
 
 #![no_std]
+#![feature(negative_impls)]
 
 // This crate is only relevant on aarch64 systems,
 // but we use a cfg gate here to allow it to be included in x86 builds
@@ -8,26 +11,36 @@
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::*;
 
-#[cfg(target_arch = "aarch64")] mod aarch64 {
+#[cfg(target_arch = "aarch64")]
+mod aarch64 {
+
+use cortex_a::registers::*;
+use log::*;
+use time::{Monotonic, ClockSource, Instant, Period, register_clock_source};
+use tock_registers::interfaces::Writeable;
+use tock_registers::interfaces::Readable;
+
 
 /// Initializes the aarch64 generic system timer
 /// and registers it as a monotonic [`ClockSource`].
 ///
 /// This only needs to be invoked once, system-wide.
-/// However, each CPU will need to enable their own timer interrupt.
-pub fn init() -> Result<(), &'static str> {
-    let period = Period::new(read_timer_period_femtoseconds());
+/// However, each CPU will need to enable their own timer interrupt separately,
+/// as this function itself does not enable the timer interrupt.
+pub fn init() {
+    let period = Period::new(timer_period_femtoseconds());
     register_clock_source::<PhysicalSystemCounter>(period);
-    Ok(())
 }
 
-// A ClockSource for the time crate, implemented using
-// the System Counter of the Generic Arm Timer. The
-// period of this timer is computed in `init` above.
+/// A ClockSource for the time crate, implemented using
+/// the System Counter of the Generic Arm Timer. The
+/// period of this timer is computed in `init` above.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct PhysicalSystemCounter;
 impl !Send for PhysicalSystemCounter { }
 impl PhysicalSystemCounter {
+    /// An instant (no-op) function that returns the current CPU's system counter. 
     pub fn get() -> Self {
         Self
     }
@@ -40,7 +53,6 @@ impl ClockSource for PhysicalSystemCounter {
     }
 }
 
-
 /// Returns the period in femtoseconds of the generic system timer.
 ///
 /// This reads the `CNTFRQ_EL0` system register.
@@ -50,20 +62,18 @@ pub fn timer_period_femtoseconds() -> u64 {
     fs_in_one_sec / counter_freq_hz
 }
 
-
-
-/// Sets this CPU's system timer interrupt to fire after `ticks_to_elapse` from now.
+/// Sets the current CPU's system timer interrupt to fire after `ticks_to_elapse` from now.
 pub fn set_next_timer_interrupt(ticks_to_elapse: u64) {
-    enable_timer(false);
+    enable_timer_interrupt(false);
     CNTP_TVAL_EL0.set(ticks_to_elapse);
-    enable_timer(true);
+    enable_timer_interrupt(true);
 }
 
-/// Enables/disables the generic system timer interrupt.
+/// Enables/disables the generic system timer interrupt on the current CPU.
 ///
 /// This writes the `CNTP_CTL_EL0` system register.
-pub fn enable_timer(enable: bool) {
-    // unmask the interrupt & enable the timer
+pub fn enable_timer_interrupt(enable: bool) {
+    // Unmask the interrupt (to enable it), and enable the timer.
     CNTP_CTL_EL0.write(
           CNTP_CTL_EL0::IMASK.val(0)
         + CNTP_CTL_EL0::ENABLE.val(match enable {

--- a/kernel/generic_timer_aarch64/src/lib.rs
+++ b/kernel/generic_timer_aarch64/src/lib.rs
@@ -1,0 +1,82 @@
+//! Support for aarch64's generic timer and system counter.
+
+#![no_std]
+
+// This crate is only relevant on aarch64 systems,
+// but we use a cfg gate here to allow it to be included in x86 builds
+// because the build system currently builds _all_ crates for x86.
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::*;
+
+#[cfg(target_arch = "aarch64")] mod aarch64 {
+
+/// Initializes the aarch64 generic system timer
+/// and registers it as a monotonic [`ClockSource`].
+///
+/// This only needs to be invoked once, system-wide.
+/// However, each CPU will need to enable their own timer interrupt.
+pub fn init() -> Result<(), &'static str> {
+    let period = Period::new(read_timer_period_femtoseconds());
+    register_clock_source::<PhysicalSystemCounter>(period);
+    Ok(())
+}
+
+// A ClockSource for the time crate, implemented using
+// the System Counter of the Generic Arm Timer. The
+// period of this timer is computed in `init` above.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PhysicalSystemCounter;
+impl !Send for PhysicalSystemCounter { }
+impl PhysicalSystemCounter {
+    pub fn get() -> Self {
+        Self
+    }
+}
+impl ClockSource for PhysicalSystemCounter {
+    type ClockType = Monotonic;
+
+    fn now() -> Instant {
+        Instant::new(CNTPCT_EL0.get())
+    }
+}
+
+
+/// Returns the period in femtoseconds of the generic system timer.
+///
+/// This reads the `CNTFRQ_EL0` system register.
+pub fn timer_period_femtoseconds() -> u64 {
+    let counter_freq_hz = CNTFRQ_EL0.get();
+    let fs_in_one_sec = 1_000_000_000_000_000;
+    fs_in_one_sec / counter_freq_hz
+}
+
+
+
+/// Sets this CPU's system timer interrupt to fire after `ticks_to_elapse` from now.
+pub fn set_next_timer_interrupt(ticks_to_elapse: u64) {
+    enable_timer(false);
+    CNTP_TVAL_EL0.set(ticks_to_elapse);
+    enable_timer(true);
+}
+
+/// Enables/disables the generic system timer interrupt.
+///
+/// This writes the `CNTP_CTL_EL0` system register.
+pub fn enable_timer(enable: bool) {
+    // unmask the interrupt & enable the timer
+    CNTP_CTL_EL0.write(
+          CNTP_CTL_EL0::IMASK.val(0)
+        + CNTP_CTL_EL0::ENABLE.val(match enable {
+            true => 1,
+            false => 0,
+        })
+    );
+
+    if false {
+        info!("timer enabled: {:?}", CNTP_CTL_EL0.read(CNTP_CTL_EL0::ENABLE));
+        info!("timer IMASK: {:?}",   CNTP_CTL_EL0.read(CNTP_CTL_EL0::IMASK));
+        info!("timer status: {:?}",  CNTP_CTL_EL0.read(CNTP_CTL_EL0::ISTATUS));
+    }
+}
+
+}

--- a/kernel/interrupt_controller/Cargo.toml
+++ b/kernel/interrupt_controller/Cargo.toml
@@ -17,6 +17,7 @@ sync_irq = { path = "../../libs/sync_irq" }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 arm_boards = { path = "../arm_boards" }
+generic_timer_aarch64 = { path = "../generic_timer_aarch64" }
 gic = { path = "../gic" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/kernel/interrupt_controller/src/aarch64.rs
+++ b/kernel/interrupt_controller/src/aarch64.rs
@@ -190,7 +190,7 @@ impl LocalInterruptControllerApi for LocalInterruptController {
     }
 
     fn enable_local_timer_interrupt(&self, enable: bool) {
-        todo!("invoke interrupts::enable_timer(enable)...")
+        generic_timer_aarch64::enable_timer_interrupt(enable)
     }
 
     fn send_ipi(&self, num: InterruptNumber, dest: InterruptDestination) {

--- a/kernel/interrupts/Cargo.toml
+++ b/kernel/interrupts/Cargo.toml
@@ -17,10 +17,10 @@ spin = "0.9.4"
 sync_irq = { path = "../../libs/sync_irq" }
 arm_boards = { path = "../arm_boards" }
 kernel_config = { path = "../kernel_config" }
+generic_timer_aarch64 = { path = "../generic_timer_aarch64" }
 gic = { path = "../gic" }
 tock-registers = "0.7.0"
 cortex-a = "7.5.0"
-time = { path = "../time" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 exceptions_early = { path = "../exceptions_early" }

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -13,14 +13,10 @@ use interrupt_controller::{
     LocalInterruptController, SystemInterruptController, InterruptDestination,
     LocalInterruptControllerApi, AArch64LocalInterruptControllerApi, SystemInterruptControllerApi,
 };
-use kernel_config::time::CONFIG_TIMESLICE_PERIOD_MICROSECONDS;
 use arm_boards::BOARD_CONFIG;
 use sync_irq::IrqSafeRwLock;
 use cpu::current_cpu;
 use log::*;
-use spin::Once;
-
-use time::{Monotonic, ClockSource, Instant, Period, register_clock_source};
 
 pub use interrupt_controller::InterruptNumber;
 
@@ -129,7 +125,7 @@ pub fn init_ap() {
     // On the bootstrap CPU, this is done in `setup_timer_interrupt()`.
     int_ctrl.enable_local_interrupt(CPU_LOCAL_TIMER_IRQ, true);
 
-    enable_timer(true);
+    generic_timer_aarch64::enable_timer_interrupt(true);
 }
 
 /// Initializes the generic system timer and the system-wide list of interrupt handlers.

--- a/kernel/interrupts/src/x86_64/mod.rs
+++ b/kernel/interrupts/src/x86_64/mod.rs
@@ -307,8 +307,7 @@ pub fn eoi(irq: Option<u8>) {
 
 extern "x86-interrupt" fn apic_spurious_interrupt_handler(_stack_frame: InterruptStackFrame) {
     warn!("APIC SPURIOUS INTERRUPT HANDLER!");
-
-    eoi(None);
+    eoi(Some(apic::APIC_SPURIOUS_INTERRUPT_IRQ));
 }
 
 extern "x86-interrupt" fn unimplemented_interrupt_handler(_stack_frame: InterruptStackFrame) {
@@ -335,8 +334,7 @@ extern "x86-interrupt" fn unimplemented_interrupt_handler(_stack_frame: Interrup
         }
     };
 
-    // TODO: use const generics here to know which IRQ to send an EOI for (only needed for PIC).
-    eoi(None); 
+    eoi(Some(0xFF)); 
 }
 
 

--- a/kernel/scheduler/Cargo.toml
+++ b/kernel/scheduler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 name = "scheduler"
-description = "Provides scheduling functionality for selecting the next task and causing a task switch"
+description = "Provides basic scheduling functionality for preemptive task switching."
 version = "0.1.0"
 edition = "2018"
 
@@ -16,3 +16,8 @@ task = { path = "../task" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = "0.14.8"
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+generic_timer_aarch64 = { path = "../generic_timer_aarch64" }
+kernel_config = { path = "../kernel_config" }
+spin = "0.9.4"

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -41,7 +41,7 @@ pub fn init() -> Result<(), &'static str> {
     }
 
     #[cfg(target_arch = "aarch64")] {
-        interrupts::init_timer(timer_tick_handler)?;
+        interrupts::setup_timer_interrupt(timer_tick_handler)?;
         interrupts::enable_timer(true);
         Ok(())
     }
@@ -50,7 +50,7 @@ pub fn init() -> Result<(), &'static str> {
 // Architecture-independent timer interrupt handler for preemptive scheduling.
 interrupt_handler!(timer_tick_handler, None, _stack_frame, {
     #[cfg(target_arch = "aarch64")]
-    interrupts::schedule_next_timer_tick();
+    interrupts::set_next_timer_interrupt(get_timeslice_ticks);
 
     // tick count, only used for debugging
     if false {
@@ -64,17 +64,27 @@ interrupt_handler!(timer_tick_handler, None, _stack_frame, {
     // in order to unblock any tasks that are done sleeping.
     sleep::unblock_sleeping_tasks();
 
-    // We must acknowledge the interrupt before the end of this handler
+    // We must acknowledge the interrupt *before* the end of this handler
     // because we switch tasks here, which doesn't return.
-    {
-        #[cfg(target_arch = "x86_64")]
-        eoi(None); // None, because IRQ 0x22 cannot possibly be a PIC interrupt
-
-        #[cfg(target_arch = "aarch64")]
-        eoi(CPU_LOCAL_TIMER_IRQ);
-    }
+    eoi(CPU_LOCAL_TIMER_IRQ);
 
     schedule();
 
     EoiBehaviour::HandlerSentEoi
 });
+
+
+/// Returns the (cached) number of system timer ticks needed for the scheduling timeslice interval.
+///
+/// This is only needed on aarch64 because it only effectively offers a one-shot timer;
+/// x86_64 can be configured once as a recurring periodic timer.
+#[cfg(target_arch = "aarch64")]
+fn get_timeslice_ticks() -> u64 {
+    static TIMESLICE_TICKS: Once<u64> = Once::new();
+
+    *TIMESLICE_TICKS.call_once(|| {
+        let timeslice_femtosecs = (CONFIG_TIMESLICE_PERIOD_MICROSECONDS as u64) * 1_000_000_000;
+        let tick_period_femtosecs = read_timer_period_femtoseconds();
+        timeslice_femtosecs / tick_period_femtosecs
+    })
+}

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -66,6 +66,9 @@ interrupt_handler!(timer_tick_handler, None, _stack_frame, {
 
     // We must acknowledge the interrupt *before* the end of this handler
     // because we switch tasks here, which doesn't return.
+    #[cfg(target_arch = "x86_64")]
+    eoi(Some(CPU_LOCAL_TIMER_IRQ));
+    #[cfg(target_arch = "aarch64")]
     eoi(CPU_LOCAL_TIMER_IRQ);
 
     schedule();

--- a/kernel/sleep/src/lib.rs
+++ b/kernel/sleep/src/lib.rs
@@ -110,8 +110,7 @@ fn remove_next_task_from_delayed_tasklist() {
     }
 }
 
-/// Remove all tasks that have been delayed but are able to be unblocked now,
-/// the current tick count is provided by the system's interrupt tick count.
+/// Remove all tasks that have been delayed but are able to be unblocked now.
 pub fn unblock_sleeping_tasks() {
     let time = now::<Monotonic>();
     while time > NEXT_DELAYED_TASK_UNBLOCK_TIME.load() {


### PR DESCRIPTION
Can now be used in the `LocalInterruptController` to manage the CPU-local timer interrupt on aarch64.