### PR TITLE
Replaces the `grub-common` with `grub-pc-bin`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-### This dockerfile sets up an Ubuntu 18.04 environment from scratch 
+### This dockerfile sets up an Ubuntu 22.04 environment from scratch 
 ### that is sufficient to build Theseus and run it using QEMU.
 
 
@@ -30,7 +30,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-ins
 RUN apt-get install -y build-essential curl git
 
 # Install Theseus's build dependencies
-RUN apt-get install -y make gcc nasm pkg-config grub-common mtools xorriso wget
+RUN apt-get install -y make gcc nasm pkg-config grub-pc-bin mtools xorriso wget
 # Install QEMU and KVM, based on <https://help.ubuntu.com/community/KVM/Installation>
 RUN apt-get install -y qemu qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils
 


### PR DESCRIPTION
Fix #1110 