### PR TITLE
Fix `heap` allocator bug

### DIFF
--- a/kernel/heap/src/lib.rs
+++ b/kernel/heap/src/lib.rs
@@ -89,7 +89,7 @@ unsafe impl GlobalAlloc for Heap {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        if (ptr as usize) < INITIAL_HEAP_END_ADDR {
+        if KERNEL_HEAP_START <= (ptr as usize) && (ptr as usize) < INITIAL_HEAP_END_ADDR {
             self.initial_allocator.lock().deallocate(ptr, layout);
         }
         else {


### PR DESCRIPTION
The implementation of `GlobalAlloc` for `Heap` assumed that all memory under `INITIAL_HEAP_END_ADDR` was allocated using the initial allocator, but this isn't true.

`MultipleHeaps` allocates large objects using mapped pages leading to objects allocated in the lower half of memory. When deallocating these objects, `Heap` tried to deallocate them using the initial allocator rather than `MultipleHeaps`.