### PR TITLE
Modify QEMU test workflow to ignore certain paths

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,19 @@ name: QEMU Test
 on:
   pull_request:
     types: [synchronize, opened, reopened]
+    paths-ignore:
+      - 'book/**'
+      - 'c_test/**'
+      - 'docker/**'
+      - 'github_pages/**'
+      - 'old_crates/**'
+      - 'scripts/**'
+      - '.gitignore'
+      - 'LICENSE-MIT'
+      - 'README.md'
+      - 'bochsrc.txt'
+      - 'rustfmt.toml'
+      - 'slirp.conf'
 jobs:
   run-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflow won't run if the changes only include the following paths:
- 'book/**'
- 'c_test/**'
- 'docker/**'
- 'github_pages/**'
- 'old_crates/**'
- 'scripts/**'
- '.gitignore'
- 'LICENSE-MIT'
- 'README.md'
- 'bochsrc.txt'
- 'rustfmt.toml'
- 'slirp.conf'

I'd rather be conservative with the list of paths to exclude because if any of the paths inadvertently affect the CI run, that could lead to weird problems.