### PR TITLE
Allow booting without keyboard or mouse

### DIFF
--- a/kernel/device_manager/src/lib.rs
+++ b/kernel/device_manager/src/lib.rs
@@ -76,8 +76,12 @@ pub fn init(
     // PS/2 is x86_64 only
     #[cfg(target_arch = "x86_64")] {
         let ps2_controller = ps2::init()?;
-        keyboard::init(ps2_controller.keyboard_ref(), key_producer)?;
-        mouse::init(ps2_controller.mouse_ref(), mouse_producer)?;
+        if let Some(kb) = ps2_controller.keyboard_ref() {
+            keyboard::init(kb, key_producer)?;
+        }
+        if let Some(m) = ps2_controller.mouse_ref() {
+            mouse::init(m, mouse_producer)?;
+        }
     }
 
     pci::init()?;


### PR DESCRIPTION
If a PS/2 controller exists, but no keyboard or mouse is plugged in, resetting those devices fails. Handle this gracefully by logging an error and continuing without them.

I really don't know much about PS/2 but this allows booting on a real PC without keyboard or mouse (and it correctly detects which of those is missing).