### PR TITLE
Don't try to initialize mouse or keyboard if there's no port

### DIFF
--- a/kernel/ps2/src/lib.rs
+++ b/kernel/ps2/src/lib.rs
@@ -111,17 +111,21 @@ pub fn init() -> Result<&'static PS2Controller, &'static str> {
     controller.write_config(config);
 
     // Step 10: Reset Devices
-    let keyboard_ref = PS2Keyboard::new(&controller);
-    if let Err(e) = keyboard_ref.reset() {
-        warn!("couldn't reset the keyboard; assuming there is none: {e}");
-    } else {
-        controller.keyboard_attached = true;
+    if port_1_works {
+        let keyboard_ref = PS2Keyboard::new(&controller);
+        if let Err(e) = keyboard_ref.reset() {
+            warn!("couldn't reset the keyboard; assuming there is none: {e}");
+        } else {
+            controller.keyboard_attached = true;
+        }
     }
-    let mouse_ref = PS2Mouse::new(&controller);
-    if let Err(e) = mouse_ref.reset() {
-        warn!("couldn't reset the mouse; assuming there is none: {e}");
-    } else {
-        controller.mouse_attached = true;
+    if port_2_works {
+        let mouse_ref = PS2Mouse::new(&controller);
+        if let Err(e) = mouse_ref.reset() {
+            warn!("couldn't reset the mouse; assuming there is none: {e}");
+        } else {
+            controller.mouse_attached = true;
+        }
     }
 
     debug!("Final PS/2 {:?}", controller.read_config());


### PR DESCRIPTION
I had hoped that #1082 would be my last PS/2-related PR, but alas, the hardware I'm working with behaves differently whether it's  being cold booted or rebooted from Linux. :(

There seems to be a case where the controller is detected as single channel, but resetting the mouse still succeeds. Setting the sampling rate then fails.

I hope this change makes sense. Input still doesn't work on the Optiplex, but I'm running into less errors on boot.