### PR TITLE
Add size option (-s) in the `ls` command

### DIFF
--- a/applications/ls/src/lib.rs
+++ b/applications/ls/src/lib.rs
@@ -19,6 +19,7 @@ use path::Path;
 pub fn main(args: Vec<String>) -> isize {
     let mut opts = Options::new();
     opts.optflag("h", "help", "print this help menu");
+    opts.optflag("s", "size", "print the size of each file in directory");
 
     let matches = match opts.parse(args) {
         Ok(m) => m,
@@ -34,13 +35,21 @@ pub fn main(args: Vec<String>) -> isize {
         return 0;
     }
 
+    let size_option = matches.opt_present("s");
+
     let Ok(curr_wd) = task::with_current_task(|t| t.get_env().lock().working_dir.clone()) else {
         println!("failed to get current task");
         return -1;
     };
+
+    if size_option && matches.free.is_empty() {
+        print_children(&curr_wd, true);
+        return 0;
+    }
+
     // print children of working directory if no child is specified
     if matches.free.is_empty() {
-        print_children(&curr_wd);
+        print_children(&curr_wd, false);
         return 0;
     }
 
@@ -49,7 +58,12 @@ pub fn main(args: Vec<String>) -> isize {
     // Navigate to the path specified by first argument
     match path.get(&curr_wd) {
         Some(FileOrDir::Dir(dir)) => {
-            print_children(&dir);
+            if size_option {
+                print_children(&dir, true);
+            }
+            else {
+                print_children(&dir, false);
+            }
             0
         }
         Some(FileOrDir::File(file)) => {
@@ -63,12 +77,18 @@ pub fn main(args: Vec<String>) -> isize {
     }
 }
 
-fn print_children(dir: &DirRef) {
+fn print_children(dir: &DirRef, print_size: bool) {
     let mut child_string = String::new();
     let mut child_list = dir.lock().list(); 
     child_list.reverse();
     for child in child_list.iter() {
-        writeln!(child_string, "{child}").expect("Failed to write child_string");
+        let child_path = dir.lock().get(child).expect("Failed to get child path");
+        if print_size {
+            let size = FileOrDir::get_file_size(&child_path);
+            writeln!(child_string, "   {}    {}", size, child).expect("Failed to write child_string");
+        } else {
+            writeln!(child_string, "{}", child).expect("Failed to write child_string");
+        }
     }
     println!("{}", child_string);
 }

--- a/applications/ls/src/lib.rs
+++ b/applications/ls/src/lib.rs
@@ -42,11 +42,6 @@ pub fn main(args: Vec<String>) -> isize {
         return -1;
     };
 
-    if size_option && matches.free.is_empty() {
-        print_children(&curr_wd, size_option);
-        return 0;
-    }
-
     // print children of working directory if no child is specified
     if matches.free.is_empty() {
         print_children(&curr_wd, size_option);

--- a/applications/ls/src/lib.rs
+++ b/applications/ls/src/lib.rs
@@ -43,13 +43,13 @@ pub fn main(args: Vec<String>) -> isize {
     };
 
     if size_option && matches.free.is_empty() {
-        print_children(&curr_wd, true);
+        print_children(&curr_wd, size_option);
         return 0;
     }
 
     // print children of working directory if no child is specified
     if matches.free.is_empty() {
-        print_children(&curr_wd, false);
+        print_children(&curr_wd, size_option);
         return 0;
     }
 
@@ -58,12 +58,7 @@ pub fn main(args: Vec<String>) -> isize {
     // Navigate to the path specified by first argument
     match path.get(&curr_wd) {
         Some(FileOrDir::Dir(dir)) => {
-            if size_option {
-                print_children(&dir, true);
-            }
-            else {
-                print_children(&dir, false);
-            }
+            print_children(&dir, size_option);
             0
         }
         Some(FileOrDir::File(file)) => {
@@ -84,8 +79,15 @@ fn print_children(dir: &DirRef, print_size: bool) {
     for child in child_list.iter() {
         let child_path = dir.lock().get(child).expect("Failed to get child path");
         if print_size {
-            let size = FileOrDir::get_file_size(&child_path);
-            writeln!(child_string, "   {}    {}", size, child).expect("Failed to write child_string");
+            match &child_path {
+                FileOrDir::File(file_ref) => {
+                    let file = file_ref.lock();
+                    writeln!(child_string, "   {}    {}", file.len(), child).expect("Failed to write child_string");
+                },
+                FileOrDir::Dir(_) => {
+                    writeln!(child_string, "   --    {}", child).expect("Failed to write child_string");
+                },
+            };
         } else {
             writeln!(child_string, "{}", child).expect("Failed to write child_string");
         }

--- a/kernel/fs_node/src/lib.rs
+++ b/kernel/fs_node/src/lib.rs
@@ -24,14 +24,6 @@ use alloc::sync::{Arc, Weak};
 use memory::MappedPages;
 use io::{ByteReader, ByteWriter, KnownLength};
 
-/// A value to represent the space on the disk (stored in meta-information) for directores
-macro_rules! DIRECTORY_DISK_SPACE {
-    () => {
-        4096
-    };
-}
-
-
 /// A reference to any type that implements the [`File`] trait,
 /// which can only represent a File (not a Directory).
 pub type FileRef = Arc<Mutex<dyn File + Send>>;
@@ -195,17 +187,6 @@ impl FileOrDir {
         match &self {
             FileOrDir::File(_) => false,
             FileOrDir::Dir(_) => true,
-        }
-    }
-
-    /// Returns the size of the file in bytes, or directory disk space.
-    pub fn get_file_size(file_or_dir: &FileOrDir) -> usize {
-        match file_or_dir {
-            FileOrDir::File(file_ref) => {
-                let file = file_ref.lock();
-                file.len()
-            },
-            FileOrDir::Dir(_) => DIRECTORY_DISK_SPACE!(),
         }
     }
 }

--- a/kernel/fs_node/src/lib.rs
+++ b/kernel/fs_node/src/lib.rs
@@ -24,6 +24,13 @@ use alloc::sync::{Arc, Weak};
 use memory::MappedPages;
 use io::{ByteReader, ByteWriter, KnownLength};
 
+/// A value to represent the space on the disk (stored in meta-information) for directores
+macro_rules! DIRECTORY_DISK_SPACE {
+    () => {
+        4096
+    };
+}
+
 
 /// A reference to any type that implements the [`File`] trait,
 /// which can only represent a File (not a Directory).
@@ -188,6 +195,17 @@ impl FileOrDir {
         match &self {
             FileOrDir::File(_) => false,
             FileOrDir::Dir(_) => true,
+        }
+    }
+
+    /// Returns the size of the file in bytes, or directory disk space.
+    pub fn get_file_size(file_or_dir: &FileOrDir) -> usize {
+        match file_or_dir {
+            FileOrDir::File(file_ref) => {
+                let file = file_ref.lock();
+                file.len()
+            },
+            FileOrDir::Dir(_) => DIRECTORY_DISK_SPACE!(),
         }
     }
 }


### PR DESCRIPTION
This pull request is to add the `ls -s` option in the Theseus operating environment. The `ls -s` is a standard linux command. It shows the sizes of files and directories in blocks, which is useful for getting a quick overview of file sizes. Below are some sample test cases:

```
/extra_files: ls -s
    --         wasm
    --         test_files
    1159    README.md
/extra_files: ls test_files -s
    --         zork_dat
    --         text
/extra_files/test_files/text: ls -s
    422     the_rise_of_skywalker.txt
    492     the_phanton_menace.txt
    477     the_last_jedi.txt
    499     the_force_awakens.txt
    486     the_empire_strikes_back.txt
    482     revenge_of_the_sith.txt
    462     return_of_the_jedi.txt
    490     attack_of_the_clones.txt
    503     a_new_hope.txt
```

Default `ls` command still works:

```
/extra_files/test_files: ls 
zork_dat
text
```
