### PR TITLE
Increase PS/2 timeouts for reset

### DIFF
--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -309,7 +309,7 @@ impl<'c> PS2Mouse<'c> {
     /// Reset the mouse.
     pub fn reset(&self) -> Result<(), &'static str> {
         self.command_to_mouse(HostToMouseCommandOrData::MouseCommand(Reset))?;
-        const VERY_ARBITRARY_TIMEOUT_VALUE: u16 = u16::MAX;
+        const VERY_ARBITRARY_TIMEOUT_VALUE: u32 = u16::MAX as u32 * 3;
         for _ in 0..VERY_ARBITRARY_TIMEOUT_VALUE {
             if let Ok(SelfTestPassed) = self.controller.read_data().try_into() { //not sure if we need to do this here, as command_to_mouse handles it on real hardware at least (same goes for keyboard reset)
                 //returns mouse id 0
@@ -476,7 +476,7 @@ impl<'c> PS2Keyboard<'c> {
         self.command_to_keyboard(HostToKeyboardCommandOrData::KeyboardCommand(ResetAndStartSelfTest))?;
         // VirtualBox and presumably real hardware wants this. Qemu worked without this.
         // Sadly self.controller.polling_receive doesn't work here, either.
-        const VERY_ARBITRARY_TIMEOUT_VALUE: u16 = u16::MAX;
+        const VERY_ARBITRARY_TIMEOUT_VALUE: u32 = u16::MAX as u32 * 4;
         for _ in 0..VERY_ARBITRARY_TIMEOUT_VALUE {
             if let Ok(SelfTestPassed) = self.controller.read_data().try_into() {
                 return Ok(())


### PR DESCRIPTION
The chosen arbitrary timeout value works in qemu, but causes a panic on boot on a Dell Optiplex 9020. I've tried a few values and with these, it boots with a Cherry and a HP keyboard and two Logitech mice.

-------------

I also had to change the `ScancodeSet` to `Set2` for the Cherry keyboard, but that's not in this PR. With these changes, Theseus *boots* on the Optiplex. I still can't input text or move the mouse.
Also, I think it would be nice if booting didn't require a mouse.