### PR TITLE
Make calls to `eoi` (end of interrupt) consistent across architectures

### DIFF
--- a/kernel/ata/src/lib.rs
+++ b/kernel/ata/src/lib.rs
@@ -894,13 +894,13 @@ const ATA_SECONDARY_IRQ: u8 = interrupts::IRQ_BASE_OFFSET + 0xF;
 /// The primary ATA interrupt handler. Not yet used for anything, but useful for DMA.
 extern "x86-interrupt" fn primary_ata_handler(_stack_frame: InterruptStackFrame ) {
     info!("Primary ATA Interrupt ({:#X})", ATA_PRIMARY_IRQ);
-    interrupts::eoi(Some(ATA_PRIMARY_IRQ));
+    interrupts::eoi(ATA_PRIMARY_IRQ);
 }
 
 /// The primary ATA interrupt handler. Not yet used for anything, but useful for DMA.
 extern "x86-interrupt" fn secondary_ata_handler(_stack_frame: InterruptStackFrame ) {
     info!("Secondary ATA Interrupt ({:#X})", ATA_SECONDARY_IRQ);
-    interrupts::eoi(Some(ATA_SECONDARY_IRQ));
+    interrupts::eoi(ATA_SECONDARY_IRQ);
 }
 
 

--- a/kernel/e1000/src/lib.rs
+++ b/kernel/e1000/src/lib.rs
@@ -462,7 +462,7 @@ extern "x86-interrupt" fn e1000_handler(_stack_frame: InterruptStackFrame) {
         if let Err(e) = e1000_nic.handle_interrupt() {
             error!("e1000_handler(): error handling interrupt: {:?}", e);
         }
-        eoi(Some(e1000_nic.interrupt_num));
+        eoi(e1000_nic.interrupt_num);
     } else {
         error!("BUG: e1000_handler(): E1000 NIC hasn't yet been initialized!");
     }

--- a/kernel/generic_timer_aarch64/src/lib.rs
+++ b/kernel/generic_timer_aarch64/src/lib.rs
@@ -69,14 +69,15 @@ pub fn set_next_timer_interrupt(ticks_to_elapse: u64) {
     enable_timer_interrupt(true);
 }
 
