### PR TITLE
Rename `async_channel` to `sync_channel`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,20 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "async_channel"
-version = "0.1.0"
-dependencies = [
- "core2",
- "crossbeam-utils",
- "debugit",
- "log",
- "mpmc",
- "sync",
- "sync_spin",
- "wait_queue",
-]
-
-[[package]]
 name = "ata"
 version = "0.1.0"
 dependencies = [
@@ -320,7 +306,6 @@ version = "0.1.0"
 dependencies = [
  "apic",
  "app_io",
- "async_channel",
  "cpu",
  "fs_node",
  "getopts",
@@ -336,6 +321,7 @@ dependencies = [
  "scheduler",
  "simple_ipc",
  "spawn",
+ "sync_channel",
  "task",
 ]
 
@@ -529,7 +515,6 @@ name = "console"
 version = "0.1.0"
 dependencies = [
  "app_io",
- "async_channel",
  "core2",
  "hull",
  "io",
@@ -538,6 +523,7 @@ dependencies = [
  "path",
  "serial_port",
  "spawn",
+ "sync_channel",
  "sync_irq",
  "task",
  "tty",
@@ -3267,13 +3253,13 @@ dependencies = [
 name = "serial_port"
 version = "0.1.0"
 dependencies = [
- "async_channel",
  "core2",
  "deferred_interrupt_tasks",
  "interrupts",
  "log",
  "serial_port_basic",
  "spin 0.9.4",
+ "sync_channel",
  "sync_irq",
 ]
 
@@ -3625,6 +3611,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_channel"
+version = "0.1.0"
+dependencies = [
+ "core2",
+ "crossbeam-utils",
+ "debugit",
+ "log",
+ "mpmc",
+ "sync",
+ "sync_spin",
+ "wait_queue",
+]
+
+[[package]]
 name = "sync_irq"
 version = "0.1.0"
 dependencies = [
@@ -3763,7 +3763,6 @@ name = "test_channel"
 version = "0.1.0"
 dependencies = [
  "app_io",
- "async_channel",
  "cpu",
  "getopts",
  "log",
@@ -3771,6 +3770,7 @@ dependencies = [
  "scheduler",
  "spawn",
  "spin 0.9.4",
+ "sync_channel",
  "task",
 ]
 
@@ -4128,9 +4128,9 @@ dependencies = [
 name = "tty"
 version = "0.1.0"
 dependencies = [
- "async_channel",
  "core2",
  "sync_block",
+ "sync_channel",
 ]
 
 [[package]]
@@ -4182,9 +4182,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 name = "unified_channel"
 version = "0.1.0"
 dependencies = [
- "async_channel",
  "cfg-if 0.1.10",
  "rendezvous",
+ "sync_channel",
 ]
 
 [[package]]

--- a/applications/bm/Cargo.toml
+++ b/applications/bm/Cargo.toml
@@ -53,8 +53,8 @@ path = "../../kernel/memory"
 [dependencies.rendezvous]
 path = "../../kernel/rendezvous"
 
-[dependencies.async_channel]
-path = "../../kernel/async_channel"
+[dependencies.sync_channel]
+path = "../../kernel/sync_channel"
 
 [dependencies.simple_ipc]
 path = "../../kernel/simple_ipc"

--- a/applications/bm/src/lib.rs
+++ b/applications/bm/src/lib.rs
@@ -1,4 +1,4 @@
-//! A collection of micro-benchmarks for Theseus. 
+//! A collection of micro-benchmarks for Theseus.
 //! They include null syscall, context switching, process creation, memory mapping, IPC and file system benchmarks.
 //! 
 //! To run the memory mapping benchmark, Theseus should be compiled with the "bm_map" configuration option.
@@ -23,7 +23,7 @@ extern crate scheduler;
 extern crate libtest;
 extern crate memory;
 extern crate rendezvous;
-extern crate async_channel;
+extern crate sync_channel;
 extern crate simple_ipc;
 extern crate getopts;
 extern crate pmu_x86;
@@ -89,10 +89,10 @@ pub fn main(args: Vec<String>) -> isize {
     opts.optflag("", "fs_delete", "file delete");
     opts.optflag("", "fs", "test code for checking FS' ability");
 
-    opts.optflag("a", "async", "Run IPC bm for the async channel");
+    opts.optflag("a", "mpmc", "Run IPC bm for the mpmc channel");
     opts.optflag("r", "rendezvous", "Run IPC bm for the rendezvous channel");
     opts.optflag("p", "pinned", "Sender and Receiver should be pinned to the same core in the IPC bm");
-    opts.optflag("b", "blocking", "Sender and Receiver should use blocking versions in the async IPC bm");
+    opts.optflag("b", "blocking", "Sender and Receiver should use blocking versions in the mpmc IPC bm");
     opts.optflag("c", "cycles", "Measure the IPC times in reference cycles (need to have a PMU for this option)");
 
 
@@ -157,8 +157,8 @@ pub fn main(args: Vec<String>) -> isize {
 					println!("RENDEZVOUS IPC");
 					do_ipc_rendezvous(pinned, cycles)
 				} else if matches.opt_present("a") {
-					println!("ASYNC IPC");
-					do_ipc_async(pinned, blocking, cycles)
+					println!("MPMC IPC");
+					do_ipc_mpmc(pinned, blocking, cycles)
 				} else {
 					Err("Specify channel type to use")
 				}
@@ -720,9 +720,9 @@ fn rendezvous_task_receiver((sender, receiver): (rendezvous::Sender<u8>, rendezv
     }
 }
 
-/// Measures the round trip time to send a 1-byte message on an async channel. 
-/// Calls `do_ipc_async_inner` multiple times to perform the actual operation
-fn do_ipc_async(pinned: bool, blocking: bool, cycles: bool) -> Result<(), &'static str> {
+/// Measures the round trip time to send a 1-byte message on an mpmc channel. 
+/// Calls `do_ipc_mpmc_inner` multiple times to perform the actual operation
+fn do_ipc_mpmc(pinned: bool, blocking: bool, cycles: bool) -> Result<(), &'static str> {
 	let child_core = if pinned {
 		Some(CPU_ID!())
 	} else {
@@ -738,9 +738,9 @@ fn do_ipc_async(pinned: bool, blocking: bool, cycles: bool) -> Result<(), &'stat
 
 	for i in 0..TRIES {
 		let lat = if cycles {
-			do_ipc_async_inner_cycles(i+1, TRIES, child_core, blocking)?	
+			do_ipc_mpmc_inner_cycles(i+1, TRIES, child_core, blocking)?	
 		} else {
-			do_ipc_async_inner(i+1, TRIES, child_core, blocking)?
+			do_ipc_mpmc_inner(i+1, TRIES, child_core, blocking)?
 		};
 		tries += lat;
 		vec.push(lat);
@@ -754,14 +754,14 @@ fn do_ipc_async(pinned: bool, blocking: bool, cycles: bool) -> Result<(), &'stat
 	// We expect the maximum and minimum to be within 10*THRESHOLD_ERROR_RATIO % of the mean value
 	let err = (lat * 10 * THRESHOLD_ERROR_RATIO) / 100;
 	if 	max - lat > err || lat - min > err {
-		printlnwarn!("ipc_async_test diff is too big: {} ({} - {})", max-min, max, min);
+		printlnwarn!("ipc_mpmc_test diff is too big: {} ({} - {})", max-min, max, min);
 	}
 	let stats = calculate_stats(&vec).ok_or("couldn't calculate stats")?;
 
 	if cycles {
-		printlninfo!("IPC ASYNC result: Round Trip Time: (cycles)",);
+		printlninfo!("IPC MPMC result: Round Trip Time: (cycles)",);
 	} else {
-		printlninfo!("IPC ASYNC result: Round Trip Time: ({})", T_UNIT);
+		printlninfo!("IPC MPMC result: Round Trip Time: ({})", T_UNIT);
 	}
 	printlninfo!("{:?}", stats);
 	printlninfo!("This test is equivalent to `lat_pipe` in LMBench when run with the pinned flag enabled");
@@ -772,13 +772,13 @@ fn do_ipc_async(pinned: bool, blocking: bool, cycles: bool) -> Result<(), &'stat
 /// Internal function that actually calculates the round trip time to send a message between two threads.
 /// This is measured by creating a child task, and sending messages between the parent and child.
 /// Overhead is measured by creating a task that just returns.
-fn do_ipc_async_inner(th: usize, nr: usize, child_core: Option<CpuId>, blocking: bool) -> Result<u64, &'static str> {
+fn do_ipc_mpmc_inner(th: usize, nr: usize, child_core: Option<CpuId>, blocking: bool) -> Result<u64, &'static str> {
 	let hpet = get_hpet().ok_or("Could not retrieve hpet counter")?;
 
-	let (sender_task, receiver_task): (fn((async_channel::Sender<u8>, async_channel::Receiver<u8>)), fn((async_channel::Sender<u8>, async_channel::Receiver<u8>))) = if blocking {
-		(async_task_sender, async_task_receiver)
+	let (sender_task, receiver_task): (fn((sync_channel::Sender<u8>, sync_channel::Receiver<u8>)), fn((sync_channel::Sender<u8>, sync_channel::Receiver<u8>))) = if blocking {
+		(mpmc_task_sender, mpmc_task_receiver)
 	} else {
-		(async_task_sender_nonblocking, async_task_receiver_nonblocking)
+		(mpmc_task_sender_nonblocking, mpmc_task_receiver_nonblocking)
 	};
 
 	// we first spawn one task to get the overhead of creating and joining the task
@@ -808,8 +808,8 @@ fn do_ipc_async_inner(th: usize, nr: usize, child_core: Option<CpuId>, blocking:
 		// which is 16 4 KiB-pages, or 65,536 bytes.
 		const CAPACITY: usize = 65536;
 
-		let (sender1, receiver1) = async_channel::new_channel(CAPACITY);
-		let (sender2, receiver2) = async_channel::new_channel(CAPACITY);
+		let (sender1, receiver1) = sync_channel::new_channel(CAPACITY);
+		let (sender2, receiver2) = sync_channel::new_channel(CAPACITY);
 		
 		let taskref1;
 
@@ -845,14 +845,14 @@ fn do_ipc_async_inner(th: usize, nr: usize, child_core: Option<CpuId>, blocking:
 /// Internal function that actually calculates the round trip time to send a message between two threads.
 /// This is measured by creating a child task, and sending messages between the parent and child.
 /// Overhead is measured by creating a task that just returns.
-fn do_ipc_async_inner_cycles(th: usize, nr: usize, child_core: Option<CpuId>, blocking: bool) -> Result<u64, &'static str> {
+fn do_ipc_mpmc_inner_cycles(th: usize, nr: usize, child_core: Option<CpuId>, blocking: bool) -> Result<u64, &'static str> {
 	pmu_x86::init()?;
 	let mut counter = start_counting_reference_cycles()?;
 
-	let (sender_task, receiver_task): (fn((async_channel::Sender<u8>, async_channel::Receiver<u8>)), fn((async_channel::Sender<u8>, async_channel::Receiver<u8>))) = if blocking {
-		(async_task_sender, async_task_receiver)
+	let (sender_task, receiver_task): (fn((sync_channel::Sender<u8>, sync_channel::Receiver<u8>)), fn((sync_channel::Sender<u8>, sync_channel::Receiver<u8>))) = if blocking {
+		(mpmc_task_sender, mpmc_task_receiver)
 	} else {
-		(async_task_sender_nonblocking, async_task_receiver_nonblocking)
+		(mpmc_task_sender_nonblocking, mpmc_task_receiver_nonblocking)
 	};
 
 	// we first spawn one task to get the overhead of creating and joining the task
@@ -883,8 +883,8 @@ fn do_ipc_async_inner_cycles(th: usize, nr: usize, child_core: Option<CpuId>, bl
 		// which is 16 4 KiB-pages, or 65,536 bytes.
 		const CAPACITY: usize = 65536;
 
-		let (sender1, receiver1) = async_channel::new_channel(CAPACITY);
-		let (sender2, receiver2) = async_channel::new_channel(CAPACITY);
+		let (sender1, receiver1) = sync_channel::new_channel(CAPACITY);
+		let (sender2, receiver2) = sync_channel::new_channel(CAPACITY);
 		
 		let taskref1;
 
@@ -916,25 +916,25 @@ fn do_ipc_async_inner_cycles(th: usize, nr: usize, child_core: Option<CpuId>, bl
 }
 
 /// A task which sends and then receives a message for a number of iterations
-fn async_task_sender((sender, receiver): (async_channel::Sender<u8>, async_channel::Receiver<u8>)) {
+fn mpmc_task_sender((sender, receiver): (sync_channel::Sender<u8>, sync_channel::Receiver<u8>)) {
 	let mut msg = 0;
     for _ in 0..ITERATIONS{
-		sender.send(msg).expect("async channel task: could not send message!");
-        msg = receiver.receive().expect("async channel task: could not receive message");
+		sender.send(msg).expect("mpmc channel task: could not send message!");
+        msg = receiver.receive().expect("mpmc channel task: could not receive message");
     }
 }
 
 /// A task which receives and then sends a message for a number of iterations
-fn async_task_receiver((sender, receiver): (async_channel::Sender<u8>, async_channel::Receiver<u8>)) {
+fn mpmc_task_receiver((sender, receiver): (sync_channel::Sender<u8>, sync_channel::Receiver<u8>)) {
 	let mut msg;
     for _ in 0..ITERATIONS{
-		msg = receiver.receive().expect("async channel task: could not receive message");
-		sender.send(msg).expect("async channel task: could not send message!");
+		msg = receiver.receive().expect("mpmc channel task: could not receive message");
+		sender.send(msg).expect("mpmc channel task: could not send message!");
     }
 }
 
 /// A task which sends and then receives a message for a number of iterations
-fn async_task_sender_nonblocking((sender, receiver): (async_channel::Sender<u8>, async_channel::Receiver<u8>)) {
+fn mpmc_task_sender_nonblocking((sender, receiver): (sync_channel::Sender<u8>, sync_channel::Receiver<u8>)) {
 	let mut msg = Ok(0);
     for _ in 0..ITERATIONS{
 		while sender.try_send(*msg.as_ref().unwrap()).is_err() {}
@@ -946,7 +946,7 @@ fn async_task_sender_nonblocking((sender, receiver): (async_channel::Sender<u8>,
 }
 
 /// A task which receives and then sends a message for a number of iterations
-fn async_task_receiver_nonblocking((sender, receiver): (async_channel::Sender<u8>, async_channel::Receiver<u8>)) {
+fn mpmc_task_receiver_nonblocking((sender, receiver): (sync_channel::Sender<u8>, sync_channel::Receiver<u8>)) {
 	let mut msg;
     for _ in 0..ITERATIONS{
 		msg = receiver.try_receive();

--- a/applications/test_channel/Cargo.toml
+++ b/applications/test_channel/Cargo.toml
@@ -29,5 +29,5 @@ path = "../../kernel/spawn"
 [dependencies.rendezvous]
 path = "../../kernel/rendezvous"
 
-[dependencies.async_channel]
-path = "../../kernel/async_channel"
+[dependencies.sync_channel]
+path = "../../kernel/sync_channel"

--- a/applications/test_channel/src/lib.rs
+++ b/applications/test_channel/src/lib.rs
@@ -9,7 +9,7 @@ extern crate task;
 extern crate spawn;
 extern crate scheduler;
 extern crate rendezvous;
-extern crate async_channel;
+extern crate sync_channel;
 extern crate cpu;
 
 
@@ -117,13 +117,13 @@ fn rmain(matches: Matches) -> Result<(), &'static str> {
     println!("Running rendezvous channel test in multiple mode.");
     rendezvous_test_multiple(send_count!(), receive_count!(), send_panic_point, receive_panic_point)?;
 
-    println!("Running asynchronous channel test in oneshot mode.");
+    println!("Running mpmc channel test in oneshot mode.");
     for _i in 0 .. iterations!() {
-        asynchronous_test_oneshot()?;
+        mpmc_test_oneshot()?;
     }
 
-    println!("Running asynchronous channel test in multiple mode.");
-    asynchronous_test_multiple(send_count!(), receive_count!(), send_panic_point, receive_panic_point)?;
+    println!("Running mpmc channel test in multiple mode.");
+    mpmc_test_multiple(send_count!(), receive_count!(), send_panic_point, receive_panic_point)?;
 
     Ok(())
 }
@@ -250,84 +250,84 @@ fn rendezvous_sender_task ((sender, iterations, panic_point): (rendezvous::Sende
 
 /// A simple test that spawns a sender & receiver task to send a single message
 /// Optionally can set panics at `send_panic` and `receive_panic` locations
-fn asynchronous_test_oneshot() -> Result<(), &'static str> {
+fn mpmc_test_oneshot() -> Result<(), &'static str> {
     let my_cpu = cpu::current_cpu();
 
-    let (sender, receiver) = async_channel::new_channel(2);
+    let (sender, receiver) = sync_channel::new_channel(2);
 
     let t1 = spawn::new_task_builder(|_: ()| -> Result<(), &'static str> {
-        warn!("asynchronous_test_oneshot(): Entered sender task!");
+        warn!("mpmc_test_oneshot(): Entered sender task!");
         sender.send("hello").map_err(|error| {
             warn!("Sender task failed due to : {:?}", error);
             return "Sender task failed";
         })?;
         Ok(())
     }, ())
-        .name(String::from("sender_task_asynchronous_oneshot"))
+        .name(String::from("sender_task_mpmc_oneshot"))
         .block();
     let t1 = pin_task!(t1, my_cpu).spawn()?;
 
     let t2 = spawn::new_task_builder(|_: ()| -> Result<(), &'static str> {
-        warn!("asynchronous_test_oneshot(): Entered receiver task!");
+        warn!("mpmc_test_oneshot(): Entered receiver task!");
         let msg = receiver.receive().map_err(|error| {
             warn!("Receiver task failed due to : {:?}", error);
             return "Receiver task failed"
         })?;
-        warn!("asynchronous_test_oneshot(): Receiver got msg: {:?}", msg);
+        warn!("mpmc_test_oneshot(): Receiver got msg: {:?}", msg);
         Ok(())
     }, ())
-        .name(String::from("receiver_task_asynchronous_oneshot"))
+        .name(String::from("receiver_task_mpmc_oneshot"))
         .block();
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
-    warn!("asynchronous_test_oneshot(): Finished spawning the sender and receiver tasks");
+    warn!("mpmc_test_oneshot(): Finished spawning the sender and receiver tasks");
     t2.unblock().unwrap();
     t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
-    warn!("asynchronous_test_oneshot(): Joined the sender and receiver tasks.");
+    warn!("mpmc_test_oneshot(): Joined the sender and receiver tasks.");
     
     Ok(())
 }
 
 
 /// A simple test that spawns a sender & receiver task to send `send_count` and receive `receive_count` messages.
-fn asynchronous_test_multiple(send_count: usize, receive_count: usize, send_panic: Option<usize>, receive_panic: Option<usize>) -> Result<(), &'static str> {
+fn mpmc_test_multiple(send_count: usize, receive_count: usize, send_panic: Option<usize>, receive_panic: Option<usize>) -> Result<(), &'static str> {
     let my_cpu = cpu::current_cpu();
 
-    let (sender, receiver) = async_channel::new_channel(2);
+    let (sender, receiver) = sync_channel::new_channel(2);
 
-    let t1 = spawn::new_task_builder(asynchronous_sender_task, (sender, send_count, send_panic))
-        .name(String::from("sender_task_asynchronous"))
+    let t1 = spawn::new_task_builder(mpmc_sender_task, (sender, send_count, send_panic))
+        .name(String::from("sender_task_mpmc"))
         .block();
 
     let t1 = pin_task!(t1, my_cpu).spawn()?;
 
-    let t2 = spawn::new_task_builder(asynchronous_receiver_task, (receiver, receive_count, receive_panic))
-        .name(String::from("receiver_task_asynchronous"))
+    let t2 = spawn::new_task_builder(mpmc_receiver_task, (receiver, receive_count, receive_panic))
+        .name(String::from("receiver_task_mpmc"))
         .block();
 
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
-    warn!("asynchronous_test_multiple(): Finished spawning the sender and receiver tasks");
+    warn!("mpmc_test_multiple(): Finished spawning the sender and receiver tasks");
     t2.unblock().unwrap();
     t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
-    warn!("asynchronous_test_multiple(): Joined the sender and receiver tasks.");
+    warn!("mpmc_test_multiple(): Joined the sender and receiver tasks.");
     
     Ok(())
 }
 
 /// A simple receiver receiving `iterations` messages
 /// Optionally may panic after sending `panic_pont` messages
-fn asynchronous_receiver_task ((receiver, iterations, panic_point): (async_channel::Receiver<String>, usize, Option<usize>)) -> Result<(), &'static str> {
-    warn!("asynchronous_test(): Entered receiver task! Expecting to receive {} messages", iterations);
+fn mpmc_receiver_task ((receiver, iterations, panic_point): (sync_channel::Receiver<String>, usize, Option<usize>)) -> Result<(), &'static str> {
+    warn!("mpmc_test(): Entered receiver task! Expecting to receive {} messages", iterations);
     
     if panic_point.is_some(){
-        warn!("asynchronous_test(): Panic will occur in receiver task at message {}",panic_point.unwrap());
+        warn!("mpmc_test(): Panic will occur in receiver task at message {}",panic_point.unwrap());
     }
 
     for i in 0..iterations {
@@ -335,23 +335,23 @@ fn asynchronous_receiver_task ((receiver, iterations, panic_point): (async_chann
             warn!("Receiver task failed due to : {:?}", error);
             return "Receiver task failed"
         })?;
-        warn!("asynchronous_test(): Receiver got {:?}  ({:03})", msg, i);
+        warn!("mpmc_test(): Receiver got {:?}  ({:03})", msg, i);
 
         if panic_point == Some(i) {
             panic!("rendezvous_test() : User specified panic in receiver");
         }
     }
 
-    warn!("asynchronous_test(): Done receiver task!");
+    warn!("mpmc_test(): Done receiver task!");
     Ok(())
 }
 
 /// A simple sender sending `iterations` messages
 /// Optionally may panic after sending `panic_pont` messages
-fn asynchronous_sender_task ((sender, iterations, panic_point): (async_channel::Sender<String>, usize, Option<usize>)) -> Result<(), &'static str> {
-    warn!("asynchronous_test(): Entered sender task! Expecting to send {} messages", iterations);
+fn mpmc_sender_task ((sender, iterations, panic_point): (sync_channel::Sender<String>, usize, Option<usize>)) -> Result<(), &'static str> {
+    warn!("mpmc_test(): Entered sender task! Expecting to send {} messages", iterations);
     if panic_point.is_some(){
-        warn!("asynchronous_test(): Panic will occur in sender task at message {}",panic_point.unwrap());
+        warn!("mpmc_test(): Panic will occur in sender task at message {}",panic_point.unwrap());
     }
 
     for i in 0..iterations {
@@ -359,14 +359,14 @@ fn asynchronous_sender_task ((sender, iterations, panic_point): (async_channel::
             warn!("Sender task failed due to : {:?}", error);
             return "Sender task failed";
         })?;
-        warn!("asynchronous_test(): Sender sent message {:03}", i);
+        warn!("mpmc_test(): Sender sent message {:03}", i);
 
         if panic_point == Some(i) {
             panic!("rendezvous_test() : User specified panic in receiver");
         }
     }
 
-    warn!("asynchronous_test(): Done sender task!");
+    warn!("mpmc_test(): Done sender task!");
     Ok(())
 }
 

--- a/applications/test_channel/src/lib.rs
+++ b/applications/test_channel/src/lib.rs
@@ -117,13 +117,13 @@ fn rmain(matches: Matches) -> Result<(), &'static str> {
     println!("Running rendezvous channel test in multiple mode.");
     rendezvous_test_multiple(send_count!(), receive_count!(), send_panic_point, receive_panic_point)?;
 
-    println!("Running mpmc channel test in oneshot mode.");
+    println!("Running sync channel test in oneshot mode.");
     for _i in 0 .. iterations!() {
-        mpmc_test_oneshot()?;
+        sync_test_oneshot()?;
     }
 
-    println!("Running mpmc channel test in multiple mode.");
-    mpmc_test_multiple(send_count!(), receive_count!(), send_panic_point, receive_panic_point)?;
+    println!("Running sync channel test in multiple mode.");
+    sync_test_multiple(send_count!(), receive_count!(), send_panic_point, receive_panic_point)?;
 
     Ok(())
 }
@@ -250,84 +250,84 @@ fn rendezvous_sender_task ((sender, iterations, panic_point): (rendezvous::Sende
 
 /// A simple test that spawns a sender & receiver task to send a single message
 /// Optionally can set panics at `send_panic` and `receive_panic` locations
-fn mpmc_test_oneshot() -> Result<(), &'static str> {
+fn sync_test_oneshot() -> Result<(), &'static str> {
     let my_cpu = cpu::current_cpu();
 
     let (sender, receiver) = sync_channel::new_channel(2);
 
     let t1 = spawn::new_task_builder(|_: ()| -> Result<(), &'static str> {
-        warn!("mpmc_test_oneshot(): Entered sender task!");
+        warn!("sync_test_oneshot(): Entered sender task!");
         sender.send("hello").map_err(|error| {
             warn!("Sender task failed due to : {:?}", error);
             return "Sender task failed";
         })?;
         Ok(())
     }, ())
-        .name(String::from("sender_task_mpmc_oneshot"))
+        .name(String::from("sender_task_sync_oneshot"))
         .block();
     let t1 = pin_task!(t1, my_cpu).spawn()?;
 
     let t2 = spawn::new_task_builder(|_: ()| -> Result<(), &'static str> {
-        warn!("mpmc_test_oneshot(): Entered receiver task!");
+        warn!("sync_test_oneshot(): Entered receiver task!");
         let msg = receiver.receive().map_err(|error| {
             warn!("Receiver task failed due to : {:?}", error);
             return "Receiver task failed"
         })?;
-        warn!("mpmc_test_oneshot(): Receiver got msg: {:?}", msg);
+        warn!("sync_test_oneshot(): Receiver got msg: {:?}", msg);
         Ok(())
     }, ())
-        .name(String::from("receiver_task_mpmc_oneshot"))
+        .name(String::from("receiver_task_sync_oneshot"))
         .block();
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
-    warn!("mpmc_test_oneshot(): Finished spawning the sender and receiver tasks");
+    warn!("sync_test_oneshot(): Finished spawning the sender and receiver tasks");
     t2.unblock().unwrap();
     t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
-    warn!("mpmc_test_oneshot(): Joined the sender and receiver tasks.");
+    warn!("sync_test_oneshot(): Joined the sender and receiver tasks.");
     
     Ok(())
 }
 
 
 /// A simple test that spawns a sender & receiver task to send `send_count` and receive `receive_count` messages.
-fn mpmc_test_multiple(send_count: usize, receive_count: usize, send_panic: Option<usize>, receive_panic: Option<usize>) -> Result<(), &'static str> {
+fn sync_test_multiple(send_count: usize, receive_count: usize, send_panic: Option<usize>, receive_panic: Option<usize>) -> Result<(), &'static str> {
     let my_cpu = cpu::current_cpu();
 
     let (sender, receiver) = sync_channel::new_channel(2);
 
-    let t1 = spawn::new_task_builder(mpmc_sender_task, (sender, send_count, send_panic))
-        .name(String::from("sender_task_mpmc"))
+    let t1 = spawn::new_task_builder(sync_sender_task, (sender, send_count, send_panic))
+        .name(String::from("sender_task_sync"))
         .block();
 
     let t1 = pin_task!(t1, my_cpu).spawn()?;
 
-    let t2 = spawn::new_task_builder(mpmc_receiver_task, (receiver, receive_count, receive_panic))
-        .name(String::from("receiver_task_mpmc"))
+    let t2 = spawn::new_task_builder(sync_receiver_task, (receiver, receive_count, receive_panic))
+        .name(String::from("receiver_task_sync"))
         .block();
 
     let t2 = pin_task!(t2, my_cpu).spawn()?;
 
-    warn!("mpmc_test_multiple(): Finished spawning the sender and receiver tasks");
+    warn!("sync_test_multiple(): Finished spawning the sender and receiver tasks");
     t2.unblock().unwrap();
     t1.unblock().unwrap();
 
     t1.join()?;
     t2.join()?;
-    warn!("mpmc_test_multiple(): Joined the sender and receiver tasks.");
+    warn!("sync_test_multiple(): Joined the sender and receiver tasks.");
     
     Ok(())
 }
 
 /// A simple receiver receiving `iterations` messages
 /// Optionally may panic after sending `panic_pont` messages
-fn mpmc_receiver_task ((receiver, iterations, panic_point): (sync_channel::Receiver<String>, usize, Option<usize>)) -> Result<(), &'static str> {
-    warn!("mpmc_test(): Entered receiver task! Expecting to receive {} messages", iterations);
+fn sync_receiver_task ((receiver, iterations, panic_point): (sync_channel::Receiver<String>, usize, Option<usize>)) -> Result<(), &'static str> {
+    warn!("sync_test(): Entered receiver task! Expecting to receive {} messages", iterations);
     
     if panic_point.is_some(){
-        warn!("mpmc_test(): Panic will occur in receiver task at message {}",panic_point.unwrap());
+        warn!("sync_test(): Panic will occur in receiver task at message {}",panic_point.unwrap());
     }
 
     for i in 0..iterations {
@@ -335,23 +335,23 @@ fn mpmc_receiver_task ((receiver, iterations, panic_point): (sync_channel::Recei
             warn!("Receiver task failed due to : {:?}", error);
             return "Receiver task failed"
         })?;
-        warn!("mpmc_test(): Receiver got {:?}  ({:03})", msg, i);
+        warn!("sync_test(): Receiver got {:?}  ({:03})", msg, i);
 
         if panic_point == Some(i) {
             panic!("rendezvous_test() : User specified panic in receiver");
         }
     }
 
-    warn!("mpmc_test(): Done receiver task!");
+    warn!("sync_test(): Done receiver task!");
     Ok(())
 }
 
 /// A simple sender sending `iterations` messages
 /// Optionally may panic after sending `panic_pont` messages
-fn mpmc_sender_task ((sender, iterations, panic_point): (sync_channel::Sender<String>, usize, Option<usize>)) -> Result<(), &'static str> {
-    warn!("mpmc_test(): Entered sender task! Expecting to send {} messages", iterations);
+fn sync_sender_task ((sender, iterations, panic_point): (sync_channel::Sender<String>, usize, Option<usize>)) -> Result<(), &'static str> {
+    warn!("sync_test(): Entered sender task! Expecting to send {} messages", iterations);
     if panic_point.is_some(){
-        warn!("mpmc_test(): Panic will occur in sender task at message {}",panic_point.unwrap());
+        warn!("sync_test(): Panic will occur in sender task at message {}",panic_point.unwrap());
     }
 
     for i in 0..iterations {
@@ -359,14 +359,14 @@ fn mpmc_sender_task ((sender, iterations, panic_point): (sync_channel::Sender<St
             warn!("Sender task failed due to : {:?}", error);
             return "Sender task failed";
         })?;
-        warn!("mpmc_test(): Sender sent message {:03}", i);
+        warn!("sync_test(): Sender sent message {:03}", i);
 
         if panic_point == Some(i) {
             panic!("rendezvous_test() : User specified panic in receiver");
         }
     }
 
-    warn!("mpmc_test(): Done sender task!");
+    warn!("sync_test(): Done sender task!");
     Ok(())
 }
 

--- a/kernel/console/Cargo.toml
+++ b/kernel/console/Cargo.toml
@@ -10,7 +10,7 @@ log = "0.4.8"
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 
 app_io = { path = "../app_io" }
-async_channel = { path = "../async_channel" }
+sync_channel = { path = "../sync_channel" }
 io = { path = "../io" }
 mod_mgmt = { path = "../mod_mgmt" }
 path = { path = "../path" }

--- a/kernel/console/src/lib.rs
+++ b/kernel/console/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate alloc;
 
 use alloc::{format, sync::Arc};
-use async_channel::Receiver;
+use sync_channel::Receiver;
 use core::sync::atomic::{AtomicU16, Ordering};
 use core2::io::Write;
 use sync_irq::IrqSafeMutex;
@@ -31,7 +31,7 @@ pub fn ignore_serial_port_input(serial_port_address: u16) {
 ///
 /// Returns the newly-spawned detection task.
 pub fn start_connection_detection() -> Result<JoinableTaskRef, &'static str> {
-    let (sender, receiver) = async_channel::new_channel(4);
+    let (sender, receiver) = sync_channel::new_channel(4);
     serial_port::set_connection_listener(sender);
 
     spawn::new_task_builder(console_connection_detector, receiver)
@@ -69,7 +69,7 @@ fn console_connection_detector(
             }
         };
 
-        let (sender, receiver) = async_channel::new_channel(16);
+        let (sender, receiver) = sync_channel::new_channel(16);
         if serial_port.lock().set_data_sender(sender).is_err() {
             warn!(
                 "Serial port {:?} already had a data sender, skipping console connection request",

--- a/kernel/serial_port/Cargo.toml
+++ b/kernel/serial_port/Cargo.toml
@@ -16,7 +16,7 @@ interrupts = { path = "../interrupts" }
 deferred_interrupt_tasks = { path = "../deferred_interrupt_tasks" }
 
 # Dependencies below here are temporary, for console creation testing.
-async_channel = { path = "../async_channel" }
+sync_channel = { path = "../sync_channel" }
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/serial_port/src/lib.rs
+++ b/kernel/serial_port/src/lib.rs
@@ -39,8 +39,8 @@ use interrupts::{PL011_RX_SPI, init_pl011_rx_interrupt};
 
 // Dependencies below here are temporary and will be removed
 // after we have support for separate interrupt handling tasks.
-extern crate async_channel;
-use async_channel::Sender;
+extern crate sync_channel;
+use sync_channel::Sender;
 
 /// A temporary hack to allow the serial port interrupt handler
 /// to inform a listener on the other end of this channel

--- a/kernel/sync_channel/Cargo.toml
+++ b/kernel/sync_channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Kevin Boos <kevinaboos@gmail.com>"]
-name = "async_channel"
+name = "sync_channel"
 description = "Channel for asynchronous Inter-Task Communication via a bounded buffer"
 version = "0.1.0"
 

--- a/kernel/tty/Cargo.toml
+++ b/kernel/tty/Cargo.toml
@@ -6,7 +6,7 @@ description = "TTY abstractions"
 edition = "2021"
 
 [dependencies]
-async_channel = { path = "../async_channel" }
+sync_channel = { path = "../sync_channel" }
 sync_block = { path = "../sync_block" }
 
 [dependencies.core2]

--- a/kernel/tty/src/channel.rs
+++ b/kernel/tty/src/channel.rs
@@ -1,4 +1,4 @@
-use async_channel::{Receiver, Sender};
+use sync_channel::{Receiver, Sender};
 use core2::io::Result;
 
 #[derive(Clone)]
@@ -9,7 +9,7 @@ pub(crate) struct Channel {
 
 impl Channel {
     pub(crate) fn new() -> Self {
-        let (sender, receiver) = async_channel::new_channel(256);
+        let (sender, receiver) = sync_channel::new_channel(256);
         Self { sender, receiver }
     }
 

--- a/kernel/tty/src/discipline.rs
+++ b/kernel/tty/src/discipline.rs
@@ -2,7 +2,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use crate::Channel;
 use alloc::vec::Vec;
-use async_channel::{new_channel, Receiver, Sender};
+use sync_channel::{new_channel, Receiver, Sender};
 use core2::io::Result;
 use sync_block::Mutex;
 

--- a/kernel/unified_channel/Cargo.toml
+++ b/kernel/unified_channel/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["Kevin Boos <kevinaboos@gmail.com>"]
 [dependencies]
 cfg-if = "0.1.6"
 
-[dependencies.async_channel]
-path = "../async_channel"
+[dependencies.sync_channel]
+path = "../sync_channel"
 
 [dependencies.rendezvous]
 path = "../rendezvous"


### PR DESCRIPTION
Renames the current `async_channel` to `sync_channel`.

Signed-off-by: Klimenty Tsoutsman <klim@tsoutsman.com>