### PR TITLE
Lazily remove exited tasks from run queue

### DIFF
--- a/kernel/scheduler_priority/src/lib.rs
+++ b/kernel/scheduler_priority/src/lib.rs
@@ -1,11 +1,12 @@
 //! This scheduler implements a priority algorithm.
 
 #![no_std]
+#![feature(core_intrinsics)]
 
 extern crate alloc;
 
 use alloc::{boxed::Box, collections::BinaryHeap, vec::Vec};
-use core::cmp::Ordering;
+use core::{cmp::Ordering, intrinsics::likely};
 
 use task::TaskRef;
 use time::Instant;
@@ -39,7 +40,7 @@ impl task::scheduler::Scheduler for Scheduler {
                 task.last_ran = time::now::<time::Monotonic>();
                 self.queue.push(task.clone());
                 return task.task;
-            } else {
+            } else if likely(!task.task.is_complete()) {
                 blocked_tasks.push(task);
             }
         }

--- a/kernel/spawn/src/lib.rs
+++ b/kernel/spawn/src/lib.rs
@@ -155,7 +155,6 @@ impl Drop for BootstrapTaskRef {
     // See the documentation for `BootstrapTaskRef::finish()` for more details.
     fn drop(&mut self) {
         // trace!("Finishing Bootstrap Task on core {}: {:?}", self.cpu_id, self.task_ref);
-        remove_current_task_from_runqueue(&self.exitable_taskref);
         self.exitable_taskref.mark_as_exited(Box::new(()))
             .expect("BUG: bootstrap task was unable to mark itself as exited");
 
@@ -996,11 +995,6 @@ where
     scheduler::schedule();
     error!("BUG: task_cleanup_final(): task was rescheduled after being dead!");
     loop { core::hint::spin_loop() }
-}
-
-/// Helper function to remove a task from its runqueue and drop it.
-fn remove_current_task_from_runqueue(current_task: &ExitableTaskRef) {
-    task::scheduler::remove_task(current_task);
 }
 
 /// A basic idle task that does nothing but loop endlessly.

--- a/kernel/task_struct/src/lib.rs
+++ b/kernel/task_struct/src/lib.rs
@@ -397,8 +397,21 @@ impl Task {
     /// [`Runnable`]: RunState::Runnable
     /// [suspended]: Task::is_suspended
     /// [running]: Task::is_running
+    #[inline]
     pub fn is_runnable(&self) -> bool {
         self.runstate() == RunState::Runnable && !self.is_suspended()
+    }
+
+    /// Returns whether this `Task` is complete i.e. will never be runnable again.
+    ///
+    /// A task is complete if it is in an [`Exited`] or [`Reaped`] run state.
+    ///
+    /// [`Exited`]: RunState::Exited
+    /// [`Reaped`]: RunState::Reaped
+    #[inline]
+    pub fn is_complete(&self) -> bool {
+        let run_state = self.runstate();
+        run_state == RunState::Exited || run_state == RunState::Reaped
     }
 
     /// Returns the namespace that this `Task` is loaded/linked into and runs within.


### PR DESCRIPTION
Avoids locking all the schedulers on task exit.

This PR also technically changes the round robin scheduler algorithm, as blocked tasks are now moved to the end of the run queue. Previously, the blocked tasks would be kept in place, aside from the task at the front of the queue which would be switched with the next runnable task using `swap_remove_front`.