-/// Enables/disables the generic system timer interrupt on the current CPU.
+/// Enables/disables the generic system timer and its interrupt on the current CPU.
 ///
 /// This writes the `CNTP_CTL_EL0` system register.
 pub fn enable_timer_interrupt(enable: bool) {
-    // Unmask the interrupt (to enable it), and enable the timer.
+    // If enable: unmask the interrupt (set bit to 0), and enable the timer.
+    // If disable: mask the interrupt (set bit to 1), and disable the timer.
     CNTP_CTL_EL0.write(
-          CNTP_CTL_EL0::IMASK.val(!enable as u64)
-        + CNTP_CTL_EL0::ENABLE.val(enable as u64)
+        CNTP_CTL_EL0::ENABLE.val(enable as u64)
+        + CNTP_CTL_EL0::IMASK.val(!enable as u64)
     );
 
     if false {

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -54,13 +54,15 @@ struct SpsrEL1(InMemoryRegister<u64, SPSR_EL1::Register>);
 #[repr(transparent)]
 struct EsrEL1(InMemoryRegister<u64, ESR_EL1::Register>);
 
-#[cfg(target_arch = "aarch64")]
 #[macro_export]
 #[doc = include_str!("../macro-doc.md")]
 macro_rules! interrupt_handler {
+    ($name:ident, _, $stack_frame:ident, $code:block) => {
+        interrupt_handler!($name, 0, $stack_frame, $code);
+    };
     ($name:ident, $x86_64_eoi_param:expr, $stack_frame:ident, $code:block) => {
         extern "C" fn $name($stack_frame: &$crate::InterruptStackFrame) -> $crate::EoiBehaviour $code
-    }
+    };
 }
 
 /// The exception context as it is stored on the stack on exception entry.

--- a/kernel/interrupts/src/macro-doc.md
+++ b/kernel/interrupts/src/macro-doc.md
@@ -2,52 +2,42 @@ Macro which helps writing cross-platform interrupt handlers.
 
 # Arguments
 
-- `$name`: the name of the function
-- `$x86_64_eoi_param`: `Some(irq_num)` if this interrupt can be handled while
-  the PIC chip is active and the handler returns `HandlerDidNotSendEoi`; `None` otherwise.
-  Ignored on `aarch64`. See [`eoi`] for more information. If the IRQ number isn't
-  constant and this interrupt can happen with the PIC chip active, call [`eoi`]
-  manually as in Example 2.
+- `$name`: the name of the interrupt handler function.
+- `$x86_64_eoi_param`: one of two possible values:
+  1. the literal underscore character `_`, used to indicate that this value isn't used
+     and the interrupt handler does not care about its value.
+     * This is useful for interrupt handlers that are aarch64 specific
+       or can only occur on x86_64's newer APIC interrupt chips, which do not require
+       specifying a specific IRQ number when sending an end of interrupt (EOI).
+  2. a valid [`InterruptNumber`] if this interrupt may be handled by the legacy PIC chip
+     on x86_64, which is used if the handler returns `HandlerDidNotSendEoi`.
 - `$stack_frame`: Name for the [`InterruptStackFrame`] parameter.
-- `$code`: The code for the interrupt handler itself. It must return an [`crate::EoiBehaviour`] enum.
+- `$code`: The code for the interrupt handler itself, which must return [`crate::EoiBehaviour`].
 
-# Example 1
+## Example 1
 
 This simply logs the stack frame to the console.
 
 ```ignore
-interrupt_handler!(my_int_0x29_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x9), stack_frame, {
+interrupt_handler!(my_int_0x29_handler, interrupts::IRQ_BASE_OFFSET + 0x9, stack_frame, {
     trace!("my_int_0x29_handler running! stack frame: {:?}", stack_frame);
-
-    // loop {}
 
     EoiBehaviour::HandlerDidNotSendEoi
 });
 ```
 
-# Example 2
+## Example 2
 
-Here's how [`eoi`] can be called manually. Note how we can pass `None` as
-`$x86_64_eoi_param`, since we call [`eoi`] in the handler.
+Here's how [`eoi`] can be called manually. Note how we use `_` for the second parameter
+in the macro (the `$x86_64_eoi_param`), since we call [`eoi`] in the handler.
 
 ```ignore
-interrupt_handler!(my_int_0x29_handler, None, stack_frame, {
+interrupt_handler!(my_int_0x29_handler, _, stack_frame, {
     trace!("my_int_0x29_handler running! stack frame: {:?}", stack_frame);
 
-    #[cfg(target_arch = "x86_64")]
+    // Call `eoi` manually.
     let irq_num = 0x29;
-
-    #[cfg(target_arch = "aarch64")]
-    let irq_num = 0x29;
-
-    // Calling `eoi` manually:
-    {
-        #[cfg(target_arch = "x86_64")]
-        eoi(Some(irq_num));
-
-        #[cfg(target_arch = "aarch64")]
-        eoi(irq_num);
-    }
+    eoi(irq_num);
 
     EoiBehaviour::HandlerSentEoi
 });

--- a/kernel/keyboard/src/lib.rs
+++ b/kernel/keyboard/src/lib.rs
@@ -105,7 +105,7 @@ extern "x86-interrupt" fn ps2_keyboard_handler(_stack_frame: InterruptStackFrame
         warn!("ps2_keyboard_handler(): KEYBOARD isn't initialized yet, skipping interrupt.");
     }
     
-    interrupts::eoi(Some(PS2_KEYBOARD_IRQ));
+    interrupts::eoi(PS2_KEYBOARD_IRQ);
 }
 
 

--- a/kernel/mouse/src/lib.rs
+++ b/kernel/mouse/src/lib.rs
@@ -74,7 +74,7 @@ extern "x86-interrupt" fn ps2_mouse_handler(_stack_frame: InterruptStackFrame) {
         warn!("ps2_mouse_handler(): MOUSE isn't initialized yet, skipping interrupt.");
     }
 
-    interrupts::eoi(Some(PS2_MOUSE_IRQ));
+    interrupts::eoi(PS2_MOUSE_IRQ);
 }
 
 

--- a/kernel/pit_clock/src/lib.rs
+++ b/kernel/pit_clock/src/lib.rs
@@ -72,5 +72,5 @@ extern "x86-interrupt" fn pit_timer_handler(_stack_frame: InterruptStackFrame) {
     let ticks = PIT_TICKS.fetch_add(1, Ordering::Acquire);
     trace!("PIT timer interrupt, ticks: {}", ticks);
 
-    interrupts::eoi(Some(PIT_CHANNEL_0_IRQ));
+    interrupts::eoi(PIT_CHANNEL_0_IRQ);
 }

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -48,7 +48,7 @@ pub fn init() -> Result<(), &'static str> {
 }
 
 // Architecture-independent timer interrupt handler for preemptive scheduling.
-interrupt_handler!(timer_tick_handler, None, _stack_frame, {
+interrupt_handler!(timer_tick_handler, _, _stack_frame, {
     #[cfg(target_arch = "aarch64")]
     generic_timer_aarch64::set_next_timer_interrupt(get_timeslice_ticks());
 
@@ -66,9 +66,6 @@ interrupt_handler!(timer_tick_handler, None, _stack_frame, {
 
     // We must acknowledge the interrupt *before* the end of this handler
     // because we switch tasks here, which doesn't return.
-    #[cfg(target_arch = "x86_64")]
-    eoi(Some(CPU_LOCAL_TIMER_IRQ));
-    #[cfg(target_arch = "aarch64")]
     eoi(CPU_LOCAL_TIMER_IRQ);
 
     schedule();

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -388,7 +388,7 @@ static INTERRUPT_ACTION_COM2_COM4: Once<Box<dyn Fn() + Send + Sync>> = Once::new
 //
 // * On x86_64, this is IRQ 0x24, used for COM1 and COM3 serial ports.
 // * On aarch64, this is interrupt 0x21, used for the PL011 UART serial port.
-interrupt_handler!(primary_serial_port_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x4), _stack_frame, {
+interrupt_handler!(primary_serial_port_interrupt_handler, interrupts::IRQ_BASE_OFFSET + 0x4, _stack_frame, {
     // log::trace!("COM1/COM3 serial handler");
 
     #[cfg(target_arch = "aarch64")] {
@@ -405,7 +405,7 @@ interrupt_handler!(primary_serial_port_interrupt_handler, Some(interrupts::IRQ_B
 });
 
 // Cross-platform interrupt handler, only used on x86_64 for COM2 and COM4 (IRQ 0x23).
-interrupt_handler!(secondary_serial_port_interrupt_handler, Some(interrupts::IRQ_BASE_OFFSET + 0x3), _stack_frame, {
+interrupt_handler!(secondary_serial_port_interrupt_handler, interrupts::IRQ_BASE_OFFSET + 0x3, _stack_frame, {
     // trace!("COM2/COM4 serial handler");
     if let Some(func) = INTERRUPT_ACTION_COM2_COM4.get() {
         func()


### PR DESCRIPTION
* Remove the `Option` from `eoi` signature on x86_64, since the active interrupt chip (PIC vs. APIC) will correctly ignore that value even if it is always provided.
  * This makes the `eoi` interface much simpler.

* In the `interrupt_handler!()` macro, allow the IRQ number parameter to be `_` to indicate that the handler doesn't care or doesn't need to actually provide an IRQ for EOI.