### PR TITLE
Don't hardcode the path for bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ### This makefile is the top-level build script that builds all the crates in subdirectories 
 ### and combines them into the final OS .iso image.
 ### It also provides convenient targets for running and debugging Theseus and using GDB on your host computer.
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 ## Disable parallelism for this Makefile since it breaks the build,
 ## as our dependencies aren't perfectly specified for each target.

--- a/cfg/Config.mk
+++ b/cfg/Config.mk
@@ -3,7 +3,7 @@
 ### So, to access the directory containing this file, you would use "../"
 
 .DEFAULT_GOAL := all
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 ## specifies which architecture we're building for
 ARCH ?= x86_64


### PR DESCRIPTION
Some systems (eg. NixOS) don't have it in /bin.