### PR TITLE
Update `cd ` command to use correct path traversal from the `path` crate to allow for parent directory

### DIFF
--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -17,7 +17,6 @@ use getopts::Options;
 pub fn main(args: Vec<String>) -> isize {
     let mut opts = Options::new();
     opts.optflag("h", "help", "print this help menu");
-    opts.optflag("p", "parent", "use '..' to change to parent directory");
 
     let matches = match opts.parse(args) {
         Ok(m) => m,
@@ -48,8 +47,7 @@ pub fn main(args: Vec<String>) -> isize {
                 return -1;
             }
             _ => {}
-        }
-        
+        } 
     }
     0
 }

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -37,7 +37,6 @@ pub fn main(args: Vec<String>) -> isize {
         curr_env.lock().working_dir = Arc::clone(root::get_root());
     } else {
         let path = matches.free[0].as_ref();
-        
         match curr_env.lock().chdir(path) {
             Err(environment::Error::NotADirectory) => {
                 println!("not a directory: {}", path);

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -41,28 +41,18 @@ pub fn main(args: Vec<String>) -> isize {
         curr_env.lock().working_dir = Arc::clone(root::get_root());
     } else {
         let path = matches.free[0].as_ref();
-        if path == Path::new("..") {
-            if let Some(parent_dir) = working_dir.lock().get_parent_dir() {
-                curr_env.lock().working_dir = Arc::clone(&parent_dir);
-            } else {
-                println!("failed to get parent directory");
+        match curr_env.lock().chdir(path) {
+            Err(environment::Error::NotADirectory) => {
+                println!("not a directory: {}", path);
                 return -1;
             }
-        }
-
-        else {
-            match curr_env.lock().chdir(path) {
-                Err(environment::Error::NotADirectory) => {
-                    println!("not a directory: {}", path);
-                    return -1;
-                }
-                Err(environment::Error::NotFound) => {
-                    println!("couldn't find directory: {}", path);
-                    return -1;
-                }
-                _ => {}
+            Err(environment::Error::NotFound) => {
+                println!("couldn't find directory: {}", path);
+                return -1;
             }
+            _ => {}
         }
+        
     }
     0
 }

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -38,7 +38,7 @@ pub fn main(args: Vec<String>) -> isize {
     } else {
         let path = matches.free[0].as_ref();
         
-        match curr_env.lock().chdir_path(path) {
+        match curr_env.lock().chdir(path) {
             Err(environment::Error::NotADirectory) => {
                 println!("not a directory: {}", path);
                 return -1;

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -18,7 +18,7 @@ use path::Path;
 pub fn main(args: Vec<String>) -> isize {
     let mut opts = Options::new();
     opts.optflag("h", "help", "print this help menu");
-    opts.optflag("p", "parent", "change parent directory");
+    opts.optflag("p", "parent", "use '..' to change to parent directory");
 
     let matches = match opts.parse(args) {
         Ok(m) => m,

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -13,7 +13,6 @@ use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use getopts::Options;
-use path::Path;
 
 pub fn main(args: Vec<String>) -> isize {
     let mut opts = Options::new();
@@ -33,8 +32,6 @@ pub fn main(args: Vec<String>) -> isize {
         println!("failed to get current task");
         return -1;
     };
-    // Obtains copy of working directory for reference
-    let working_dir = Arc::clone(&curr_env.lock().working_dir);
     
     // go to root directory
     if matches.free.is_empty() {

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -31,7 +31,7 @@ pub fn main(args: Vec<String>) -> isize {
         println!("failed to get current task");
         return -1;
     };
-    
+
     // go to root directory
     if matches.free.is_empty() {
         curr_env.lock().working_dir = Arc::clone(root::get_root());

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -37,7 +37,8 @@ pub fn main(args: Vec<String>) -> isize {
         curr_env.lock().working_dir = Arc::clone(root::get_root());
     } else {
         let path = matches.free[0].as_ref();
-        match curr_env.lock().chdir(path) {
+        
+        match curr_env.lock().chdir_path(path) {
             Err(environment::Error::NotADirectory) => {
                 println!("not a directory: {}", path);
                 return -1;

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -43,7 +43,6 @@ pub fn main(args: Vec<String>) -> isize {
         curr_env.lock().working_dir = Arc::clone(root::get_root());
     } else {
         let path = matches.free[0].as_ref();
-        
         if path == Path::new("..") {
             if let Some(parent_dir) = working_dir.lock().get_parent_dir() {
                 curr_env.lock().working_dir = Arc::clone(&parent_dir);

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -39,7 +39,6 @@ pub fn main(args: Vec<String>) -> isize {
     
     // go to root directory
     if matches.free.is_empty() {
-        println!("empty");
         curr_env.lock().working_dir = Arc::clone(root::get_root());
     } else {
         let path = matches.free[0].as_ref();

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -33,7 +33,6 @@ pub fn main(args: Vec<String>) -> isize {
         println!("failed to get current task");
         return -1;
     };
-    
     // Obtains copy of working directory for reference
     let working_dir = Arc::clone(&curr_env.lock().working_dir);
     

--- a/applications/cd/src/lib.rs
+++ b/applications/cd/src/lib.rs
@@ -47,7 +47,7 @@ pub fn main(args: Vec<String>) -> isize {
                 return -1;
             }
             _ => {}
-        } 
+        }
     }
     0
 }

--- a/kernel/environment/src/lib.rs
+++ b/kernel/environment/src/lib.rs
@@ -31,20 +31,6 @@ impl Environment {
     /// Changes the current working directory.
     #[doc(alias("change"))]
     pub fn chdir(&mut self, path: &Path) -> Result<()> {
-        for component in path.components() {
-            let new = self.working_dir.lock().get(component.as_ref());
-            match new {
-                Some(FileOrDir::Dir(dir)) => {
-                    self.working_dir = dir;
-                }
-                Some(FileOrDir::File(_)) => return Err(Error::NotADirectory),
-                None => return Err(Error::NotFound),
-            }
-        }
-        Ok(())
-    }
-
-    pub fn chdir_path(&mut self, path: &Path) -> Result<()> {
         match path.get(&self.working_dir) {
             Some(FileOrDir::Dir(dir)) => {
                 self.working_dir = dir;

--- a/kernel/environment/src/lib.rs
+++ b/kernel/environment/src/lib.rs
@@ -44,6 +44,17 @@ impl Environment {
         Ok(())
     }
 
+    pub fn chdir_path(&mut self, path: &Path) -> Result<()> {
+        match path.get(&self.working_dir) {
+            Some(FileOrDir::Dir(dir)) => {
+                self.working_dir = dir;
+                Ok(())
+            }
+            Some(FileOrDir::File(_)) => Err(Error::NotADirectory),
+            None => Err(Error::NotFound),
+        }
+    }
+
     /// Returns the value of the environment variable with the given `key`.
     #[doc(alias("var"))]
     pub fn get(&self, key: &str) -> Option<&String> {


### PR DESCRIPTION
This pull request adds the option to navigate to the parent directory respective of the current working directory, without specifying the full path. The `cd ..` is a standard operation in linux. For example, if current directory is `/extra_files/test_files`, running `cd ..` moves directory to `/extra_files`.

Below are some test cases ran on Theseus:

```
/extra_files/test_files: cd ..
task[20] existed with code 0 (0x0)
/extra_files: 
```

```
/extra_files: cd ..
task [21] exited with code 0 (0x0)
/: 
```

```
/extra_files/test_files/text: cd ..
task[28] exited with code 0 (0x0)
/extra_files/test_files:
```

The default `cd` operation still works too:


```
/extra_files/test_files/: cd text
task[29] exited with code 0 (0x0)
/extra_files/test_files/text: 
```
